### PR TITLE
becrypto.xyz

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "becrypto.xyz",
     "hicrypto.io",
     "crypto.nl",
     "zycrypto.com",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/e2bc11e9-4a75-4aa2-b766-e68e5f7aa8ac/#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/922