### PR TITLE
ethzero-wallet.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -87,6 +87,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "ethzero-wallet.com",
     "xn--metherwalle-jb9et7d.com",
     "xn--coinesk-jo3c.com",
     "venchainfoundation.com",


### PR DESCRIPTION
Fake Etherzero wallet, phishing for private keys

https://urlscan.io/result/4f0f019f-bb66-4f62-972f-1235e3dca9f6#summary

![image](https://user-images.githubusercontent.com/2313704/35187127-e834bde0-fe16-11e7-94c6-0205bd419893.png)
