### PR TITLE
gonetwork-airdrop.co

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -150,6 +150,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "gonetwork-airdrop.co",
     "secure-transaction-confirmation.droppages.com",
     "neonexchanges.org",
     "eth-transact.secure.droppages.com",


### PR DESCRIPTION
Fake GoNetwork site

https://urlscan.io/result/9730606b-8a73-44f7-a892-7fef63e1f718#summary

address; 0xa8eb559EEb38C6CB6A8BC6C39bAdd86B113cd875