### PR TITLE
got-eth.com + eth-share.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,8 @@
     "audius.co"
   ],
   "blacklist": [
+    "got-eth.com",
+    "eth-share.com",
     "geteth.online",
     "get.etherofficial.com",
     "etherofficial.com",

--- a/src/config.json
+++ b/src/config.json
@@ -293,7 +293,6 @@
   ],
   "blacklist": [
     "got-eth.com",
-    "eth-share.com",
     "geteth.online",
     "get.etherofficial.com",
     "etherofficial.com",


### PR DESCRIPTION
got-eth.com
Trust-trading scam site
https://urlscan.io/result/2fbd7dd3-efbf-42eb-9aae-074f09567895/
address:  0xb0D2d2791657ce6CdF48b77A1E10F62E9b4Ee74B

eth-share.com
Trust-trading scam site
https://urlscan.io/result/e4278155-8b0d-4c7e-b198-88cb6d9e0c5c
address:  0xb0D2d2791657ce6CdF48b77A1E10F62E9b4Ee74B