### PR TITLE
ocrypto.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "ocrypto.org",
     "wecrypto.net",
     "iccrypto.io",
     "crypto.kred",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/e231ff72-a68e-4e99-9d45-67569bb6ec25#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/878#issuecomment-365568410