### PR TITLE
mpcrypo.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -9,6 +9,7 @@
     "localethereum.com"
   ],
   "whitelist": [
+    "mpcrypo.com",
     "localethereum.com",
     "localbitcoins.com",
     "huobipro.com",


### PR DESCRIPTION
False positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/a5a6fa13-a1e4-4ef8-988d-e7d45729b6f8#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/995