### PR TITLE
zzcrypto.net & zzcrypto.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,8 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "zzcrypto.org",
+    "zzcrypto.net",
     "crypto.bg",
     "mycrypto24.online",
     "acrypto.io",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/717281b1-0a8e-413f-b93d-a071f69b4daa#summary
https://urlscan.io/result/de93382f-f4b2-411b-932d-03fc5a0174a5#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/863