### PR TITLE
airdrop-bluzelle.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -215,6 +215,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "nnyctncrwaillet.com",
     "myunetherhawallet.com",
     "airdrop-bluzelle.com",
     "tronfoundation.tech",

--- a/src/config.json
+++ b/src/config.json
@@ -215,6 +215,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "airdrop-bluzelle.com",
     "tronfoundation.tech",
     "safely-transfer.com",
     "eth.vu",

--- a/src/config.json
+++ b/src/config.json
@@ -215,6 +215,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "myunetherhawallet.com",
     "airdrop-bluzelle.com",
     "tronfoundation.tech",
     "safely-transfer.com",


### PR DESCRIPTION
Fake airdrop phishing for private keys

https://urlscan.io/result/bc1a39c6-b716-4e8c-b0cf-f9063ac08bb6#summary

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1293