### PR TITLE
wanchainfunding.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "wanchainfunding.org",
     "ico-telegram.io",
     "iconfoundation.site",
     "iost.co",


### PR DESCRIPTION
Fake Wanchain crowdsale site

https://urlscan.io/result/87f22920-8c5a-4de9-8e87-822e5acd5c0f#summary

address: 0xB76a4770587f76d6c644DeeC275a2c76069b5F14