### PR TITLE
scrypto.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "scrypto.io",
     "mycrypto.dk",
     "mvzcrypto.com",
     "ambcrypto.com",


### PR DESCRIPTION
False positive blacklisting when adding mycrypto.com to the fuzzy list

https://urlscan.io/result/2f4526e7-c8c0-44d5-be85-5f5a27cfb4cb#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/852