### PR TITLE
klareol5.ru + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,9 @@
     "audius.co"
   ],
   "blacklist": [
+    "klareol5.ru",
+    "20000.paperplane.io",
+    "secure093555613.safethpay.com",
     "get.ico-eth.org",
     "ico-eth.org",
     "payment-ethereum.online",


### PR DESCRIPTION
klareol5.ru
Trust-trading scam site
https://urlscan.io/result/b78f0e98-7b67-41da-805b-f50e8a306a2e/
address: 0x3d9D797B15Dfe68d5010fE9C9e8a1AAb1F040932

20000.paperplane.io
Trust-trading scam site
https://urlscan.io/result/b326c49a-5f55-4a16-bb99-8236d5de9d5c/
address: 0x58DCE1959623E1210FE465ca3AFa3a05590cC4E7

secure093555613.safethpay.com
Trust-trading scam site
https://urlscan.io/result/03cec5c5-3796-464d-81f6-3e262ca8f188/
address: 0xe2972F7b92E32162E8dD4c30B0516bAa2A24C3c9