### PR TITLE
etherzeroclaim.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "etherzeroclaim.com",
     "etherzero.promo",
     "etherzero.org",
     "bluzelle.pro",


### PR DESCRIPTION
Fake Etherzero domain asking for seed phrases and sending them off to `POST https://marketcsgo.ru/admin/bulbikmain.php`

https://urlscan.io/result/9d602c7f-e45b-4b34-98c0-2c5d80063ad6/#summary