### PR TITLE
quarkchains.io + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -284,6 +284,13 @@
     "decrypto.net"
   ],
   "blacklist": [
+    "quarkchains.io",
+    "ethcollection.paperplane.io",
+    "hydroggenplatform.com",
+    "ldcx.market",
+    "eth-airdrop.com",
+    "ether-promo.unas.cz",
+    "xn--tbtc-zpa34a.com",
     "xn--myetherwalt-crb27c.com",
     "hydroplatform.org",
     "eth-giveaway.today",


### PR DESCRIPTION
quarkchains.io
Fake Quarkchains crowdsale site
https://urlscan.io/result/e912cd64-ee28-42ad-86d0-263903c8ee99/
address: 0xd7bb68B0cE5893983e5a2511b87E083609eB6fF9

ethcollection.paperplane.io
Trust-trading scam site
https://urlscan.io/result/7d4e356e-cc7a-4b55-b236-8447c54a2150/
address: 0xc8a7eFA8FF219CF002081c10c47F1D5F62b3FEe5

hydroggenplatform.com
Fake Hydro site linking to a fake MyEtherWallet - xn--myetherwalt-crb27c.com
https://urlscan.io/result/1a768393-0abc-4084-b38b-32ec22dd824c/

ldcx.market
Fake idex market phishing for private keys
https://urlscan.io/result/d592ac38-9d4a-4914-a25b-bad24a830aa3/

xn--mytherwallet-5vb.net
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/3b1cb53b-5668-43e7-b25c-692f865f665e/

eth-airdrop.com
Trust-trading scam site
https://urlscan.io/result/fff723f3-acc3-453f-b0ac-675ff33642d3/
address: 0x8a8869a8B53573294B0E03820253607D5528679d

ether-promo.unas.cz
Trust-trading scam site
https://urlscan.io/result/f7d2021a-cebf-47b6-ae66-a069a05bddd9/
address: 0xd5e846494df899e0d7ea5e628501dfe420d2643b

xn--tbtc-zpa34a.com
Fake HitBtc exchange phishing for logins
https://urlscan.io/result/816e0a21-4279-4963-8060-43adef0b997d/
https://urlscan.io/result/efe81a7e-aef8-4a86-aea1-682d54d0158a/