### PR TITLE
walleteos.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -281,7 +281,6 @@
     "remme.io",
     "jibrel.network",
     "twinity.com",
-    "originprotocol.com",
     "decrypto.net",
     "audius.co"
   ],

--- a/src/config.json
+++ b/src/config.json
@@ -286,6 +286,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "walleteos.org",
     "nathanielpopper.promo-eths.com",
     "promo-eths.com",
     "pay.ethconfirm.com",


### PR DESCRIPTION
walleteos.org
Fake web wallet phishing for keys (sending to POST test.php)
https://urlscan.io/result/9e7c9e56-7075-4f9f-9c81-9b0965e41439
Fixes: https://github.com/MetaMask/eth-phishing-detect/issues/1631