### PR TITLE
Add yocrypto.io to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -91,7 +91,8 @@
     "metabase.com",
     "etherdelta.com",
     "metabase.one",
-    "cryptokitties.co"
+    "cryptokitties.co",
+    "yocrypto.io"
   ],
   "blacklist": [
     "tokensale.adhive.net",


### PR DESCRIPTION
Not sure why my website is being flagged and shows the red Metamask phising screen when Metamask is active.