### PR TITLE
wwwpaywithink.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -89,6 +89,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "wwwpaywithink.com",
     "coniomi.com",
     "paywithnk.com",
     "paywithlnk.com",


### PR DESCRIPTION
Suspected paywithink phishing (once updated - currently a holding page)

https://urlscan.io/result/e99086eb-c59c-4d2a-ad3e-ab612e1092dc#summary