### PR TITLE
zycrypto.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "zycrypto.com",
     "mmcrypto.io",
     "mycrypter.com",
     "crypto.tickets",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/0b7ff374-165f-4148-8708-3f23c2db1d6c#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/909