### PR TITLE
ethereum-zero.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "ethereum-zero.com",
     "quanstamptoken.tk",
     "bluzelle.network",
     "ether-wallet.org",


### PR DESCRIPTION
Etherzero domain, but nothing supporting it being the legit domain. Also hosted on  a server used before to host other phishing campaigns. Asking for your chain code.

https://urlscan.io/result/377618e7-96dc-4ef6-b4e7-1ba88c0f4d86#summary