### PR TITLE
eth-giveaway.co.nf

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -265,6 +265,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "eth-giveaway.co.nf",
     "giveavvay10000eth.host",
     "5000eth.org",
     "eth-giveaway.updog.co",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/e778f394-cb3d-4646-bae2-313020b9408a

address: 0x4F484c32c4810AE8129f1B724b09c663F8341713