### PR TITLE
coinbaseverifier.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "coinbaseverifier.com",
     "ether-giveaway.net",
     "ethget.me",
     "ethbonus.org",


### PR DESCRIPTION
coinbaseverifier.com
Fake Coinbase phishing for logins and 2fa codes
https://urlscan.io/result/d0fe7e51-605d-4f3a-89b3-9bff24670054
https://urlscan.io/result/e702afd3-75db-4707-bef1-2a614e392d7e
https://urlscan.io/result/d0d176c2-1325-4a1c-896b-3722a0c719bc
https://urlscan.io/result/b14c0553-ba07-4d42-8972-6e5a0130ab80