### PR TITLE
saferpayether.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,12 @@
     "audius.co"
   ],
   "blacklist": [
+    "saferpayether.com",
+    "ethgive.global",
+    "ethpromo.info",
+    "ethereum-promo.org",
+    "crypto-claims.org",
+    "getethnow.com",
     "tron.gg",
     "tronfoundation.cc",
     "tronfoundation.gift",


### PR DESCRIPTION
saferpayether.com
Trust trading scam site
https://urlscan.io/result/009e33e8-7787-4f64-be5f-731284318afa/
address: 0x4Dad23689bEf624aF5d1757A56135901c915FCFD

ethgive.global
Trust trading scam site
https://urlscan.io/result/46792cd3-e970-48f3-8f9b-62b25e39e02a/
address: 0x9849424a2f3516B70b56D70330c45c25DcCb2C02

ethpromo.info
Trust trading scam site
https://urlscan.io/result/92f5e9e6-1175-417b-86c8-a7ef0f374f6a/
address: 0x88620C720523c822adCdc1d5484915fcD85BAf73

ethereum-promo.org
Trust trading scam site
https://urlscan.io/result/69373894-565e-4aab-8b8e-d5e6c0676ab0/
address: 0x48dcc01a31E38e14F6a63846E371C6e9Cb0C3f3a

crypto-claims.org
Trust trading scam site
https://urlscan.io/result/83bc8915-e840-49e0-9167-e174c72d28dd/
address: 0x839DB3994bef8842C0809AB84996bA839fCac11e

getethnow.com
Trust trading scam site
https://urlscan.io/result/ed3667d5-d398-4d5f-be10-bd306a22209a/
address: 0x9a4B3419F7e74ffaaC61aa7AE8D345Dc4b8F0758