### PR TITLE
xn--myethewalet-ns8eqq.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -79,6 +79,7 @@
     "metabase.one"
   ],
   "blacklist": [
+    "xn--myethewalet-ns8eqq.com",
     "nnyetherwallelt.ru.com",
     "ico-wacoin.com",
     "xn--myeterwalet-nl8enj.com",


### PR DESCRIPTION
Fake MEW - reported on EAL stats (http://eal-phishing-stats.herokuapp.com/) but cannot resolve domain.