### PR TITLE
brm.10000eth-gift.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,11 @@
     "audius.co"
   ],
   "blacklist": [
+    "brm.10000eth-gift.com",
+    "ethsecure.info",
+    "get.ico-eth.net",
+    "ico-eth.net",
+    "collectmyethers.org",
     "givefree-eth.com",
     "now-5000ether.paperplane.io",
     "eth-give.info",


### PR DESCRIPTION
brm.10000eth-gift.com
Trust trading scam site
https://urlscan.io/result/1896bdfa-0856-4436-9f89-dad49bf313c9/
addresss: 0x8858297c69ed011c48feAa96F0c89349Ef389B67

ethsecure.info
Trust trading scam site
https://urlscan.io/result/9fba6899-498b-4fa5-90ac-89103d99a55a/
address: 0x60e6a89060B325148FE247e9E1C0d090e2764ec2

get.ico-eth.net
Trust trading scam site
https://urlscan.io/result/13d338f1-1511-4016-b43d-a1723fe646ad/
address: 0x821Efcb121B9c646dc8D5FB61E9c8ee9C30BA9e4

ico-eth.net
Trust trading scam site
https://urlscan.io/result/13d338f1-1511-4016-b43d-a1723fe646ad/
address: 0x821Efcb121B9c646dc8D5FB61E9c8ee9C30BA9e4

collectmyethers.org
Trust trading scam site
https://urlscan.io/result/7fb3e928-8c60-459a-9498-eed1a6008588/
address: 0xf9f876a42FCB0d40759790781FDc886449f54008