### PR TITLE
adhive.net & tokensale.adhive.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -94,6 +94,8 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "tokensale.adhive.net",
+    "adhive.net",
     "decentral.market",
     "cryptoexploite.com",
     "blockclain.net",


### PR DESCRIPTION
Fake Adhive crowdsale site

https://urlscan.io/result/dc3c5bde-d67f-4ebc-a6b0-af1506f5139f/#summary
https://urlscan.io/result/53034b1b-6003-4abc-8059-04325286dd3c#summary

address: 0x74104E8C7F546C7398d198F6678310cE9D1b8814