### PR TITLE
etherdelta.pw

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -86,6 +86,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "etherdelta.pw",
     "ethereum-giveaway.org",
     "mysimpletoken.org",
     "binancc.com",


### PR DESCRIPTION
Fake EtherDelta domain - hosted on the same server as the fake powrledger.io/airdrop/ domain. Assuming bad actor.

https://urlscan.io/result/83fd9bac-ed49-411e-b534-b4ecb6681c64#summary