### PR TITLE
giveavvay10000eth.host

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -265,6 +265,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "giveavvay10000eth.host",
     "5000eth.org",
     "eth-giveaway.updog.co",
     "updog.co",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/d89401e8-c351-44f8-a416-68e84408e42a

address: 0xAd2E834840954231b924b51bFB92C7f457CA30D9