### PR TITLE
wanchainalliance.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "wanchainalliance.org",
     "nucleus-vision.net",
     "ledgerwallet.by",
     "nucleuss.vision",


### PR DESCRIPTION
Fake Wanchain crowdsale site

https://urlscan.io/result/d0b676de-463f-4d9c-89a5-b4048a2c1a3d#summary

address: 0xdF3e77CD5e563f93fC7ecA905d3302e95f9bb150