### PR TITLE
vlberate.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -72,6 +72,7 @@
     "metabase.com"
   ],
   "blacklist": [
+    "vlberate.io",
     "ethereumwallet-kr.info",
     "omise-go.org",
     "iconexus.social",


### PR DESCRIPTION
Fake viberate crowdsale site (now down, but can popup again)