### PR TITLE
musk-party-gifts.updog.co + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,9 @@
     "twinity.com"
   ],
   "blacklist": [
+    "musk-party-gifts.updog.co",
+    "yobittrading.net",
+    "yobit-trading.net",
     "securetransfer.ethpromotion.com",
     "ethpromotion.com",
     "brickblockio.info",


### PR DESCRIPTION
musk-party-gifts.updog.co
Trust-trading scam site
https://urlscan.io/result/910a27b7-0484-4608-8892-61ef3fac0b0d
address: 0x10c44aB858B90E09C725158906F71833fF417ACC

yobittrading.net
Fake Yobit phishing for logins
https://urlscan.io/result/3544d2aa-24ba-4ae9-869b-643b87e717bf/

yobit-trading.net
Fake Yobit phishing for logins
https://urlscan.io/result/666b538b-b924-43d6-8134-227374cfd777/