### PR TITLE
tgram.cc and grampreico.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -89,6 +89,8 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "grampreico.com",
+    "tgram.cc",
     "ton-gramico.com",
     "wwwpaywithink.com",
     "coniomi.com",


### PR DESCRIPTION
grampreico.com
Fake Telegram crowdsale site
https://urlscan.io/result/946380cf-37a9-48ee-8c24-f5746a01724c/#summary
address: 0x26F7Eb488661C33c43089aD61944f3231222b32f

tgram.cc
Fake Telegram ICO site
https://urlscan.io/result/fe30f20e-6cd9-4603-85b5-903e154eec1b/#summary