### PR TITLE
metamesh.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -6,6 +6,7 @@
     "myetherwallet.com"
   ],
   "whitelist": [
+    "metamesh.org",
     "metatask.io",
     "metmask.com",
     "metarasa.com",


### PR DESCRIPTION
Whitelisting domain - auto-blocked due to fuzzy search on "metamask". Site is wireless community, building a mesh network. Fixes #78