### PR TITLE
tron-wallet.info

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "tron-wallet.info",
     "appcoinsproject.com",
     "vechain.foundation",
     "tronlab.site",


### PR DESCRIPTION
Fake web-wallet for tron - not giving users tokens once sent to address they control

https://urlscan.io/result/670fc845-60fb-4ffb-a9ff-ef856bab5e9f/#summary

address: 0xf4c87c851d772b0f9e72cca0690327f2bc505015