### PR TITLE
thekey.vin and thekey-vip.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -984,6 +984,7 @@
     "xn--myeherwallet-vk5f.com",
     "xn--yethewallet-iw8ejl.com",
     "xn--bittrx-th8b.com",
-    "xn--polniex-n0a.com"
+    "xn--polniex-n0a.com",
+    "thekey.vin"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -985,6 +985,7 @@
     "xn--yethewallet-iw8ejl.com",
     "xn--bittrx-th8b.com",
     "xn--polniex-n0a.com",
-    "thekey.vin"
+    "thekey.vin",
+    "thekey-vip.com"
   ]
 }


### PR DESCRIPTION
Fake https://thekey.vip ICO websites. They were being spammed in TheKey's Telegram chat.

https://urlscan.io/result/27031fb8-bf9a-4989-8b64-7c54b0bc6285#summary
https://urlscan.io/result/5c53c8b2-51d6-410a-8c4e-74c3e1fb35ef#summary