### PR TITLE
securetransfer.ethpromotion.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,8 @@
     "twinity.com"
   ],
   "blacklist": [
+    "securetransfer.ethpromotion.com",
+    "ethpromotion.com",
     "brickblockio.info",
     "collect.ethforyou.com",
     "ethforyou.com",


### PR DESCRIPTION
securetransfer.ethpromotion.com
Reported trust-trading scam site
https://urlscan.io/result/36766ff5-250b-4766-9607-1c1aa0be310b
https://urlscan.io/result/090213ab-b079-4f3c-9e08-2eae482f0418

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1581