### PR TITLE
crypto.jobs

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "crypto.jobs",
     "crypto.help",
     "my.crypt.observer",
     "crypt.observer",


### PR DESCRIPTION
Blacklisted due to fuzzy list on mycrypto.com

https://urlscan.io/result/80886bfc-6708-4bb5-af13-718e18e7943b#summary

See: https://github.com/MetaMask/eth-phishing-detect/issues/836