### PR TITLE
eth-today.rf.gd

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -256,6 +256,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "eth-today.rf.gd",
     "ethereum.org-giveaway.live",
     "bonus.ether-gift.com",
     "ether-gift.com",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/009e84e6-f710-490c-be37-93244f3da5a0

address: 0xB64f875dAA42173cCAC0b01e502695B61a1A9A64