### PR TITLE
mycrypto24.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "mycrypto24.online",
     "acrypto.io",
     "mycrypto.ca",
     "scrypto.io",


### PR DESCRIPTION
False positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/28d1c3ff-72b4-403b-b95e-eb321d5ff254#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/860