### PR TITLE
bluzelle.promo and tokensale.bluzelle.promo

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -86,6 +86,8 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "bluzelle.promo",
+    "tokensale.bluzelle.promo",
     "cedarlake.org",
     "marketingleads4u.com",
     "cashaa.co",


### PR DESCRIPTION
Fake bluzella crowdsale site

https://urlscan.io/result/573e79be-22e6-4654-8832-6adc1ae1f084/#summary
https://urlscan.io/result/ffcc895a-c38c-4c2a-a14b-e5a35683081b#summary

address: 0xAc82537fae701B2046F62BB718c4857787b0b647