### PR TITLE
ethbonus.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -292,6 +292,9 @@
     "audius.co"
   ],
   "blacklist": [
+    "ethbonus.net",
+    "etherspromo.org",
+    "ethergiving.org",
     "ethn.cc",
     "xn--myethrwalt-zmbt05c.com",
     "eth.share-coin.net",


### PR DESCRIPTION
ethbonus.net
Trust trading scam site
https://urlscan.io/result/24e152c8-2257-44da-8c07-34f3cd019f52/
address: 0xB6751b16Add74242Ea28131ae7008F093734e455

etherspromo.org
Trust trading scam site
https://urlscan.io/result/618476f8-329b-4055-9529-95f93208b95c/
address: 0x837d87448dF3e3CfBE1d613287E2C16d6e8a811C

ethergiving.org 
Trust trading scam site
https://urlscan.io/result/017306a8-66d2-471d-83c1-f52a224e3751/
address: 0x3BD49b98ffcC5f717eED0c9e78a276Ae979de6e4