### PR TITLE
quanttstamp.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -79,6 +79,7 @@
     "metabase.one"
   ],
   "blacklist": [
+    "quanttstamp.com",
     "gladius.im",
     "ethereumstorage.net",
     "powerledgerr.com",


### PR DESCRIPTION
Fake Quantstamp airdrop asking for private keys via MEW redirection/link (Linking to fake MEW - http://www.xn--myethewallet-jd5f.com)

https://urlscan.io/result/79d856be-702f-442c-93b3-43152f7d888f#summary