### PR TITLE
xn--myetherwalett-4hc.net + ethereumgiveaway.typeform.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -306,6 +306,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "xn--myetherwalett-4hc.net",
     "zecblock.info",
     "litecoin-chain.info",
     "ripple-chain.org",

--- a/src/config.json
+++ b/src/config.json
@@ -306,6 +306,7 @@
     "audius.co"
   ],
   "blacklist": [
+    "ethereumgiveaway.typeform.com",
     "xn--myetherwalett-4hc.net",
     "zecblock.info",
     "litecoin-chain.info",


### PR DESCRIPTION
xn--myetherwalett-4hc.net
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/09f14bd0-e3a7-4856-935d-f2b8099055b0/
https://urlscan.io/result/ddcc788a-777c-447e-9b59-0eef6164f559/

ethereumgiveaway.typeform.com
Fake giveaway collecting data on users and directing them to a fake MyEtherWallet xn--myetherwalett-4hc.net
https://urlscan.io/result/e40eb8c4-86a3-4551-a108-c481ab40afed/