### PR TITLE
get-ethereum.cc + freecoiners.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -256,6 +256,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "get-ethereum.cc",
     "nmyetlerwailet.com",
     "eth-promo.webz.cz",
     "etherclaims.rf.gd",

--- a/src/config.json
+++ b/src/config.json
@@ -256,6 +256,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "freecoiners.com",
     "get-ethereum.cc",
     "nmyetlerwailet.com",
     "eth-promo.webz.cz",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/b4fe2b60-87b2-45e5-9ca5-db11bda9a1dc

address: 0xF939D9285fFb6FC05780E9549b161d9e9fac6F7d