### PR TITLE
givefree-eth.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,9 @@
     "audius.co"
   ],
   "blacklist": [
+    "givefree-eth.com",
+    "now-5000ether.paperplane.io",
+    "eth-give.info",
     "xn--mytherwallet-fvb.net",
     "xn--myethewllet-ife2794g.com",
     "xn--metherwallt-crb6719g.com",	


### PR DESCRIPTION
givefree-eth.com
Trust trading scam site
https://urlscan.io/result/bad66464-c8d9-4b3b-ab76-e5c289c3388a/
address: 0x8c34460976e89EDdE3e2898DC7F23b597d295103

now-5000ether.paperplane.io
Trust trading scam site
https://urlscan.io/result/c93cc8b5-3b23-4410-88f0-13279f277fa0/
address: 0xDC3896Be3EB4bB3B3eb2f936348E942796078920

eth-give.info
Trust trading scam site
https://urlscan.io/result/51efc557-f9d8-4af2-b8b6-5943f6b4a1bd/
address: 0x7eA4270D456BC7B3E1C72f8a21a88a90C3D60147