### PR TITLE
cindicator.network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "cindicator.network",
     "wanchainetwork.org",
     "wamchain.org",
     "wanchainltd.org",


### PR DESCRIPTION
Fake cindicator airdrop asking for private keys

https://urlscan.io/result/fca12de3-d6a8-41ac-848f-ac610f3e1e16#summary
https://urlscan.io/result/b6033dd0-a137-4955-ac8d-42c96a0f2178#summary

address: 0x545f5e5c54d8ac72af1c7de8c070387b73841a24