### PR TITLE
ethc.fund + ethereum.czweb.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -237,6 +237,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "ethc.fund",
     "eth-giveaway.trade",
     "gram-ico.io",
     "etherscans.net",

--- a/src/config.json
+++ b/src/config.json
@@ -237,6 +237,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "ethereum.czweb.org",
     "ethc.fund",
     "eth-giveaway.trade",
     "gram-ico.io",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/5759564a-8a90-422c-98f3-a64d2df1d07c#summary

address;  0xF42788CBBdb00a32a981355ec5b9143b3C639c74