### PR TITLE
list of fake MEW domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -215,6 +215,16 @@
     "twinity.com"
   ],
   "blacklist": [
+    "myetherapywaillet.com",
+    "myetherapywalilet.com",
+    "myetherapywallet.com",
+    "myetherapywalliet.com",
+    "mybethernvwallet.com",
+    "myotherapywallet.com",
+    "myuuetheraswallet.com",
+    "nnyctncrwalliet.com",
+    "nnyctncrvvallet.com",
+    "myetheurwallet.com",
     "ico-telegram-ton.com.ru",
     "ton-ico.ga",
     "mailingserver2.com",


### PR DESCRIPTION
Fake MyEtherWallet domains

myetheurwallet.com
https://urlscan.io/result/d31fe922-28bd-470a-ba54-773554740a48/#summary

myetnarvellat.com
https://urlscan.io/result/931444c3-3bb7-4849-bfc0-479e21add808/#summary

nnyctncrvvallet.com
https://urlscan.io/result/0f7da764-e4a7-49b2-b37f-fe86c50ebbfa/#summary

nnyctncrwalliet.com
https://urlscan.io/result/5bce0ccc-9d3b-48e6-a092-06747461c6b1/#summary

myuuetheraswallet.com
https://urlscan.io/result/2e5507ac-0ca1-4ea0-86e5-c99bbbf53c2b/#summary

myunetherhawallet.com
https://urlscan.io/result/f0e39243-c2e6-4655-bb5c-acd3e829f020/#summary

myotherapywallet.com
https://urlscan.io/result/49e51423-2789-4837-9da7-37a244f72fce/#summary

mybethernvwallet.com
https://urlscan.io/result/8b1f66a2-6ceb-4407-b2d8-3a54fc0093db/#summary

myetherapywalliet.com
https://urlscan.io/result/85616bb2-863d-4721-a8bf-ecf90f90b45e/#summary

myetherapywallet.com
https://urlscan.io/result/3e9f5fc7-2727-494d-ba00-10a083ee84e1/#summary

myetherapywalilet.com
https://urlscan.io/result/9001ac34-468e-4c88-9c31-a1ab47970550/#summary

myetherapywaillet.com
https://urlscan.io/result/ad257acd-41c3-4877-bfc2-ab14271da0fc/#summary

myegethercowwallet.com
https://urlscan.io/result/262fc03c-2832-47c9-9b46-eab1f9568134/#summary

source: https://twitter.com/switchingtoguns/status/980910852365832194