### PR TITLE
quarkchain.pub

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "quarkchain.pub",
     "claim-eth.com",
     "send.ethergot.com",
     "ethergot.com",


### PR DESCRIPTION
quarkchain.pub
Fake Quarkchain crowdsale site
https://urlscan.io/result/d6742e8b-8d03-469b-ae25-6fa235e0c4db/
https://urlscan.io/result/46cc2a3c-1e97-454f-b21d-6a2fd9e8ab06/
address: 0x118db57c34621ACd0A91F02C8c18cD1a3AD7C213