### PR TITLE
ethconfirm.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,9 @@
     "audius.co"
   ],
   "blacklist": [
+    "ethconfirm.info",
+    "offer.ethsn.com",
+    "ethsn.com",
     "hydroraindrop.typeform.com",
     "ethgift.org",
     "etherdelta.githiub.io",


### PR DESCRIPTION
ethconfirm.info
Trust-trading scam site
https://urlscan.io/result/82012737-52af-4be3-9a0c-aea2b0856601/
address: 0x92FA227D01DedeDAE2a50B9Da02413C48a872424

offer.ethsn.com
Trust-trading scam site
https://urlscan.io/result/23ad8b13-e953-4feb-8b63-0fb4af476fa8
address: 0xe597880Cb0591c6fc09E1B2778c26CAD34922B82

ethsn.com
Trust-trading scam site
https://urlscan.io/result/84912892-f8b7-48a8-ae37-9b5366bbd068
address: 0xe597880Cb0591c6fc09E1B2778c26CAD34922B82