### PR TITLE
quantslamp.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -78,6 +78,7 @@
     "etherdelta.com"
   ],
   "blacklist": [
+    "quantslamp.com",
     "metelpay.com",
     "xn--eterdelta-m75d.com",
     "linksmartcontract.com",


### PR DESCRIPTION
Fake Quantstamp ICO site

https://urlscan.io/result/ae84faae-4549-44de-bdf0-bc91903816db#summary
https://urlscan.io/result/2f02c8b5-6588-44a9-8c88-7d54ddd72103#summary

address 0xda1cC010259496d407a764c381D0E82182D68D89