### PR TITLE
xn--binnce-5nf.com xn--biace-4l1bb.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -137,6 +137,8 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "xn--binnce-5nf.com",
+    "xn--biace-4l1bb.com",
     "jiocoins.io",
     "xn--polonx-0va26t.com",
     "myetlherewallet.org",


### PR DESCRIPTION
Fake binance domains, IDN homograph attacks

https://urlscan.io/result/0bdbd58f-ca42-4267-b6f8-d3b0cf517c78
https://urlscan.io/result/7d991acf-c665-486c-a538-3bc1f4f01c96#summary