### PR TITLE
wallets-ether.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "wallets-ether.com",
     "brm.10000eth-gift.com",
     "ethsecure.info",
     "get.ico-eth.net",


### PR DESCRIPTION
wallets-ether.com
Hosting a fake MyEtherWallet and being promoted by a fake MyEtherWallet account on Etherscan DISQUS channel
https://urlscan.io/result/1af2b467-495d-402e-b7d5-51b26fe0e621

![image](https://user-images.githubusercontent.com/2313704/40274524-642079aa-5bd0-11e8-92a5-1fc9b4cde8ba.png)
