### PR TITLE
biitbay.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,9 @@
     "audius.co"
   ],
   "blacklist": [
+    "biitbay.com",
+    "kcucoin.com",
+    "vvallbtc.com",
     "eth-promo.net",
     "tdex.market",
     "login-myetherwallets.com",


### PR DESCRIPTION
biitbay.com
Fake BitBay phishing for logins
https://urlscan.io/result/3ec3a21c-2cba-4f5f-b958-993a57f2f92f/
https://urlscan.io/result/41d9ef68-c211-46dc-bb09-17b3573dcfef/

kcucoin.com
Fake Kucoin phishing for logins
https://urlscan.io/result/115e223c-93dc-4b3f-a100-1b62432c0e15/
https://urlscan.io/result/47115a44-ddca-4c30-b823-c5b48d2f9303/

vvallbtc.com
Fake Wallbtc site phishing for logins
https://urlscan.io/result/46ab3f47-41a9-4771-a781-ee13cc29625b/