### PR TITLE
get-ethereum.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -265,6 +265,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "get-ethereum.org",
     "axpire.tech",
     "eth-givea-way.com",
     "eosreward.io",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/369f80f7-6191-4bef-9109-50635606d083

address: 0x78c544EEdE78eb781707A1d46377bf6BE9D028Df