### PR TITLE
calchain.net + ethpays.me

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,8 @@
     "audius.co"
   ],
   "blacklist": [
+    "calchain.net",
+    "ethpays.me",
     "idex-info.com",
     "idex-market.org",
     "myetherewallete.com",


### PR DESCRIPTION
calchain.net
Fake airdrop directing users to a fake MyEtherWallet (xn--myetherwlet-37a36j[dot]com & xn--myetherwllt-37a50e[dot]com). Suspected address: 0x4121cc82607ebab3f334e067f37fe2709c403bf6
https://urlscan.io/result/bd447370-4992-4d03-b41e-ab4afd24103c/
https://urlscan.io/result/892e43a7-10e2-4b57-9a27-996d967f96f5/

ethpays.me
Trust trading scam site
https://etherscan.io/address/0x297A88c749273F2DE6a378A6015Dd624D993C671
address: 0x297A88c749273F2DE6a378A6015Dd624D993C671