### PR TITLE
blockstack.network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -79,6 +79,7 @@
     "metabase.one"
   ],
   "blacklist": [
+    "blockstack.network",
     "ico-tzero.com",
     "spectre.site",
     "tzero.pw",


### PR DESCRIPTION
Fake blockstack.org crowdsale site

https://urlscan.io/result/5f773378-2f8b-4a35-bc32-ca8e4940e1dc/#summary

```
<!-- Mirrored from blockstack.com/ by HTTrack Website Copier/3.x [XR&CO'2014], Thu, 16 Nov 2017 04:54:09 GMT -->
```