### PR TITLE
mycrypto.dk

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "mycrypto.dk",
     "mvzcrypto.com",
     "ambcrypto.com",
     "crypto.bi",


### PR DESCRIPTION
False positive when adding mycrypto.com to the fuzzy list.

https://urlscan.io/result/e01d94ac-37b1-4d41-b889-4e33a674cc00#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/848