### PR TITLE
quarkchain.website + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,10 @@
     "twinity.com"
   ],
   "blacklist": [
+    "quark-chain.io",
+    "quarkchain.org",
+    "quarkchaln.io",
+    "quarkchain.website",
     "get-ethereum.ml",
     "5000eth.net",
     "claim.payeths.com",


### PR DESCRIPTION
quarkchain.website
Fake Quarkchain crowdsale site
https://urlscan.io/result/5216d67c-bba3-46b3-835b-7e86e60307fc/
https://urlscan.io/result/904435a0-bbb9-4a1b-a296-5d39c48024fb/
address: 0xB9Ee29FF43D319c126ED2Dbdd74d49a2659EDe56

quarkchaln.io
Suspicious quarkchain crowdsale domain
https://urlscan.io/result/e470a4c6-ac47-4aec-acaa-14330637e7d9/

quarkchain.org
Suspicious quarkchain crowdsale domain
https://urlscan.io/result/cb7b3e7c-3aff-4808-a497-459ce6654b66/

quark-chain.io
Fake Quarkchain crowdsale site
https://urlscan.io/result/473cb4d9-849e-4eff-83a9-c64cc66fcd03/
https://urlscan.io/result/ef143090-8f61-4b5f-98c8-8d681972938c/
address: 0xbEaaD836E717Dd22f59752d60223971db197EF4E