### PR TITLE
btcoin.vu + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,9 @@
     "audius.co"
   ],
   "blacklist": [
+    "btcoin.vu",
+    "btc-giveaway.com",
+    "btcofficial.info",
     "collect.bestethgift.com",
     "bestethgift.com",
     "idek.io",


### PR DESCRIPTION
btcoin.vu
Trust trading scam site
https://urlscan.io/result/faed9c9a-b3af-4291-b403-985fc6219621/

btc-giveaway.com
Trust trading scam site
https://urlscan.io/result/518bc26e-4078-4946-a05a-2477a7cdc049/

btcofficial.info
Trust trading scam site
https://urlscan.io/result/35a3211f-ad7a-4b71-9aa6-814efab12e87/