### PR TITLE
etherzero.promo

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "etherzero.promo",
     "etherzero.org",
     "bluzelle.pro",
     "token-selfkey.org",


### PR DESCRIPTION
Fake etherzero site.

Can't connect to host, but is a GoogleAd and search result

![image](https://user-images.githubusercontent.com/2313704/34941534-06f65434-f9ec-11e7-8625-dbfd48f2ba07.png)

![image](https://user-images.githubusercontent.com/2313704/34940312-f69cafca-f9e6-11e7-9b61-3196a364d31c.png)

![image](https://user-images.githubusercontent.com/2313704/34940402-4e4e59b2-f9e7-11e7-88ba-95e62b3fe48f.png)
