### PR TITLE
bricklblock.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -78,6 +78,7 @@
     "etherdelta.com"
   ],
   "blacklist": [
+    "bricklblock.io",
     "bittrexy.com",
     "utrust.so",
     "myethierwallet.org",


### PR DESCRIPTION
Blacklisted as per #285

The domain bricklblock.io could not be resolved to a valid IPv4/IPv6 address. We won't try to load it in the browser.