### PR TITLE
eth-get.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,12 @@
     "audius.co"
   ],
   "blacklist": [
+    "eth-get.com",
+    "giveaway-ether.info",
+    "ether-give.club",
+    "eth.promo-etherum.com",
+    "promo-etherum.com",
+    "winplatform.io",
     "index-macro.com",
     "185.156.173.87",
     "eos-paperwallet.com",


### PR DESCRIPTION
eth-get.com
Trust trading scam site
https://urlscan.io/result/3625920c-652d-4e0f-bdf2-5bced94e57fd/
address: 0xf8abBDc8578B940b82906a2E8da893B164D4FA59

giveaway-ether.info
Trust trading scam site
https://urlscan.io/result/e47f8558-80bc-49d7-a10f-b09c4a9484ed/
address: 0xa78959E1568448a3CF866968872431E710458552

ether-give.club
Trust trading scam site
https://urlscan.io/result/a21636bf-face-4f76-a4b8-66f994d84a70/
address: 0x50a9a8c8ce2bb0ea10f4d4a586ac2d77257b8247

eth.promo-etherum.com
Trust trading scam site
https://urlscan.io/result/8ed60ed2-dd11-44f3-9bf7-751f2ffd668b/
address: 0x2d19F9FEcE6DA18f2899944B0621C5eCeBAa249B

promo-etherum.com
Trust trading scam site
https://urlscan.io/result/f8fde317-2a1d-4238-bf5d-40325eeca1f7/
address: 0x5526dc369bBE6B9B2c5e64BB368C1d3Ccfa58271

winplatform.io
Trust trading scam site
https://urlscan.io/result/f35a204f-b470-46cd-8733-61f4c61d4562/
address: 0xaC2530772075b7576a7b27390e348Fadf3345c29