### PR TITLE
zenprolocol.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -86,6 +86,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "zenprolocol.com",
     "ethscan.io",
     "etherscan.in",
     "props-project.com",


### PR DESCRIPTION
See https://github.com/409H/EtherAddressLookup/pull/248

Website not available, https://urlscan.io/result/6bbbc757-947f-4c6d-bff9-234b7a935f56#summary
https://www.whois.com/whois/zenprolocol.com