### PR TITLE
xn--polniex-n0a.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -963,6 +963,7 @@
     "xn--myeherwallt-kbb8039g.com",
     "xn--myeherwallet-vk5f.com",
     "xn--yethewallet-iw8ejl.com",
-    "xn--bittrx-th8b.com"
+    "xn--bittrx-th8b.com",
+    "xn--polniex-n0a.com"
   ]
 }


### PR DESCRIPTION
Fake Poloniex. Reported it to SafeBrowsing as well.
https://urlscan.io/result/30b5b50f-673a-4a60-8e0d-7a3b33e8bc6f#summary