### PR TITLE
crypto.kred

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "crypto.kred",
     "ohmycrypto.io",
     "spcrypto.net",
     "melcrypto.com",


### PR DESCRIPTION
False positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/ad72d2fd-aaf7-4f55-947c-c32b522bfb49#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/873