### PR TITLE
etherepromo.win + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -306,6 +306,14 @@
     "audius.co"
   ],
   "blacklist": [
+    "etherepromo.win",
+    "ethtowallet.com",
+    "ethsclaim.com",
+    "ethaward.com",
+    "airdrop24.com",
+    "eth.mediumblog.top",
+    "mediumblog.top",
+    "dropeth.org",
     "get.ethpublic.com",
     "ethpublic.com",
     "ethereum-get.org",


### PR DESCRIPTION
etherepromo.win
Trust trading scam site
https://urlscan.io/result/09d9765e-fa43-4ad6-8bc7-8299334918dd/
address: 0x13403162EF6cF6219441667Ae22892c997262611

ethtowallet.com
Trust trading scam site
https://urlscan.io/result/0eb77abb-2088-42aa-9f8a-e5031ed08cc0/
address: 0xA6626a8a85f2032930A25D278aE149191E3ba247

ethsclaim.com
Trust trading scam site
https://urlscan.io/result/c1087b2d-afb9-460c-a2f3-c9cdc0a8240c/
address: 0x4508B6691D8c938781F130519625B4CDD7B1f804

ethaward.com
Trust trading scam site
https://urlscan.io/result/95665bc9-85b4-466b-8c81-c897dab1bb4d/
address: 0x5f38DcBc5a2DBE1e040a60153750feb7E1CfA570

airdrop24.com
Trust trading scam site - http://prntscr.com/jr816v
https://urlscan.io/result/67622e5c-364e-447e-926f-fac618df85ef/
https://urlscan.io/result/340ef367-fda6-4657-a891-7ac33704bf51/
address: 0x87c348573F02768A97aFb57aac3bb6877A353Ae9

eth.mediumblog.top
Trust trading scam site
https://urlscan.io/result/a817c264-c980-41ef-83b8-6c9a70249fc9/
address: 0x40949225c4a1745a9946F6AAf763241c082cb9ac

dropeth.org
Trust trading scam site
https://urlscan.io/result/6d3e87cb-b6ca-46c1-a7de-6fb2d0e06d6d/
address: 0x8F9F6AAdAf78225b94A84CA9CA80328D0d6b21EA