### PR TITLE
9crypto.co

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "mycrypto.com"
   ],
   "whitelist": [
+    "9crypto.co",
     "netmask.hu",
     "cryptokittens.club",
     "rucrypto.com",


### PR DESCRIPTION
False positive blacklisting

https://urlscan.io/result/e73db368-f1ea-47c5-90cc-6d85aeb2b873#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/955