### PR TITLE
bankera.live

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -109,6 +109,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "bankera.live",
     "trx.foundation",
     "tokensale.adhive.net",
     "adhive.net",


### PR DESCRIPTION
Fake bankera.com ICO site.

https://urlscan.io/result/faab258d-1214-42f9-9bb5-9cf1a8725c26
https://urlscan.io/result/ad96aa8a-1789-4fa3-9033-dccc7546ab52