### PR TITLE
Blacklisting a bunch of domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,16 @@
     "twinity.com"
   ],
   "blacklist": [
+    "get-ethereum.ml",
+    "5000eth.net",
+    "claim.payeths.com",
+    "payeths.com",
+    "gameofdeception.get-5000-eth.com",
+    "zilliqablockchain.com",
+    "ethgiveavvay.com",
+    "rebellios.com",
+    "kinecosystems.org",
+    "zilliqa.online",
     "mycrypto.get-5000-eth.com",
     "get-5000-eth.com",
     "eden-chain.io",


### PR DESCRIPTION
get-ethereum.ml
Trust-trading scam site
https://urlscan.io/result/5fc621f9-da68-46e7-8f38-b0cd59bd7267
address: 0x497E4c58A4106fEE817e3BEce3C5c029e964Eb49

5000eth.net
Trust-trading scam site
https://urlscan.io/result/370c0de0-f1b0-41db-b55d-89d519a66ff2/
address: 0x2276f412d2ae5dc2cdc293b0df70a8273f6f6771

claim.payeths.com
Trust-trading scam site
https://urlscan.io/result/ca69f450-c79a-4069-895a-df755862e4f1/
address: 0xb48c99C37b7cf4AC0A1c2dcA518782C1FEB4f066

gameofdeception.get-5000-eth.com
Trust-trading scam site
https://urlscan.io/result/f8be78d5-494c-498d-843c-2cb1693e754d/
address: 0xf6238cBC1b74b183E54d63A555f867bAA00D92dF

bonus.gift-ethers.com
Trust-trading scam site
https://urlscan.io/result/4e277554-3505-420c-a3f5-f56306ec0454/
address: 0x471DBd4D8FCe14EAe3B36EFA8Fa97A3937038DFA

xn--coinelegraph-wk5f.com
Fake Cointelegram promoting a fake Tron TRX airdrop. Promoting xn--mycrypt-ix4c.com and xn--myethewalet-ms8erq.com to phish keys
https://urlscan.io/result/c2069c83-c75c-4f44-ba43-094e11d03e45/

xn--myethewalet-ms8erq.com
Fake MyEtherWallet - idn homograph attack domain
https://urlscan.io/result/e5c5cbf2-9e07-4921-93c9-64c1c1067a47/


zilliqablockchain.com
Fake Zilliqa airdrop phishing for private keys
https://urlscan.io/result/5b7d04d6-ea85-431e-b95c-bfcfcbe97352/
https://urlscan.io/result/b3b7701f-6311-43c0-b4f3-a9197f7facb2/
https://urlscan.io/result/55c56538-5f80-4c07-bd67-185bfd605f53/

gifto.tech
Fake Gifto airdrop phishing for private keys
https://urlscan.io/result/33873f55-cd81-402a-8e7d-0f3aee2de5e0/
https://urlscan.io/result/1b61d63b-9749-46c7-bdb3-ed1a6667dfdc/
https://urlscan.io/result/3c1b5695-0314-4ac0-9b0c-8db64fc25e2d

ethgiveavvay.com
Trust-trading scam site
https://urlscan.io/result/82283d6b-63ce-485c-99cd-17af3980f76f/
address: 0x89c0e39f3b3Be95c238912788687DBAebe7e6A2B

rebellios.com
Fake Rebellios airdrop phishing for private keys
https://urlscan.io/result/381b4799-e532-4c44-8c8d-e629a1a88e34/

quarkchain.tech
Fake QuarkChain crowdsale site
https://urlscan.io/result/2bcbd042-649a-4fb6-a617-257ad9e334ac/
https://urlscan.io/result/8712d5bd-8123-4738-939e-cb39f4b17fcd/
address: 0x4910e010EbF5b3366d1E80a134C1FA538FF7994c

kinecosystems.org
Fake KIN airdrop site phishing for private keys
https://urlscan.io/result/d2b2e941-f499-4e9e-af19-0b8332299d50/
https://urlscan.io/result/0230ea53-9abe-4ed8-a255-20b8f4720e8f/
https://urlscan.io/result/729b52fd-8a91-440f-882b-258fb6638d15/
address: 0x4910e010EbF5b3366d1E80a134C1FA538FF7994c

zilliqa.online
Fake Zilliqa airdrop site phishing for private keys
https://urlscan.io/result/9e7ce877-8dfe-476e-ad84-e2d3ccfbb53b/
https://urlscan.io/result/a48331a8-8d33-45b7-88d2-e6b24377e5bd/
https://urlscan.io/result/9ae7e405-bb23-4831-b5a7-037632c2d023/