### PR TITLE
ethtopromo.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -303,6 +303,15 @@
     "audius.co"
   ],
   "blacklist": [
+    "ethtopromo.org",
+    "register-eos.io",
+    "ethereum-get.info",
+    "xn--myethrwaet-inb90ca.com",
+    "myetherwallet.com.token.signinverication.signmessage.carpediem.legal",
+    "carpediem.legal",
+    "myetherwailet.pw",
+    "xn--myethrallet-ol9e8v.com",
+    "keytron.io",
     "xn--mytherwalt-smbh17c.com",
     "bitcointalk.to",
     "ethbonus.net",


### PR DESCRIPTION
ethtopromo.org
Trust trading scam site
https://urlscan.io/result/33450afe-f8cd-4035-b8b6-877803188e71
address: 0x6D0Aef62e321Cf1AFB74A4A305f380d9f5c34c8A

register-eos.io
Fake EOS registration phishing for keys
https://urlscan.io/result/931596ee-5af2-4818-b01d-20505732579a/
https://urlscan.io/result/2dca75c1-e997-45af-9140-2a9375d1cb9e/

ethereum-get.info
Trust trading scam site
https://urlscan.io/result/a6e68320-b32d-4cc9-9f4b-5bc3d2ca9ae1/
address: 0x8715e3E9cBe013bf54de58431a078a650B2Ece1A

xn--myethrwaet-inb90ca.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/db3a5037-8399-40cb-9fb8-1521daa0a1c3/
https://urlscan.io/result/d5945023-5f96-4d91-a9da-954cf476ea57/

myetherwallet.com.token.signinverication.signmessage.carpediem.legal
Fake MyEtherWallet. Suspected address: 0x5c3a228510D246b78a3765C20221Cbf3082b44a4 0xCDb26199dB086d54F7b11e50cA4374b4Dd9CE13f
https://urlscan.io/result/ced73107-bdd6-475d-9ab4-bbcbf2538e3b/

myetherwailet.pw
Fake MyEtherWallet
https://urlscan.io/result/5b8ac9cb-337a-4c31-ba44-0d74c79b7cd1/

xn--myethrallet-ol9e8v.com
Fake MyEtherWallet - IDN homograph attack domain - Suspected address: 0x71481c3ac7853ef63c87f0e9f91b6a5e16e04438
https://urlscan.io/result/7a7ecd12-66de-4457-b328-016bc12cad83/

keytron.io
Fake airdrop  directing users to xn--myethrwaet-inb90ca[dot]com. Suspected address: 0x58F288F0A8C287F5922c08d9693c045942609f23
https://urlscan.io/result/1f8d37bc-e4eb-490e-b08c-4f943d2dcfbc/
https://urlscan.io/result/2f010f3c-4e88-4dce-8907-c3d40b4d5c84/