### PR TITLE
etherdelta.githiub.io + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,11 @@
     "audius.co"
   ],
   "blacklist": [
+    "etherdelta.githiub.io",
+    "githiub.io",
+    "ether-promo.org",
+    "atn437.ethgiveeth.com",
+    "ethgiveeth.com",
     "5000eth-promo.com",
     "myetherofficial.com",
     "myetherwallat.online",


### PR DESCRIPTION
etherdelta.githiub.io
Fake EtherDelta phishing for keys
https://urlscan.io/result/41a55787-4d42-4589-b1c8-b65286b6bb65/
https://urlscan.io/result/c55ea5c2-cb63-4066-88f2-a210259165f2/

ether-promo.org
Trust-trading scam site
https://urlscan.io/result/9dac2ed5-2a85-4036-9e2d-aa0b0fdb1f10/
address: 0xf6eb7d25dfb8cd1d8fcb8d1cccab9f6f3e594ea8

ico-telegram.org
Fake Telegram crowdsale site
https://urlscan.io/result/ee0ea79c-cf88-41a9-b644-5c8bbf6fb275/
address: 0x5a3dEe76449fE47158Bf6b3B68c629c4ecD2554f

atn437.ethgiveeth.com
Trust-trading scam site
https://urlscan.io/result/c1e509a1-7d54-42c4-bd50-86e64b12a5c9/
address: 0xa47879FC57ECD8b52bfe7cF61B9bb41B7ef84eFC

ethgiveeth.com
Hosting trust-trading scam sites
https://urlscan.io/result/39eded42-b52b-45bd-b6b8-fbd93dee2c1c/
address: 0xa47879FC57ECD8b52bfe7cF61B9bb41B7ef84eFC

xn--metherwalet-uib39f.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/2b23f18f-51cd-4cdd-9cb3-c00b3e20b66d/