### PR TITLE
crypto.pro

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "crypto.pro",
     "ocrypto.org",
     "wecrypto.net",
     "iccrypto.io",


### PR DESCRIPTION
False positive since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/7c2c7947-4799-4a55-b4e9-35b467579ae9/#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/887