### PR TITLE
tokensale-adhive.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -152,6 +152,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "tokensale-adhive.com",
     "ataritoken.ltd",
     "transfer-address-confirmation.droppages.com",
     "droppages.com",


### PR DESCRIPTION
Fake Adhive crowdsale site

https://urlscan.io/result/b8b5f9fd-5a0e-4e10-9006-9e09308bbdbc#summary

address: 0xC4625787be3fcCfF6AC2971945806AcC167C8CBd