### PR TITLE
crypto.bi + others

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "crypto.bi",
     "crypto.jobs",
     "crypto.help",
     "my.crypt.observer",

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "ambcrypto.com",
     "crypto.bi",
     "crypto.jobs",
     "crypto.help",

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "mvzcrypto.com",
     "ambcrypto.com",
     "crypto.bi",
     "crypto.jobs",


### PR DESCRIPTION
False positive blacklist since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/c7b8c20f-dfc6-434f-a899-f3d5ba985083#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/838