### PR TITLE
ohmycrypto.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "ohmycrypto.io",
     "spcrypto.net",
     "melcrypto.com",
     "zzcrypto.org",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/a05728c8-5d5e-4576-a26a-61c340eb0e84#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/871