### PR TITLE
xn--myetherwallt-ovb.net +  idexmarkets.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,8 @@
     "twinity.com"
   ],
   "blacklist": [
+    "xn--myetherwallt-ovb.net",
+    "idexmarkets.com",
     "ethsafepay.net",
     "presale.getmyethers.net",
     "getmyethers.net",


### PR DESCRIPTION
xn--myetherwallt-ovb.net
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/463e92e9-546c-4f8f-b3b7-52c24e52be79
https://urlscan.io/result/0a7b23e9-7654-4230-91b2-f24bc92fafb8
suspected address: 0xa7b8edb0583b478e2b7c431feb4bc6629a6cd1e5

idexmarkets.com
Fake Idex market phishing for private keys - pushing to save.php
https://urlscan.io/result/125859e6-e9ac-4f2b-b6fe-adb5cc06e1da