### PR TITLE
xn--mytherwallet-2d6f.com & xn--cointeegraph-wz4f.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -79,7 +79,6 @@
     "metabase.one"
   ],
   "blacklist": [
-    "xn--mytherwallet-2d6f.com",
     "xn--cointeegraph-wz4f.com",
     "myerherwalet.com",
     "qauntstanp.com",

--- a/src/config.json
+++ b/src/config.json
@@ -79,6 +79,8 @@
     "metabase.one"
   ],
   "blacklist": [
+    "xn--mytherwallet-2d6f.com",
+    "xn--cointeegraph-wz4f.com",
     "myerherwalet.com",
     "qauntstanp.com",
     "myetherermwallet.com",


### PR DESCRIPTION
Fake cointelegraph with smear campaign on MEW, redirecting to a fake MEW
https://urlscan.io/result/7f8cac28-8c59-422c-b7c4-29cbf4d63a4a#summary

Fake MEW - linked by xn--cointeegraph-wz4f.com
https://urlscan.io/result/c6c18896-c529-4e50-a74d-b106aeea7dbe#summary