### PR TITLE
eth-giveaway.updog.co

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -265,6 +265,8 @@
     "twinity.com"
   ],
   "blacklist": [
+    "eth-giveaway.updog.co",
+    "updog.co",
     "gift-ether.com",
     "bonus.gift-ether.com",
     "mycrypto.cm",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/0a958074-e7e3-4d21-a219-134ff37482a6

address: 0xd0bD5Be5DF3681608F5FDA3D003EFaA0371dc4d7