### PR TITLE
utrust.so

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -78,6 +78,7 @@
     "etherdelta.com"
   ],
   "blacklist": [
+    "utrust.so",
     "myethierwallet.org",
     "metallpay.com",
     "kraken-wallet.com",


### PR DESCRIPTION
Fake utrust.io crowdsale site.
Google Ad
address: 0x8A46Aa04725b2E2029bdCb924D671Fd6a9c11daB
https://urlscan.io/result/d5c7821f-7985-416e-9883-24aca61734ea/#summary

https://github.com/409H/EtherAddressLookup/commit/bd85254d84f78ae8f393ea8471c865132b1396da