### PR TITLE
pundix.tech

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -284,6 +284,7 @@
     "decrypto.net"
   ],
   "blacklist": [
+    "pundix.tech",
     "quarkchains.io",
     "ethcollection.paperplane.io",
     "hydroggenplatform.com",


### PR DESCRIPTION
pundix.tech
Fake airdrop site phishing for private keys
https://urlscan.io/result/e62e529f-c009-41a2-b831-0892a7e4bffa/
https://urlscan.io/result/798eef51-9a69-4d94-b82e-16059e740e57/
https://urlscan.io/result/3edf13ef-b0d4-4d06-bde3-ff46f23e3ef2/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1611