### PR TITLE
Update config.json - myetherwallet.com.ru & myetherwallet.ru.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -135,6 +135,8 @@
     "myetherwallet.tech",
     "myetherwallet.top",
     "myetherwallet.net",
+    "myetherwallet.ru.com",
+    "myetherwallet.com.ru",
     "etherclassicwallet.com",
     "omg-omise.co",
     "omise-go.com",


### PR DESCRIPTION
Branding MyEtherWallet, not owned by MyEtherWallet. Phishing.