### PR TITLE
bluzelle.cc

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "bluzelle.cc",
     "ethblender.com",
     "ethpaperwallet.net",
     "waltontoken.org",


### PR DESCRIPTION
Fake bluzelle crowdsale site. Taken down by cloudflare and the registrar

https://urlscan.io/result/663ff123-b945-48df-b533-a442d2774bb3#summary