### PR TITLE
powrrledger.com & xn--myeherwalet-ms8eyy.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -79,6 +79,8 @@
     "metabase.one"
   ],
   "blacklist": [
+    "powrrledger.com",
+    "xn--myeherwalet-ms8eyy.com",
     "qlink-ico.com",
     "tokensale.gamefllp.com",
     "gamefllp.com",


### PR DESCRIPTION
Fake Powerledger airdrop site, redirecting to a fake MEW (xn--myeherwalet-ms8eyy.com)

https://urlscan.io/result/6c86eb4f-e57a-4872-a702-8b288cec9a12#summary
https://urlscan.io/result/972f8111-32cb-49ef-bb29-d3278ec469b4#summary