### PR TITLE
add kactus.io to the whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -247,7 +247,8 @@
     "cryptokitties.co",
     "remme.io",
     "jibrel.network",
-    "twinity.com"
+    "twinity.com",
+    "kactus.io"
   ],
   "blacklist": [
     "nkn-token.io",


### PR DESCRIPTION
```js
var PhishingDetector = require("eth-phishing-detect/src/detector")
var config = require("eth-phishing-detect/src/config.json")
const detector = new PhishingDetector(config)
const value = detector.check('kactus.io')
// {match: "auctus.org", result: true, type: "fuzzy"}
```

Kactus has nothing to do with eth, please add it to the whitelist