### PR TITLE
eoslaunch.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "eoslaunch.io",
     "coinbase.pro-fork.com",
     "pro-fork.com",
     "ethgiveaway.zkr.kr",


### PR DESCRIPTION
eoslaunch.io
Fake EOS site phishing for private keys
https://urlscan.io/result/9a270b7a-d578-4651-a54f-010dc9046951
https://urlscan.io/result/9a270b7a-d578-4651-a54f-010dc9046951