### PR TITLE
eos-dac.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -239,6 +239,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "eos-dac.com",
     "localetherwallet.com",
     "free5000eth.com",
     "ethpaysafe.com",


### PR DESCRIPTION
Fake EOSDAC site, stealing keys to get an airdrop

https://urlscan.io/result/07cfe006-bba3-4393-b881-15bdd0b49d51
https://urlscan.io/result/df357eb6-fa02-44b3-98ee-7e7e0f17c61b
https://urlscan.io/result/b1181935-ce7e-4688-842d-ee7172fa49e0