### PR TITLE
eth-giveaway-706.htmlcomponentservice.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -182,6 +182,8 @@
     "twinity.com"
   ],
   "blacklist": [
+    "eth-giveaway-706.htmlcomponentservice.com",
+    "htmlcomponentservice.com",
     "mybinance.info",
     "xn--myethewallet-kjc.com",
     "polyswamr.io",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/fadf6395-0a84-4481-bc7c-f3681409da78#summary

address: 0x1e3c07Ce10973fCAebC81468af1d3F390d2A4c71

Blacklisting htmlcomponentservice.com because a lot of these trust-trading scams are using it