### PR TITLE
ethsafepay.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,9 @@
     "twinity.com"
   ],
   "blacklist": [
+    "ethsafepay.net",
+    "presale.getmyethers.net",
+    "getmyethers.net",
     "xn--tbtc-upa94a.com",
     "xn--itbtc-9g1b.com",
     "myetherwalleth.org",


### PR DESCRIPTION
ethsafepay.net
Trust-trading scam site
https://urlscan.io/result/b15ca1ae-a6b5-4b73-ae84-df6f40283bfe
address: 0x1b8ee5cB5520ea3d12F64a8973c2A4F0cbcB1564

presale.getmyethers.net
Fake crowdsale site for Brickblock
https://urlscan.io/result/7b9bf563-cd1b-4fff-a9c5-cc3b57c332fd
https://urlscan.io/result/e9e1ca4a-277f-4daa-8957-15e6788e0c5f
address: 0x40949225c4a1745a9946F6AAf763241c082cb9ac