### PR TITLE
quntstamp.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -79,6 +79,7 @@
     "metabase.one"
   ],
   "blacklist": [
+    "quntstamp.com",
     "xn--changely-j59c.com",
     "shapeshlft.com",
     "coinbasenews.co.uk",


### PR DESCRIPTION
Fake Quantstamp airdrop site

https://urlscan.io/result/90415d45-1547-477d-a786-9c74e74157ab#summary