### PR TITLE
xn--etherdlta-0f7d.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "xn--etherdlta-0f7d.com",
     "sether.in",
     "xn--ttrex-ysa9423c.com",
     "bluzelle.eu",


### PR DESCRIPTION
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/646

Fake EtherDelta stealing private keys with acasa.php

```
<div class="modal-body">
          <form name="isa" action="acasa.php" method="post" autocomplete="off">
            <div class="form-group"><label class="trn" data-trn-key="address">Address</label><input type="text" name="homeaddress" class="form-control"
                placeholder="0x..."></div>
            <div id="pkDiv">
              <div class="form-group"><label class="trn" data-trn-key="private_key">Private key</label><input type="text" class="form-control" placeholder="0x..."
                  name="homekey"></div>
            </div>
            <div class="modal-footer"><button type="button" class="btn btn-default trn" data-trn-key="cancel">Cancel</button><input type="submit" class="btn btn-primary trn"
                name="homesubmit" id="homesubmit" data-trn-key="import_account" value="Import Account" /></div>
          </form>
        </div>
```

https://urlscan.io/result/0914c30d-5a58-4ae7-a288-b66d0ca1141c/#summary

Twitter: https://twitter.com/fintechnewsdept/status/952337723402067969