### PR TITLE
address-transfer-confirmation.droppages.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -150,6 +150,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "address-transfer-confirmation.droppages.com",
     "b5z.net",
     "p.b5z.net",
     "xn--coindes-bx3c.com",


### PR DESCRIPTION
Fake ETH giveaway by a SatoshiLite Twitter imposter

https://urlscan.io/result/9cac4738-94d5-43f2-bdff-e57ac381f2df#summary

address: 0x785a751B2E36b2B0Fdb80100B7ca14889a768A22