### PR TITLE
add twinity.com to whitelist.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -163,7 +163,8 @@
     "metabase.one",
     "cryptokitties.co",
     "remme.io",
-    "jibrel.network"
+    "jibrel.network",
+    "twinity.com"
   ],
   "blacklist": [
     "miroskii.com",


### PR DESCRIPTION
Twinity is a 3D virtual world.  Its url, `twinity.com` produces a fuzzy match with `dfinity.org`