### PR TITLE
zacrypto.info + more false positives

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "zacrypto.info",
     "mycrypto.com",
     "remix.ethereum.org",
     "metahash.io",

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "mycrypto.live",
     "yocrypto.io",
     "crypto.ba",
     "zacrypto.info",

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "crypto.ba",
     "zacrypto.info",
     "mycrypto.com",
     "remix.ethereum.org",

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "yocrypto.io",
     "crypto.ba",
     "zacrypto.info",
     "mycrypto.com",

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "crypto.cr",
     "mycrypto.live",
     "yocrypto.io",
     "crypto.ba",


### PR DESCRIPTION
Incorrectly blacklisted when I added mycrypto to the fuzzy list

https://urlscan.io/result/401d8c07-1870-4f09-b264-b2fa553c8679#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/811