### PR TITLE
myetehrewallet.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,14 @@
     "audius.co"
   ],
   "blacklist": [
+    "myetehrewallet.com",
+    "lbex.market",
+    "idex-info.net",
+    "get-eth.win",
+    "eth-claim.org",
+    "eth-givebacknow.tumblr.com",
+    "ethfreebie.com",
+    "ethpayethers.com",
     "kinetictokenform.typeform.com",
     "kinetictoken.net",
     "xn--myetherwllt-r7a44e.com",


### PR DESCRIPTION
myetehrewallet.com
Fake MyEtherWallet
https://urlscan.io/result/8e75a814-3f7b-4de0-ac08-2ca577017731/

lbex.market
Fake Idex market phishing for keys
https://urlscan.io/result/8e75a814-3f7b-4de0-ac08-2ca577017731/

idex-info.net
Fake Idex market phishing for keys
https://urlscan.io/result/85332caf-df30-4aaa-8fca-16c9970daa4b/

get-eth.win
Trust trading scam site
https://urlscan.io/result/b64e468a-e397-4801-903e-d30c0d216ac2/
address: 0x3BD49b98ffcC5f717eED0c9e78a276Ae979de6e4

eth-claim.org
Trust trading scam site
https://urlscan.io/result/a587f026-fc54-42b2-96db-f4dafe60f183/
address: 0x34d202c37f9609A3d0d44db259ff51Bae8ea2D0f

eth-givebacknow.tumblr.com
Trust trading scam site
https://urlscan.io/result/52ca3146-aafc-4b1e-8371-7e85a97160d0/
address: 0x6CFDdE4E08c9e2CF1b9A32d2C31203966B17f816

ethfreebie.com
Trust trading scam site
https://urlscan.io/result/7ebb125f-60b9-4612-9456-5f7c4bbeb324/
address: 0xDe72b9575B532aB7Cf37C677d95e9cE612b05ACe

ethpayethers.com
Trust trading scam site
https://urlscan.io/result/45d29af2-30e5-486a-b5d7-cfc16d6b1a0a/
address: 0xdb7E6449A14100922caD1eCc5aBEa0FB37FF2106