### PR TITLE
trinity.tech

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -10,6 +10,7 @@
     "dfinity.org"
   ],
   "whitelist": [
+    "trinity.tech",
     "metahusk.com",
     "mrcrypto.fr",
     "affinity.store",


### PR DESCRIPTION
false-positive blacklisting on a fuzzy match for dfinity.org

https://urlscan.io/result/e06a93b3-36e7-4593-83e6-ee3328ca7c97#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1070