### PR TITLE
Whitelist crypto.bg

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "crypto.bg",
     "mycrypto24.online",
     "acrypto.io",
     "mycrypto.ca",


### PR DESCRIPTION
I'm submitting a pull request on behalf of the largest Bulgarian bitcoin exchange Crypto.bg - https://news.bitcoin.com/bankers-shut-bulgarias-bitcoin-exchanges/

Our team noticed that a couple of days ago our domain was blacklisted by Metamask as posibble phishing attempt by the Ethereum Phishing Detector. Over the years of our operations we have never exchanged ETH/ETC, although our future plans include creating and integrating an ethereum asset token (ERC20 token) on our website in order to facilitate easier bitcoin and altcoin trading for our users in Bulgaria.

Crypto.bg is owned by Bitcoin Solutions EOOD: a registered legal entity in Bulgaria, and we have operated publicly and transparently for several years, hence we believe we have been erroneously blacklisted by MetaMask's phishing detection and are available to discuss any concerns at info@crypto.bg.