### PR TITLE
privcoin.io + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,11 @@
     "twinity.com"
   ],
   "blacklist": [
+    "privcoin.io",
+    "free-eth.paperplane.io",
+    "paperplane.io",
+    "ihcx.market",
+    "helbizcoin.net",
     "telegram-token.io",
     "icostats.io",
     "musk-party-gifts.updog.co",


### PR DESCRIPTION
privcoin.io
Fake Ethereum mixer
https://urlscan.io/result/984000c1-2232-43b0-94ab-3f954960bf10/
suspected address: 0xa3e785ee490e1102fe32512973c96Dc7DC876348 

free-eth.paperplane.io
Trust-trading scam site
https://urlscan.io/result/0d58983b-a077-40eb-bb0c-9955258ccc6a/
address: 0x92cd726CE03cEaa4bF7198ce9c52D05D63ceE575

ihcx.market
Fake Idex market
https://urlscan.io/result/3c3cec2a-4925-4a3f-b615-3210c37f7de9/
https://urlscan.io/result/b60ca10a-76fc-4a30-a930-e280e0b40c50/

helbizcoin.net
Fake airdrop phishing for private keys linking to a fake MyEtherWallet xn--myetherwallt-ovb.net
https://urlscan.io/result/f70319e5-9548-47f9-9c87-5b09bef7b218/
https://urlscan.io/result/f388ff99-cafd-4b53-94c3-f630f2342407/