### PR TITLE
affinity.store

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -10,6 +10,8 @@
     "dfinity.org"
   ],
   "whitelist": [
+    "affinity.store",
+    "affinity.serif.com",
     "xfinity.com",
     "dfinity.org",
     "ggcrypto.net",


### PR DESCRIPTION
False-positive blacklist

https://urlscan.io/result/2a5acad4-8cc3-49b2-83e9-67bc8b3cd7b5/#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1061