### PR TITLE
spcrypto.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "spcrypto.net",
     "melcrypto.com",
     "zzcrypto.org",
     "zzcrypto.net",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/c6ca75bf-385e-4e00-8dab-f9044a1883b0#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/867