### PR TITLE
ethblender.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "ethblender.com",
     "ethpaperwallet.net",
     "waltontoken.org",
     "icoselfkey.org",


### PR DESCRIPTION
Fake blender - reported to not send coins to destination wallets you specify

https://urlscan.io/result/45f6b960-3de8-4285-939b-cc40c6272232#summary

address: 0x91619a3456FDbAc90bD93f51F2917981f0ED3097