### PR TITLE
ico-bluzelle.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "ico-bluzelle.com",
     "bluzelle.im",
     "bluzelle.one",
     "bluzele.sale",


### PR DESCRIPTION
Fake Bluzelle crowdsale site

https://urlscan.io/result/bf4db025-cfdb-40c0-a6bc-e60eedcce8e3#summary

address: 0x33bf8bde242216da572d6486d641ae0a18137306