### PR TITLE
tomochain.tech

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "tomochain.tech",
     "xn--ehterdeta-wd6d.com",
     "mycryiptowaliet.com",
     "lendium.tech",


### PR DESCRIPTION
tomochain.tech
Fake Tomochain airdrop phishing for private keys
https://urlscan.io/result/e5fee213-90cc-4bd2-9a07-235c3e5e77ad/
https://urlscan.io/result/4e70356c-a0bd-46fb-8697-989bad358ed4/
https://urlscan.io/result/bd186b12-9184-4be9-bf58-349375ec2dce/