### PR TITLE
secure375446884521.safeethpay.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,14 @@
     "audius.co"
   ],
   "blacklist": [
+    "secure375446884521.safeethpay.com",
+    "safeethpay.com",
+    "quarkchain.in",
+    "rnyetherwallel.com",
+    "xn--methrwallet-uib92a.com",
+    "domain501dom.com",
+    "myethwalllet.info",
+    "secure75405732935.safethpay.com",
     "wallets-ether.com",
     "brm.10000eth-gift.com",
     "ethsecure.info",


### PR DESCRIPTION
secure375446884521.safeethpay.com
Trust trading scam site
https://urlscan.io/result/bc664136-1940-4072-9186-72472d25905c/
address: 0xF36b756013f80B162e8713fb37dF7dDA0Cd7F143

safeethpay.com
Trust trading scam site
https://urlscan.io/result/a63ba90a-3e4b-453e-9965-13a06540c314/
address: 0xF36b756013f80B162e8713fb37dF7dDA0Cd7F143

xn--myethrwllet-pjb5u.com
Fake MyEtherWallet - IDN homograph attack domain - suspected address: 0x3a878eddb991ebcbc7c8052055b2e5ed5d0d1ba4
https://urlscan.io/result/94054a20-8453-4235-9863-f999b720d974/
https://urlscan.io/result/7065f90d-a3bf-43b5-9d21-0484cf2bd9ea/

quarkchain.in
Fake Quarkchain crowdsale site
https://urlscan.io/result/d414bcf8-63a2-4845-a12b-eb62f2bf78d6/
https://urlscan.io/result/1e282255-b773-43a1-b3cb-2f33dd50be48/
address: 0x118db57c34621ACd0A91F02C8c18cD1a3AD7C213

rnyetherwallel.com
Fake MyEtherWallet
https://urlscan.io/result/b1fff316-7923-434d-87f0-a419f72ff4d2/

xn--methrwallet-uib92a.com
Fake MyEtherWallet - IDN homograph attack domain - related to raindrop-form.typeform.com/to/AuA5Uh
https://urlscan.io/result/6b1b0b30-116a-4a75-afb2-15f10d6b0bc3/

myether-walletofficial.com
Fake MyEtherWallet
https://urlscan.io/result/d19354a3-564c-45de-8591-193de8abdc36/

domain501dom.com
Fake MyEtherWallet
https://urlscan.io/result/94c501b6-8158-4bb9-8f6b-d2d915ef8e17/

myethwalllet.info 
Fake MyEtherWallet
https://urlscan.io/result/7d101221-0e45-4a9f-9ddf-efd860b9f8fc/


secure75405732935.safethpay.com
Trust trading scam site
https://urlscan.io/result/81d7122d-1ac6-490e-9ed5-25033d408e88/
address: 0xF36b756013f80B162e8713fb37dF7dDA0Cd7F143