### PR TITLE
Whitelist Decrypto.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -272,7 +272,8 @@
     "cryptokitties.co",
     "remme.io",
     "jibrel.network",
-    "twinity.com"
+    "twinity.com",
+    "decrypto.net"
   ],
   "blacklist": [
     "ethgiveavvay.site",


### PR DESCRIPTION
My website Decrypto.net is a blockchain news and analysis blog, and has been incorrectly blacklisted. I have inserted the URL into the whitelist.