### PR TITLE
Revert erroneous blacklisting of HUOBI exchange (huobipro.com)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -11,6 +11,7 @@
   "whitelist": [
     "localethereum.com",
     "localbitcoins.com",
+    "huobipro.com",
     "ncrypto.tech",
     "9crypto.co",
     "netmask.hu",
@@ -150,7 +151,6 @@
   "blacklist": [
     "b5z.net",
     "p.b5z.net",
-    "huobipro.com",
     "xn--coindes-bx3c.com",
     "locaeltherum.com",
     "myetherwallet.tokenimport.com",


### PR DESCRIPTION
Seems to have slipped in by mistake in #969 