### PR TITLE
Add tomo-coin.io phishing site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1506,6 +1506,7 @@
     "havven-ico.com",
     "havven-ico.eu",
     "hawen.io",
-    "havven.xyz"
+    "havven.xyz",
+    "tomo-coin.io"
   ]
 }


### PR DESCRIPTION
True site is https://tomocoin.io.
I would like to report the phishing site http://tomo-coin.io