### PR TITLE
crypto.nl

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "crypto.nl",
     "zycrypto.com",
     "mmcrypto.io",
     "mycrypter.com",


### PR DESCRIPTION
False-positive since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/5c9820ef-9cb5-4ce7-98f4-be6073d17ed8/#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/911