### PR TITLE
etherfree.tech

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "etherfree.tech",
     "secure-ethereum.tw1.su",
     "phantasma-ico.io",
     "sentinelprotocol.pw",


### PR DESCRIPTION
etherfree.tech
Trust-trading scam site, promoted by twitter userid: 330491787
https://urlscan.io/result/16734e7f-017f-454f-ad29-0a60191e75ee
address: 0x8C9D135aC2778e1A7d326932AaD302e7c22c94D7