### PR TITLE
iccrypto.io & wecrypto.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "iccrypto.io",
     "crypto.kred",
     "ohmycrypto.io",
     "spcrypto.net",

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "wecrypto.net",
     "iccrypto.io",
     "crypto.kred",
     "ohmycrypto.io",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/34abcfc5-f206-4eb0-964a-07b6ed4350ca#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/876