### PR TITLE
nucleusico.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "nucleusico.com",
     "tronlab.tech",
     "0x-project.com",
     "gift-token-events.mywebcommunity.org",


### PR DESCRIPTION
Fake nucleus ico crowdsale site

https://urlscan.io/result/24ed2240-00ed-4686-8285-34e33692f9f7/#summary
https://urlscan.io/result/19881a3b-103d-4783-af39-bafc053c2be7/#summary

address: 0xf962933e44b1DFC771738A034c80D87bDcd96eCC