### PR TITLE
usermd.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -154,6 +154,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "usermd.net",
     "xn--gemn-nzab.com",
     "xn--bnance-3va.com",
     "xn--binnce-yc8b.com",


### PR DESCRIPTION
Blacklisting domain that people are subdomaining off for fake sites

masanchez.usermd.net
https://urlscan.io/result/68e2e839-0cd6-4d93-8e4b-e64ccdefc470#summary