### PR TITLE
nuclus.co + actu.fr

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12,6 +12,7 @@
     "auctus.org"
   ],
   "whitelist": [
+    "actu.fr",
     "nuclus.co",
     "auctus.org",
     "ncrypto.io",

--- a/src/config.json
+++ b/src/config.json
@@ -12,6 +12,7 @@
     "auctus.org"
   ],
   "whitelist": [
+    "nuclus.co",
     "auctus.org",
     "ncrypto.io",
     "dfinery.com",


### PR DESCRIPTION
Currently fuzzy blacklisted

https://urlscan.io/result/69febaa2-6a50-4c8b-b778-e2ed553dbba4#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1257