### PR TITLE
quanstamptoken.tk

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "quanstamptoken.tk",
     "bluzelle.network",
     "ether-wallet.org",
     "tron-wallet.info",


### PR DESCRIPTION
Fake Quanstamp site - hosted on the same server as many other scams/phishing domains

https://urlscan.io/result/282bc4f8-d7a3-428c-b54f-9be92aaf94e2/#summary