### PR TITLE
5000ethereum.online + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -284,6 +284,12 @@
     "decrypto.net"
   ],
   "blacklist": [
+    "5000ethereum.online",
+    "hederahashgaph.com",
+    "5000-eth.paperplane.io",
+    "zilliqablockchain.org",
+    "idec.market",
+    "ihex.market",
     "zclassiccoins.com",
     "omisegowallet.network",
     "musk.vu",


### PR DESCRIPTION
5000ethereum.online
Trust-trading scam site
https://urlscan.io/result/6d91fc66-0751-4b26-8a13-016ab6bee276/
address: 0xa5e83199a7ECB6669064d492F15ddC096b6cbAb8
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1605

hederahashgaph.com
Fake HederaHashGraph crowdsale site
https://urlscan.io/result/72f0e61c-b7ba-42af-895d-487a696e80e9/
https://urlscan.io/result/10818b4e-04d7-403b-b1bf-52957b2557da/
address: 0x873a35F651892AEe1D9360be80ae904f7D76068f

5000-eth.paperplane.io
Trust-trading scam site
https://urlscan.io/result/9cc72afa-df4c-49f9-a640-65bc2cb2e3f5/
address: 0x1691B2F9986598E12C57Aba5bE50ebd5346247E0

ethpromo.org
Trust-trading scam site
https://urlscan.io/result/e780ae7d-4702-49f5-874b-bc8802e2d843/
address: 0x52beED3924b0824411D03EA2fE51E429717dcF10

zilliqablockchain.org
Fake Zilliqa airdrop phishing for private keys
https://urlscan.io/result/d2a4b412-0f82-48ab-a9d5-336112054c34/
https://urlscan.io/result/aee0f97b-73f6-4a12-9ac3-c61df57f16d3/
https://urlscan.io/result/c7588f94-f089-4194-96d5-e3f07c1d070c/

idec.market
Fake Idex site phishing for private keys
https://urlscan.io/result/c8d5bee3-a966-4a24-82a8-7edf9e1dff90/

ihex.market
Fake Idex site phishing for private keys
https://urlscan.io/result/b0a26318-1dd3-46a4-a99e-b5b14d8d177d/