### PR TITLE
spectre-ai.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -79,6 +79,7 @@
     "metabase.one"
   ],
   "blacklist": [
+    "spectre-ai.org",
     "powerledgr.com",
     "simpletoken.live",
     "sale.simpletoken.live",


### PR DESCRIPTION
Fake Spectre crowdsale site (legit; https://www.spectre.ai/)

https://urlscan.io/result/314a4c9b-36b5-47fc-b065-cc11e7158271#summary
https://urlscan.io/result/857d354c-491f-4357-8ab4-deaa4393d685#summary

address: 0x6e3E57E536aab05950774945d9cdBf506865c52f