### PR TITLE
fantoms.foundation

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -304,6 +304,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "fantoms.foundation",
     "etherskan.io",
     "etherscan.ltd",
     "myiteher.com",


### PR DESCRIPTION
fantoms.foundation
Fake Fantom crowdsale site
https://urlscan.io/result/2ae25deb-e191-4638-8f76-790258d653e8
address: 0x8d305Fd29aEbd6e0562dE9321d55E7f0E6fbaCaD

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1771