### PR TITLE
mqtcrypto.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "mqtcrypto.com",
     "crypto.press",
     "becrypto.xyz",
     "hicrypto.io",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/fc75ff07-4d52-4dfd-bf64-3acdbdc87145#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/929