### PR TITLE
beetolen.com & beetokem.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,8 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "beetolen.com",
+    "beetokem.com",
     "block.chaiins.in",
     "origintrail.in",
     "bit-z.ru",


### PR DESCRIPTION
Fake beetoken domain redirecting to a binance referral. Blacklisted for worst case.

https://urlscan.io/result/796109f8-e4c0-4ea4-85f0-51a2082fbe26#summary
https://urlscan.io/result/3aa8733f-ebfa-4740-8490-53db2d00b9da#summary