### PR TITLE
xn--tbtc-upa94a.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,13 @@
     "twinity.com"
   ],
   "blacklist": [
+    "xn--tbtc-upa94a.com",
+    "xn--itbtc-9g1b.com",
+    "myetherwalleth.org",
+    "brickblocks.io",
+    "zilliqanetwork.com",
+    "brickblock.cc",
+    "quarkchain.de",
     "promo-give-ethereum.org",
     "give-ethereum.org",
     "ethereum-giveaway.site",


### PR DESCRIPTION
xn--tbtc-upa94a.com
Hitbtc IDN homograph attack domain
https://urlscan.io/result/8ba318ad-2de0-4e94-b0e3-ccbca4148adf

xn--itbtc-9g1b.com
HitBtc IDN homograph attack domain
https://urlscan.io/result/b2a99dfa-8942-40e5-9dfe-8f5c4b22e10e

myetherwalleth.org
Fake MyEtherWallet
https://urlscan.io/result/dee9a62f-c4b7-43ea-8741-d312a604bbf2

brickblocks.io
Fake Brickblock crowdsale site
https://urlscan.io/result/62e91cae-f09a-4684-be41-40538dab9d01#summary
address: 0x2Dc5616EC2b9D24906F0e11dC8D8a736392dFeDD

zilliqanetwork.com
Fake Zilliqa airdrop phishing for private keys
https://urlscan.io/result/ab513a2f-d18e-4c45-8ba6-187c7ce18805
https://urlscan.io/result/906a4afa-2e05-476c-af80-5310b1a672f8
https://urlscan.io/result/33146cb3-2b61-41ba-bfd1-967b5478f0bc

brickblock.cc
Fake Brickblock crowdsale site
https://urlscan.io/result/22d28420-24bc-41b2-8569-7897dc4a02b1
suspected address: 0xf346fdCd5A205bA8F25edf0ffcddcc7a6583ac65

quarkchain.de
Fake Quarkchain crowdsale site
https://urlscan.io/result/d67e69df-ca10-4b5b-b93f-c0f221b26516
https://urlscan.io/result/06420b3f-af1f-4cb3-aa61-eaa203f76a02
address: 0xB9Ee29FF43D319c126ED2Dbdd74d49a2659EDe56