### PR TITLE
eth-giveaway.today + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -284,6 +284,8 @@
     "decrypto.net"
   ],
   "blacklist": [
+    "xn--myetherwalt-crb27c.com",
+    "hydroplatform.org",
     "eth-giveaway.today",
     "etherget.online",
     "ethplatform.org",

--- a/src/config.json
+++ b/src/config.json
@@ -284,6 +284,10 @@
     "decrypto.net"
   ],
   "blacklist": [
+    "eth-giveaway.today",
+    "etherget.online",
+    "ethplatform.org",
+    "mycrypton.net",
     "5000ethereum.online",
     "hederahashgaph.com",
     "5000-eth.paperplane.io",


### PR DESCRIPTION
eth-giveaway.today
Trust-trading scam site
https://urlscan.io/result/cb202214-02a1-4a07-a112-f1db79932308/
address: 0x3F2cf669C657316985B01b1B797cb259c97d6551

etherget.online
Trust-trading scam site
https://urlscan.io/result/72e80e6c-515a-4e59-9042-5fc7754aeab3/
https://urlscan.io/result/7cda6081-4bba-47ab-85d6-053a6b45f078
address: 0xa8afa9a714e06b9eb1b500617494ac213f2d428a

ethplatform.org
Trust-trading scam site
https://urlscan.io/result/da8bf6a1-868a-4125-b26a-0f213d2d684e/
address: 0x54B623C82365ef20680B17301bD949BcD5599Eb9

mycrypton.net
Trust-trading scam site
https://urlscan.io/result/2aa06783-eb36-492a-a9c0-3a4a5a774450/
address: 0x7eD44f8b304cD71664Cbe8C94614660859Fca2c6