### PR TITLE
etherbonus.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -303,6 +303,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "etherbonus.net",
     "ethtopromo.org",
     "register-eos.io",
     "ethereum-get.info",


### PR DESCRIPTION
etherbonus.net
Trust trading scam site
https://urlscan.io/result/23ac8e61-4133-4ab2-a980-0a072c8d2c16
address: 0xCd88045eCC901DD6E0BEb11381D42C10429042b4