### PR TITLE
claimeth.epizy.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -291,6 +291,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "claimeth.epizy.com",
     "walleteos.org",
     "nathanielpopper.promo-eths.com",
     "promo-eths.com",


### PR DESCRIPTION
claimeth.epizy.com
Trust-trading scam site
https://urlscan.io/result/aaede76a-084f-478b-92a9-2f668fc0ea27
https://urlscan.io/result/99843887-f183-42c0-ae4d-9aab94c5abc0
address: 0x40949225c4a1745a9946F6AAf763241c082cb9ac
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1641