### PR TITLE
mycrypter.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "mycrypter.com",
     "crypto.tickets",
     "crypto.pro",
     "ocrypto.org",


### PR DESCRIPTION
False-positive blacklist since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/81c9e00a-3382-4e66-84e0-c2e963f3f9ea/#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/896