### PR TITLE
bonus.etherpayout.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -179,6 +179,8 @@
     "twinity.com"
   ],
   "blacklist": [
+    "bonus.etherpayout.com",
+    "etherpayout.com",
     "ethereum-giveaway.info",
     "xn--bnanc-fsax.com",
     "xn--binnce-y0a.com",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/53b1a7ca-6313-4fcb-9739-9cdae9fb3d8f#summary
https://urlscan.io/result/7e0630b8-9ce0-443f-8873-52ca250df10a

address: 0x508e1101755a4a6ae228b0e18002a816ce3418cE