### PR TITLE
clo-airdrop.info

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -256,6 +256,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "clo-airdrop.info",
     "freecoiners.com",
     "get-ethereum.cc",
     "nmyetlerwailet.com",


### PR DESCRIPTION
Fake airdrop phishing for private keys

https://urlscan.io/result/26dadd21-312c-462c-bb38-81188154c2ab

![image](https://user-images.githubusercontent.com/2313704/39211577-fa37be16-4803-11e8-873d-beec158aa103.png)
