### PR TITLE
token-gram.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "token-gram.org",
     "xn--shapshift-e4a.com",
     "xn--shapshift-y4a.com",
     "xn--shpeshift-c2a.com",


### PR DESCRIPTION
Fake Telegram crowdsale site

address: 0xb2172027cb233198A3945A2c864f1Ec5b7E3b3Da

https://twitter.com/durov/status/944360557318205440?ref_src=twsrc%5Etfw&ref_url=https%3A%2F%2Ftechcrunch.com%2F2018%2F01%2F20%2Ftelegram-ico-scammers%2F
![image](https://user-images.githubusercontent.com/2313704/35652156-5e198f38-06da-11e8-996a-14b7131ae480.png)

![image](https://user-images.githubusercontent.com/2313704/35652271-d01333a0-06da-11e8-9044-20e9320f342c.png)


See https://github.com/409H/EtherAddressLookup/pull/275