### PR TITLE
decentral.market

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -92,6 +92,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "decentral.market",
     "cryptoexploite.com",
     "blockclain.net",
     "xn--blckchin-5za9o.info",


### PR DESCRIPTION
decentral.market is a fake cryptocurrency news website that posts articles from other sites. When it copies ICO participation guides, it replaces the contribution address with a different address.

Example: Arcblock and Republic Protocol have the same Ethereum address (0xdefb014b9e2f3bd81cdb084821f99b681cfca695).

https://urlscan.io/result/13e72351-ec0c-4ea0-89b4-c2b9e3031197#summary

see https://github.com/409H/EtherAddressLookup/pull/282