### PR TITLE
ethgiveavvay.site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -275,6 +275,7 @@
     "twinity.com"
   ],
   "blacklist": [
+    "ethgiveavvay.site",
     "etherums-givingaway.atspace.tv",
     "etherfree.tech",
     "secure-ethereum.tw1.su",


### PR DESCRIPTION
ethgiveavvay.site
Trust-trading scam site
https://urlscan.io/result/45b3534d-7722-4936-99b5-b4ff382a9d83
address: 0x0C4762Bc7B1Af1DC9448A827f53861c118B712dE