### PR TITLE
add seele ico scam domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1395,6 +1395,9 @@
     "ethzero-wallet.org",
     "zeepln.io",
     "wepowers.network",
-    "wepower.vision"
+    "wepower.vision",
+    "seele.promo",
+    "seele-ico.eu",
+    "seele-ico.pro"
   ]
 }

--- a/src/hosts.txt
+++ b/src/hosts.txt
@@ -1034,3 +1034,6 @@
 0.0.0.0 wepowers.network
 0.0.0.0 wepower.vision
 0.0.0.0 sparc.pro
+0.0.0.0 seele.promo
+0.0.0.0 seele-ico.eu
+0.0.0.0 seele-ico.pro


### PR DESCRIPTION
These three domains are being used in attempts to scam potential seele ico investors, original site is https://seele.pro