### PR TITLE
block.chaiins.in

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "block.chaiins.in",
     "origintrail.in",
     "bit-z.ru",
     "xn--myetherallet-nu5f.com",


### PR DESCRIPTION
Fake blockchain.info website

urlscan cannot resolve it, neither can I.

```
Non-authoritative answer:
Name:    block.chaiins.in
Address:  128.199.45.227
```

![image](https://user-images.githubusercontent.com/2313704/35644662-737a30ee-06c1-11e8-9c89-31bcd4a8da4a.png)