### PR TITLE
air-eos.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "air-eos.com",
     "got-eth.com",
     "geteth.online",
     "get.etherofficial.com",


### PR DESCRIPTION
air-eos.com
Fake EOS airdrop phishing for private keys
https://urlscan.io/result/68f65da4-0da8-400e-8d8b-f90becb972f2/
https://urlscan.io/result/4baebde4-1821-47f9-abf3-206c2e95fd00