### PR TITLE
fusion.tokencrowdsale.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -109,6 +109,7 @@
     "cryptokitties.co"
   ],
   "blacklist": [
+    "fusion.tokencrowdsale.online",
     "trx.foundation",
     "tokensale.adhive.net",
     "adhive.net",


### PR DESCRIPTION
Fake fusion crowdsale site.

https://urlscan.io/result/04cd85b7-6530-4944-af28-197cdee50eb3#summary

See; https://github.com/409H/EtherAddressLookup/pull/292