### PR TITLE
bitfinex.eu

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -264,6 +264,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "bitfinex.eu",
     "www-mycryptos.com",
     "www-mycryqto.com",
     "mycrypto4cash.com",


### PR DESCRIPTION
Fake Bitfinex domain hosting a trust-trading scam giveaway via iframe (trust-cryptopayment.com)

https://urlscan.io/result/68ee20ab-261a-4f0f-98ee-50e0ad24c779