### PR TITLE
ethg.me + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,11 @@
     "audius.co"
   ],
   "blacklist": [
+    "ethg.me",
+    "jdex.market",
+    "idex-myaccount.com",
+    "index-markct.com",
+    "ldox.market",
     "10000eth.net",
     "eoslaunch.io",
     "coinbase.pro-fork.com",


### PR DESCRIPTION
ethg.me
Trust trading scam site
https://urlscan.io/result/f56b696b-cf85-41e7-858a-e4dff63cc5d8/
address: 0xB9CEe6fa32eb4d0c8F30E3cd335b72461bD9126e

jdex.market
Fake Idex market site stealing private keys
https://urlscan.io/result/d348adc2-a97d-42a9-951c-9b0e777140ce/

idex-myaccount.com
Fake Idex market site stealing private keys
https://urlscan.io/result/ad09dab8-a77a-4567-9109-0853b30edaac/

index-markct.com
Fake Idex market site stealing private keys
https://urlscan.io/result/bb0f9101-30b3-4083-aeb9-a58831886cb5/

ldox.market
Fake Idex market site stealing private keys
https://urlscan.io/result/b8f029df-111f-40c4-b672-53a90748a4c8/