### PR TITLE
vechain-foundation.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -152,6 +152,8 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "poloniex.work",
+    "secure.poloniex.work",
     "vechain-foundation.org",
     "telegram.tokyo",
     "forkdelta.io",

--- a/src/config.json
+++ b/src/config.json
@@ -152,6 +152,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "vechain-foundation.org",
     "telegram.tokyo",
     "forkdelta.io",
     "ton-sale.com",


### PR DESCRIPTION
Fake Vechain airdrop phishing for private keys

https://urlscan.io/result/995bdff7-a420-40c0-8b10-bf7330f08925#summary
https://urlscan.io/result/42120a29-b958-4ceb-94b4-0d71f49f2a1d#summary