### PR TITLE
keyfund.io + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,11 @@
     "audius.co"
   ],
   "blacklist": [
+    "keyfund.io",
+    "ethereum-promo.xf.cz",
+    "myetherwallet.comsigninverication.signmessage.crocweb.online",
+    "crocweb.online",
+    "myeosdac.top",
     "ethofficial.info",
     "getsomeeth.com",
     "giveawaycrypto.org",


### PR DESCRIPTION
keyfund.io
Fake airdrop directing users to a fake MyEtherWallet xn--myethrwalt-vmbe17c.com
https://urlscan.io/result/164ac14a-06a9-4119-9a9b-f22a0fe126db/
https://urlscan.io/result/d8327bb3-ff86-4620-9f6c-716bb93aeca0/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1746

ethereum-promo.xf.cz
Trust trading scam site
https://urlscan.io/result/b68e6017-64fc-40b6-9d6f-8940f0341343/
address: 0x997ad34840281d459251abdf9c90d9a8c6a6e01a

myetherwallet.comsigninverication.signmessage.crocweb.online
Fake MyEtherWallet. Suspected address: 0x6ab2a9088916bf97c248888009b669aa37bab681 0xcdb26199db086d54f7b11e50ca4374b4dd9ce13f 0x5127E8d79160f4cD177F5aC5A1e860acAa59a34B
https://urlscan.io/result/46be63c2-3bf1-470f-88df-edc88c95284d/
https://urlscan.io/result/9d5b4442-7b25-49ab-90f1-715b045ebfd1/

myeosdac.top
Fake EOS airdrop asking for address validation on a telegram group
https://urlscan.io/result/6957d778-4402-4ae3-9ffa-0bd358c27364/
address: 0xFe68F28599B19c5D8a562E8cC7F7b07C36E0A99D