### PR TITLE
hicrypto.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "hicrypto.io",
     "crypto.nl",
     "zycrypto.com",
     "mmcrypto.io",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/d6ab1636-47ec-48d3-8bab-2ce5d243b978#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/914