### PR TITLE
the-ether.pro

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -72,6 +72,7 @@
     "metabase.com"
   ],
   "blacklist": [
+    "the-ether.pro",
     "etherdelta.gitnub.io",
     "kirkik.com",
     "monetha.ltd",


### PR DESCRIPTION
Web wallet - can't withdraw balance

No event listener on the withdraw button, only changing the text to "Loading". Another issue with `convert_currency()` function not existing.

![image](https://user-images.githubusercontent.com/2313704/30188624-46e482d0-9427-11e7-83b9-f7910a4bb544.png)
