### PR TITLE
ether-wallet.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "ether-wallet.org",
     "tron-wallet.info",
     "appcoinsproject.com",
     "vechain.foundation",


### PR DESCRIPTION
Fake Ethereum web wallet not crediting users the ETH they send

https://urlscan.io/result/b38e8a91-07a4-4a5f-bcd2-86c7a4560142#summary

address: 0xc0fed35b43f59c2bfb1eb544bd8921bfb18140c2