### PR TITLE
ripiocredlt.network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -78,6 +78,7 @@
     "etherdelta.com"
   ],
   "blacklist": [
+    "ripiocredlt.network",
     "myetlherwa11et.com",
     "dentacoin.in",
     "rdrtg.com",


### PR DESCRIPTION
Fake ripio credit crowdsale site

https://urlscan.io/result/c14c4855-84d0-4baf-af60-ea193049502a#summary

address: 0xa6B60dd3bE491aAfE5AbA8622b35C0eAd608D3FD