### PR TITLE
jkcrypto.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "jkcrypto.com",
     "crypto.cr",
     "mycrypto.live",
     "yocrypto.io",


### PR DESCRIPTION
Incorrectly blacklisted when I added mycrypto to the fuzzy list

https://urlscan.io/result/f74a90e1-5d3c-4b26-846f-ba568149cbb5#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/818