### PR TITLE
eth.secure-transactionssecure.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -166,6 +166,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "reeveclancy.wixsite.com",
     "transfer-eth.neocities.org",
     "eth.secure-transactionssecure.com",
     "secure-transactionssecure.com",

--- a/src/config.json
+++ b/src/config.json
@@ -166,6 +166,7 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "transfer-eth.neocities.org",
     "eth.secure-transactionssecure.com",
     "secure-transactionssecure.com",
     "nnyiictehervvailiat.com",

--- a/src/config.json
+++ b/src/config.json
@@ -166,6 +166,8 @@
     "jibrel.network"
   ],
   "blacklist": [
+    "eth.secure-transactionssecure.com",
+    "secure-transactionssecure.com",
     "nnyiictehervvailiat.com",
     "odachi.neocities.org",
     "bittrex-give.com",


### PR DESCRIPTION
Hosting a trust-trading scam

https://urlscan.io/result/e436ea08-a502-46da-93fa-a6d531082c70#summary

address:  0xb82bFd79d5A8C0cc0d4C045633288b48A2beDdcB

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1094