### PR TITLE
Added omise-go.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -159,6 +159,7 @@
     "omise-go.com",
     "omise-go.net",
     "omise-omg.com",
+    "omise-go.io",
     "tenx-tech.com",
     "tokensale-tenx.tech",
     "ubiqcoin.org",


### PR DESCRIPTION
Added new OmiseGO airdrop phishing domain: omise-go.io