### PR TITLE
mycrypto.ca & acrypto.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "acrypto.io",
     "mycrypto.ca",
     "scrypto.io",
     "mycrypto.dk",

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "mycrypto.ca",
     "scrypto.io",
     "mycrypto.dk",
     "mvzcrypto.com",


### PR DESCRIPTION
False positive blacklist since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/16fa0729-dc3c-48ab-b7ac-33b4eb3949c8#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/857