### PR TITLE
funfaircoin.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -190,6 +190,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "funfaircoin.org",
     "coinbase-secure-a2k34j.bitballoon.com",
     "ethereumtrans.com",
     "xn--condes-8bb1661d.com",


### PR DESCRIPTION
Fake funfair airdrop phishing for private keys

https://urlscan.io/result/6a282aff-ccf1-428e-adff-f16eda050f1c#summary
https://urlscan.io/result/5d441727-2622-4147-a03d-8e007ec86e45#summary
https://urlscan.io/result/9cd3582c-d28c-48c1-b170-8fbf692367bf#summary