### PR TITLE
xn--mytherwallet-5vb.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,10 @@
     "twinity.com"
   ],
   "blacklist": [
+    "xn--mytherwallet-5vb.net",
+    "i-dexmarket.com",
+    "bi-ttrex.com",
+    "www-bittrex.com",
     "xn--bifinex-fb4c.com",
     "xn--blockcain-g95d.com",
     "xn--coinbas-z8a.info",


### PR DESCRIPTION
xn--mytherwallet-5vb.net
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/438ede62-8084-45ae-8ba0-f7a903b064a1

i-dexmarket.com
Fake IdexMarket site stealing keys with POST save.php
https://urlscan.io/result/4931c135-5f4c-4fd8-b605-87e7ea86075f

bi-ttrex.com
Fake Bittrex
https://urlscan.io/result/c9a1ded3-a566-4446-b5f7-0fe293bbed0f

www-bittrex.com
Fake Bittrex
https://urlscan.io/result/c2ea4b8a-e18a-496c-b5a5-6c794eb68c57
https://urlscan.io/result/a7649a0d-0b90-47b8-ac1a-df40f72b6f24