### PR TITLE
givingawayethereum.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -237,6 +237,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "givingawayethereum.com",
     "ethereum.czweb.org",
     "ethc.fund",
     "eth-giveaway.trade",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/ac0b23c5-36ff-44b9-9767-798136293672#summary

address: 0x41Cd1343C6e497C075b7ed1E9f003d65141833E2