### PR TITLE
wwwkodakcoin.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "wwwkodakcoin.com",
     "myetherwallet.uk.com",
     "kodakone.cc",
     "nyeihitervvallet.com",


### PR DESCRIPTION
Fake kodakcoin domain (www.kodakcoin.com) redirecting to a binance referral. Blacklisted for worst case.

https://urlscan.io/result/e8731acf-e3a9-4637-a0b0-84426e9e0009#summary