### PR TITLE
nathanielpopper.promo-eths.com + promo-eths.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -285,6 +285,8 @@
     "audius.co"
   ],
   "blacklist": [
+    "nathanielpopper.promo-eths.com",
+    "promo-eths.com",
     "pay.ethconfirm.com",
     "ethconfirm.com",
     "eth-share.com",


### PR DESCRIPTION
promo-eths.com
Trust-trading scam site
https://urlscan.io/result/895064e4-f592-4699-b014-a2ae51e8ced1
address: 0x24F7ea54D9CDb021C0788Caab3c1796Aa8b2C161

nathanielpopper.promo-eths.com
Trust-trading scam site
https://urlscan.io/result/d80f52a8-c689-4e8a-ac30-541d686a74a0
address: 0x24F7ea54D9CDb021C0788Caab3c1796Aa8b2C161