### PR TITLE
crypto.press

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "crypto.press",
     "becrypto.xyz",
     "hicrypto.io",
     "crypto.nl",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/3f07b74d-6732-441e-a696-f0d3ce44d845#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/924