### PR TITLE
ethgiveaway.zkr.kr + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,9 @@
     "audius.co"
   ],
   "blacklist": [
+    "ethgiveaway.zkr.kr",
+    "eth-promo.wixsite.com",
+    "calchain.io",
     "air-eos.com",
     "got-eth.com",
     "geteth.online",


### PR DESCRIPTION
ethgiveaway.zkr.kr
Trust trading scam site
https://urlscan.io/result/6a755409-20bc-48b9-8af2-b21b10b2dfb5/
address: 0x9852286460022e5151381361bA4271c7272cF966

eth-promo.wixsite.com
Trust trading scam site
https://urlscan.io/result/9a662a44-7d02-459f-86b6-76a81e2cc6da/
address: 0x9852286460022e5151381361bA4271c7272cF966

calchain.io
Fake airdrop emailing users to go to signupform1.typeform.com via email, which then directs them to xn--myetherwalt-kbb96i.com
https://urlscan.io/result/4192662f-9496-4572-a45c-b24143ff721b/
https://urlscan.io/result/2ca50f69-3fd0-4e91-8cc2-4502977e7e2b/