### PR TITLE
eth.altervista.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -192,6 +192,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "eth.altervista.org",
     "musk.gift",
     "mycrypto.bz",
     "eth.vg",


### PR DESCRIPTION
Trust trading scam site

https://urlscan.io/result/64af7fed-9e65-4b45-a15c-857f627b87d3#summary

address: 0xBa25FEffe57126B503C2A313D928ee99E25884b6