### PR TITLE
polyswarm.pw

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -140,6 +140,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "polyswarm.pw",
     "dock-io.org",
     "dock.network",
     "blocklancer.me",


### PR DESCRIPTION
Fake polyswarm crowdsale site

https://urlscan.io/result/84a72b79-75a2-4a9a-b650-c0b874853021/#summary
https://urlscan.io/result/f6bfd502-d9b2-4a2d-b990-1421a1f3f594/#summary

address: 0x247733aF8B2BB8e63e3a2A419761c0fd71D40499

see https://github.com/409H/EtherAddressLookup/pull/311