### PR TITLE
dai-stablecoin.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "dai-stablecoin.com",
     "eos-token.org",
     "venchain.org",
     "deepbrainchain.co",


### PR DESCRIPTION
This is a phishing site that links to a "secret sale" of a fake Dai token.