### PR TITLE
eos-swap.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "eos-swap.com",
     "keyfund.io",
     "ethereum-promo.xf.cz",
     "myetherwallet.comsigninverication.signmessage.crocweb.online",


### PR DESCRIPTION
eos-swap.com
Fake EOS countdown, phishing for private keys with POST /VerifyToken.php
https://urlscan.io/result/0a39213a-6447-4660-b663-09fd8fdb8d0c/