### PR TITLE
mmcrypto.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "mmcrypto.io",
     "mycrypter.com",
     "crypto.tickets",
     "crypto.pro",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/c0bd0d2d-8fdd-474f-87ab-ba8faa026e08#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/908