### PR TITLE
xn--myetherwllt-f7a75e.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "xn--myetherwllt-f7a75e.com",
     "ethgive.me",
     "ethgives.me",
     "promaestros.co.uk",


### PR DESCRIPTION
xn--myetherwllt-f7a75e.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/8d098940-7a44-4f2d-979e-62860d3e39a9/
https://urlscan.io/result/7e3a7ec8-8268-48e6-ae47-5fe72a65f909/