### PR TITLE
gocrypto.me

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -10,6 +10,7 @@
     "dfinity.org"
   ],
   "whitelist": [
+    "twinity.com",
     "gocrypto.me",
     "finity.ai",
     "weffkemining.com",

--- a/src/config.json
+++ b/src/config.json
@@ -10,7 +10,6 @@
     "dfinity.org"
   ],
   "whitelist": [
-    "twinity.com",
     "gocrypto.me",
     "finity.ai",
     "weffkemining.com",

--- a/src/config.json
+++ b/src/config.json
@@ -10,6 +10,7 @@
     "dfinity.org"
   ],
   "whitelist": [
+    "gocrypto.me",
     "finity.ai",
     "weffkemining.com",
     "nwcrypto.com",


### PR DESCRIPTION
False-positive blacklist on a fuzzy match on mycrypto

https://urlscan.io/result/a810527b-56ef-4ac3-bd7e-533fe3777c2b#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1101