### PR TITLE
beetoken-ico.eu and iost.co

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "beetoken-ico.eu",
     "cindicator.network",
     "wanchainetwork.org",
     "wamchain.org",

--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "iost.co",
     "beetoken-ico.eu",
     "cindicator.network",
     "wanchainetwork.org",


### PR DESCRIPTION
Fake beetoken crowdsale site

https://urlscan.io/result/41729511-aa53-4b67-a203-89114cdc9a05/#summary

address; 0xE0b13c073e8173b06062c69A160EbB54e2AF86c3