### PR TITLE
ethereumgiveaway5000.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -261,6 +261,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "ethereumgiveaway5000.com",
     "get-5000eth.com",
     "take5000eth.com",
     "ether_promo.kissr.com",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/a410e48e-bbdc-4ce3-bb70-a0d59573cf5c

address: 0x72a8BF69f282c2eB752d48b7778C0f0B6EAeaBAC