### PR TITLE
eth4everyone.com + ethtransaction.ezyro.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -293,7 +293,6 @@
   ],
   "blacklist": [
     "eth4everyone.com",
-    "ethtransaction.ezyro.com",
     "mew-ehterwallat.com",
     "94.100.18.96",
     "get.it-now-eth.com",

--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,8 @@
     "audius.co"
   ],
   "blacklist": [
+    "eth4everyone.com",
+    "ethtransaction.ezyro.com",
     "mew-ehterwallat.com",
     "94.100.18.96",
     "get.it-now-eth.com",


### PR DESCRIPTION
eth4everyone.com
Trust trading scam site
https://urlscan.io/result/195115dd-6b79-46bf-a4c2-3868e387441e
address: 0x86A120236c1f595ea53a93736b2E397C27aF802e

ethtransaction.ezyro.com
Trust trading scam site
https://urlscan.io/result/7b821f66-6a4a-419d-beb5-3a3549c4f15c
address: 0xf39f8505c37080998a58bc9bdd946b81d4949004