### PR TITLE
xn--havvn-9za.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -154,6 +154,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "xn--havvn-9za.io",
     "havvenio.com",
     "nucelus.vision",
     "metronometoken.io",


### PR DESCRIPTION
Fake Havven crowdsale site - idn homograph attack - redirects to an already blacklisted havven.sale

https://urlscan.io/result/a29fb056-1003-48a7-b55f-39c48700bcdf#summary