### PR TITLE
ebtweinfinance.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -285,6 +285,13 @@
     "audius.co"
   ],
   "blacklist": [
+    "ebtweinfinance.com",
+    "cardanoethereum.com",
+    "ethergiveaway.website",
+    "get-ethereum.info",
+    "get-event-ethereum.info",
+    "give-eth.news",
+    "eth-box.xf.cz",
     "ethersforme.net",
     "giftethers.com",
     "m342edium.ethersforme.net",


### PR DESCRIPTION
ebtweinfinance.com
Fake Cointal site
https://urlscan.io/result/ff989c2e-38d1-490a-88e4-dd1198a56049

cardanoethereum.com
Trust-trading scam site
https://urlscan.io/result/8873c613-ebae-405b-8fd2-089ef2186416/
address: 0x27075c2f55bD05c8F7009E8b5a1d3cF131806dD5

ethergiveaway.website
Trust-trading scam site
https://urlscan.io/result/39f924ea-0bb1-4a91-b78e-39f83e306a94/
address: 0x2511A5cF945e1cDA14E3210d2a56eA0dE1d3E031

output.jsbin.com/jejegu
Trust-trading scam site
https://urlscan.io/result/6d723911-f212-4cc0-8885-8f547e737add/
address: 0x3389a9CacB4A3FdbE43DB14D132b3F1e215A835d

get-ethereum.info
Trust-trading scam site
https://urlscan.io/result/5e3c5745-1eac-4791-89d6-09cd96173576/
address: 0x1056d8d9EbB0E0d8710A0E2A1852d4A09d56464A

get-event-ethereum.info
Trust-trading scam site
https://urlscan.io/result/d33733b9-b54c-4f0b-9270-8f2dfb65f0e5/
address: 0x1056d8d9EbB0E0d8710A0E2A1852d4A09d56464A

give-eth.news
Trust-trading scam site
https://urlscan.io/result/23b0d9e6-6e10-4924-b1c1-82a43bf84af1/
address: 0x1056d8d9EbB0E0d8710A0E2A1852d4A09d56464A

eth-box.xf.cz
Trust-trading scam site
https://urlscan.io/result/ae7c5fb4-ebf3-48c4-be94-c6e2f0ef1e7b/
address: 0xEcF37AF81B814D418b5cDF2ec985508888D7c67A