### PR TITLE
idexmarket.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "idexmarket.io",
     "myetehrewallet.com",
     "lbex.market",
     "idex-info.net",


### PR DESCRIPTION
idexmarket.io
Fake Idex market phishing keys with GET store.php?mapza=<privkey>&action1=1
https://urlscan.io/result/151f9aff-a89c-4866-bab8-afb3356f4f1a
https://urlscan.io/result/b47a139d-b4a2-4b9c-88db-46ae619274a0