### PR TITLE
ethnow.me + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,10 @@
     "audius.co"
   ],
   "blacklist": [
+    "ethnow.me",
+    "quarkchain.supply",
+    "fastethget.com",
+    "securepeth.club",
     "tron-online.info",
     "anatomia.co",
     "xn--myethrwalt-vmbe17c.com",


### PR DESCRIPTION
ethnow.me
Trust trading scam site
https://urlscan.io/result/f787d772-f091-4360-8a9a-00f8d6460a7e
address: 0x7b16e9f14cB9Fd74bf254C620996C7f4750AB1b4

quarkchain.supply
Fake Quarkchain crowdsale site
https://urlscan.io/result/fad2dc3c-91d4-4477-847a-74d7208524c0
https://urlscan.io/result/1cd9cae7-2fb6-44b4-af13-18ebaf947425/
address: 0xdf7dEd886067E693F50aDb227Cf5c0421Ea351B8

fastethget.com
Trust trading scam site
https://urlscan.io/result/2689c12b-4d73-4601-a305-f280d347fa84
address: 0x99947568Fa087B633b0677fe4487873Da4D43318

securepeth.club
Trust trading scam site
https://urlscan.io/result/734ac47e-123a-47f7-9280-c6d1dcab7908
address: 0x85D642EAfb5F15Ef54852B57302040ab066ff2C4