### PR TITLE
ethpromo.io + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,11 @@
     "audius.co"
   ],
   "blacklist": [
+    "ethpromo.io",
+    "verifcaon.site",
+    "myetherwallet.com.signinverication.verifcaon.site",
+    "verifywallet.typeform.com",
+    "xn--myethewallet-4nf.net",
     "xn--myetherwllt-f7a75e.com",
     "ethgive.me",
     "ethgives.me",


### PR DESCRIPTION
ethpromo.io
Trust trading scam site
https://urlscan.io/result/802c5bce-c40e-42d7-8f6a-cc65d6c5a5bf
address: 0x4Dad23689bEf624aF5d1757A56135901c915FCFD

myetherwallet.com.signinverication.verifcaon.site
Fake MyEtherWallet. Suspected address: 0xCDb26199dB086d54F7b11e50cA4374b4Dd9CE13f
https://urlscan.io/result/66e84dbd-bf6b-4b96-8d16-98dce1025c6f/
https://urlscan.io/result/47be8e46-ddc4-4a93-b776-6847138cc918/

verifywallet.typeform.com
Fake airdrop directing users to a fake MyEtherWallet xn--myethewallet-4nf.net
https://urlscan.io/result/ecf4888e-2f9c-4bea-8f01-40ad98e80dc3/

xn--myethewallet-4nf.net
Fake MyEtherWallet - IDN homograph attack domain. Suspected address: 0x1ee6b25a0e3f855a10916766df3a056e924e5dce
https://urlscan.io/result/073f84b4-ef76-4bfc-8d81-544b26e92afd/
https://urlscan.io/result/b59355f9-cbda-4df1-9fa7-9ce93af62d69/