### PR TITLE
mrcrypto.fr

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -10,6 +10,7 @@
     "dfinity.org"
   ],
   "whitelist": [
+    "mrcrypto.fr",
     "affinity.store",
     "affinity.serif.com",
     "xfinity.com",


### PR DESCRIPTION
False-positive blacklisting (Detected on fuzzy check on mycrypto)

https://urlscan.io/result/9c35a0bd-6d13-4523-ae00-7b71be2b2e84#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1063