### PR TITLE
decentralland.org & xn--metherwalet-ns8ep4b.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -80,6 +80,8 @@
     "metabase.one"
   ],
   "blacklist": [
+    "decentralland.org",
+    "xn--metherwalet-ns8ep4b.com",
     "redpulsetoken.co",
     "propsproject.tech",
     "xn--myeterwalet-nl8emj.com",


### PR DESCRIPTION
Fake decentraland airdrop site linked to a fake MEW site xn--metherwalet-ns8ep4b.com

https://urlscan.io/result/f60d0aab-7ced-4e81-a94b-a1df1834ab79#summary
https://urlscan.io/result/d12b57e3-1d10-4cee-a6c8-6988a7c164a6#summary