### PR TITLE
bluzelle-ico.eu

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "bluzelle-ico.eu",
     "bleuzelle.com",
     "vechainfoundation.com",
     "appcoinstoken.org",


### PR DESCRIPTION
Fake Bluzelle crowdsale site

https://urlscan.io/result/ea246a1c-0f08-44c7-8ce5-165d7f6f5659/#summary
https://urlscan.io/result/6ddc5de6-9296-41bf-8dc9-09fdb6d6279f#summary

address: 0xf747726200C7FC14Ef4CE267b1F070128C2260Dd