### PR TITLE
sale.canay.io & canay.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -86,6 +86,8 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "sale.canay.io",
+    "canay.io",
     "ethtools.com",
     "wabicoin.co",
     "sirinslabs.com",


### PR DESCRIPTION
Fake Canya crowdsale site

https://blog.canya.com.au/2017/12/18/security-alert-beware-sophisticated-phishing-scam/