### PR TITLE
wanchainfoundation.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "wanchainfoundation.org",
     "xn--polniex-ex4c.com",
     "xn--polniex-s1a.com",
     "xn--polonex-ieb.com",


### PR DESCRIPTION
Fake wachain site, asking for private keys and giving a contribution address

https://urlscan.io/result/2ad1d740-c519-4b17-a69f-16ce9758369b/#summary

address: 0xBbDEF8b12BABD3ab6018566BC17eC3Aa302b8348

![image](https://user-images.githubusercontent.com/2313704/35350492-ff2ddda2-0135-11e8-8046-f73c5ce89916.png)
