### PR TITLE
add ton-sale.com to the blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -150,6 +150,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "ton-sale.com",
     "ico-telegram.online",
     "telegramtoken.io",
     "gonetwork-airdrop.co",


### PR DESCRIPTION
ton-sale.com has been created as an alias to ton.fund, which is already in the blacklist