### PR TITLE
melcrypto.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "melcrypto.com",
     "zzcrypto.org",
     "zzcrypto.net",
     "crypto.bg",


### PR DESCRIPTION
False positive blacklisting since adding mycrypto.com to the fuzzy list.

https://urlscan.io/result/7eb8bd40-5c46-4633-a87b-2347ae4032a1#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/865