### PR TITLE
tron-foundation.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -140,6 +140,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "sale-orchid.com",
     "electrify-asia.info",
     "tron-foundation.org",
     "dflnlty.org",

--- a/src/config.json
+++ b/src/config.json
@@ -140,6 +140,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "electrify-asia.info",
     "tron-foundation.org",
     "dflnlty.org",
     "polyswarm.tech",

--- a/src/config.json
+++ b/src/config.json
@@ -140,6 +140,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "tron-foundation.org",
     "dflnlty.org",
     "polyswarm.tech",
     "tokensale.polyswarm.tech",


### PR DESCRIPTION
Fake TRON airdrop site phishing for private keys

https://urlscan.io/result/eb2e60fe-e74e-42f0-b05c-d35550c7dfdd#summary
https://urlscan.io/result/8597bd89-07af-4a04-9f87-c26eda6d9aba#summary