### PR TITLE
EthTools.com is NOT a phishing site.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -124,7 +124,6 @@
     "singularitynet.in",
     "sale.canay.io",
     "canay.io",
-    "ethtools.com",
     "wabicoin.co",
     "envion.top",
     "sirinslabs.com",


### PR DESCRIPTION
EthTools.com is NOT a phishing site.
https://medium.com/ethtools/psa-speculation-is-toxic-fbf2be13d5db