### PR TITLE
etherums-givingaway.atspace.tv

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "etherums-givingaway.atspace.tv",
     "etherfree.tech",
     "secure-ethereum.tw1.su",
     "phantasma-ico.io",


### PR DESCRIPTION
etherums-givingaway.atspace.tv
Trust-trading scam site promoted by twitter userid 992068651569287170
https://urlscan.io/result/9015c65f-470c-4cbe-9c12-c74ea3970d7f/
addresss: 0x368bE389Ce940bf17C3296344086E368bc4C60f3