### PR TITLE
gatcoins.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "gatcoins.io",
     "icoselfkey.org",
     "etherzeroclaim.com",
     "etherzero.promo",


### PR DESCRIPTION
Fake gatcoin crowdsale site

https://urlscan.io/result/c95d03ca-e472-4580-85f3-d24dd8cda892#summary

address: 0xb37da5c9179345341fe50d37cfc961ba47c01f9a (reported in ESD, confirmed with Disqus comments)