### PR TITLE
wamchain.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "wamchain.org",
     "wanchainltd.org",
     "wanchainalliance.org",
     "nucleus-vision.net",


### PR DESCRIPTION
Suspicious domain (similar to wanchain.org) on a Russain server that has previously hosted etherdelta and tenx clones

https://urlscan.io/result/14842465-d7b5-440a-93a3-f5c2093da32d#summary