### PR TITLE
xn--es-8bb.com xn--myetherallt-pl9elw.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -133,6 +133,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "finetrux.com",
     "telcoin.pro",
     "xn--es-8bb.com",
     "xn--myetherallt-pl9elw.com",

--- a/src/config.json
+++ b/src/config.json
@@ -133,6 +133,8 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "xn--es-8bb.com",
+    "xn--myetherallt-pl9elw.com",
     "ico-dock.org",
     "dock.io-bonus.online",
     "docks.site",

--- a/src/config.json
+++ b/src/config.json
@@ -133,6 +133,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "telcoin.pro",
     "xn--es-8bb.com",
     "xn--myetherallt-pl9elw.com",
     "ico-dock.org",


### PR DESCRIPTION
Fake Eos airdrop site - idn homograph attack - links to xn--myetherallt-pl9elw.com

https://urlscan.io/result/e0013795-54cd-4c54-a69c-09666b9ebfd0/#summary
https://urlscan.io/result/03a41315-680a-48f0-9661-4171faf1125e/#summary