### PR TITLE
promotoeth.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "promotoeth.org",
     "ethpromo.cc",
     "idex-market.eu",
     "idex-login.net",


### PR DESCRIPTION
promotoeth.org
Trust trading scam site
https://urlscan.io/result/b59fd627-9211-4725-a6b4-1b9cabd617d9
address: 0xb733A811edF703701d2403d8196df87306BED6D6