### PR TITLE
z-crypto.com & pqcrypto.org 

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -9,6 +9,7 @@
     "localethereum.com"
   ],
   "whitelist": [
+    "z-crypto.com",
     "mpcrypo.com",
     "localethereum.com",
     "localbitcoins.com",

--- a/src/config.json
+++ b/src/config.json
@@ -9,6 +9,7 @@
     "localethereum.com"
   ],
   "whitelist": [
+    "pqcrypto.org",
     "z-crypto.com",
     "mpcrypo.com",
     "localethereum.com",


### PR DESCRIPTION
False-positive blacklisting since adding mycrypto.com to the fuzzy list

https://urlscan.io/result/71d398ed-37c4-4413-9a2c-1c905a8bd6f3#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1005