### PR TITLE
waves-ethereum-eth.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -285,6 +285,8 @@
     "audius.co"
   ],
   "blacklist": [
+    "waves-ethereum-eth.org",
+    "ethereum-eth.life",
     "mycrypto-com.com",
     "quarkchain.pl",
     "get-5001-ethereum.com",


### PR DESCRIPTION
xn--therdelta-uf7d.com
Fake EtherDelta - IDN homograph attack domain
https://urlscan.io/result/84a1f753-e1b0-46bf-ba12-40275fbbd15e/

xn--etherdela-ss6d.com
Fake EtherDelta - IDN homograph attack domain
https://urlscan.io/result/a89ad5a4-1086-4efe-b849-4771fb91c224/

xn--etherdelt-876d.com
Fake EtherDelta - IDN homograph attack domain
https://urlscan.io/result/7b37135f-d63c-4cfc-8e01-af1fb30ee878/

waves-ethereum-eth.org
Trust-trading scam site
https://urlscan.io/result/8476cf28-aadc-44b3-96fa-5feb8b762a62/
address: 0xfbb62df5cbc8d0bc4c2a0e5c53b8602d49471495