### PR TITLE
xn--polonix-17a.com + xn--tro-k5y.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,8 @@
     "twinity.com"
   ],
   "blacklist": [
+    "xn--tro-k5y.com",
+    "xn--tro-k5y.com",
     "privcoin.io",
     "free-eth.paperplane.io",
     "paperplane.io",

--- a/src/config.json
+++ b/src/config.json
@@ -275,7 +275,7 @@
     "twinity.com"
   ],
   "blacklist": [
-    "xn--tro-k5y.com",
+    "xn--polonix-17a.com",
     "xn--tro-k5y.com",
     "privcoin.io",
     "free-eth.paperplane.io",


### PR DESCRIPTION
xn--polonix-17a.com
Possible Fake Poloniex - IDN homograph attack domain
https://urlscan.io/result/dd1c3447-e641-44ab-804c-fa2ba168011a/

xn--tro-k5y.com
Fake Tron site - IDN homograph attack domain - directs user to fake MEW xn--myethewalet-ms8erq.com
https://urlscan.io/result/697570b9-b0b3-4300-bfda-43ee4e9a86e6/