### PR TITLE
mycrypto.website

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -9,6 +9,7 @@
     "localethereum.com"
   ],
   "whitelist": [
+    "mycrypto.website",
     "pqcrypto.org",
     "z-crypto.com",
     "mpcrypo.com",


### PR DESCRIPTION
False-positive blacklisting

https://urlscan.io/result/d917edac-ea05-438e-a20d-ccfcb029f182#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1027