### PR TITLE
Add coin.red-puise.com to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -76,6 +76,7 @@
     "etherdelta.com"
   ],
   "blacklist": [
+    "coin.red-puise.com",
     "ibittreix.com",
     "coinkbase.com",
     "cindicator.pro",


### PR DESCRIPTION
Add coin.red-puise.com to the blacklist. Phishing site for coin.red-pulse.com.