### PR TITLE
metahash.net and metahash.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -7,6 +7,8 @@
     "cryptokitties.co"
   ],
   "whitelist": [
+    "metahash.io",
+    "metahash.net",
     "metahash.org",
     "cryptotitties.com",
     "cryptocities.net",


### PR DESCRIPTION
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/745

https://urlscan.io/result/f47b23f2-d570-49d8-b5d0-191a7e1205de#summary (metahash.net)
https://urlscan.io/result/b10b7de9-cfa5-4d92-a0e8-cff359c80ed1#summary (metahash.io - cannot resolve)