### PR TITLE
wabicoin.co

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -86,6 +86,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "wabicoin.co",
     "sirinslabs.com",
     "tronlab.co",
     "paxful.com.ng",


### PR DESCRIPTION
Fake wabi airdrop site, asking for private keys

https://urlscan.io/result/cc12d587-e2f0-45a9-87a7-9945601998b7/#summary
https://urlscan.io/result/c83115d4-0b03-4c94-8b2f-4ebdace5c80b#summary
https://urlscan.io/result/61797582-ea15-4ffa-a658-399f57b562e8#summary

https://twitter.com/StevieMatCrypto/status/942686772609409024

reported address: 0x29e225d888cf11c5e67613bffd30bcf071eb3d4a