### PR TITLE
myethrwatt.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -306,6 +306,9 @@
     "audius.co"
   ],
   "blacklist": [
+    "myethrwatt.com",
+    "ether-share.com",
+    "btcs-share.com",
     "etherepromo.win",
     "ethtowallet.com",
     "ethsclaim.com",


### PR DESCRIPTION
myethrwatt.com
Fake MyEtherWallet
https://urlscan.io/result/1f77aa01-14ee-4317-be8f-1d2030cb553c/

ether-share.com
Trust trading scam site
https://urlscan.io/result/33a218d0-7e94-4d4e-8090-13f65ab41907/
address: 0xEd51c3c2fb6E6965aEd7beeC167B0596dc36116D

btcs-share.com
Trust trading scam site. Bitcoin address: 1N2GSugUiQ9bgG94YFhexLqdEXrLZ9CQXa
https://urlscan.io/result/a7fbb413-e0df-4622-ae19-95196c3b1dc0/