### PR TITLE
ipsx.promo

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -152,6 +152,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "ipsx.promo",
     "tokensale-adhive.com",
     "ataritoken.ltd",
     "transfer-address-confirmation.droppages.com",


### PR DESCRIPTION
Fake ipsx crowdsale site

https://urlscan.io/result/f251b8ae-f559-41f2-a0ef-235a4013e063#summary

address: 0xb8689c29bdc7c84f33706ff0f96eafc222ba6d86