### PR TITLE
Blacklist cloudkitties

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -86,6 +86,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "cloudkitties.co",
     "kittystat.com",
     "singularitynet.in",
     "sale.canay.io",


### PR DESCRIPTION
I’m not sure if it’s the job of this blacklist to protect against trademark and copyright violations, but “Cloud Kitties” goes well beyond rip-off territory and directly into fraud. It is clear that they are trying to represent themselves as selling actual CryptoKitties while they _are not_.