### PR TITLE
A bunch of fake MyEtherWallets

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -306,6 +306,12 @@
     "audius.co"
   ],
   "blacklist": [
+    "myetherethwallet.com",
+    "myethervualet.gq",
+    "myetherwallea.org",
+    "myetherwallee.org",
+    "myetherwalletl.org",
+    "myetherwalleu.org",
     "xn--myethrwalett-8vb19c.net",
     "free-ethereum.us",
     "tron-mainnet.network",


### PR DESCRIPTION
myetherethwallet.com
Fake MyEtherWallet
https://urlscan.io/result/45442ba7-f836-4319-80c3-c37d0eade14a/

myethervualet.gq
Fake MyEtherWallet (suspicious domain, kit not deployed yet)
https://urlscan.io/result/2a6c7b21-b9c8-40f6-8f07-453a482fe0c7/

myetherwallea.org
Fake MyEtherWallet (suspicious domain)
https://urlscan.io/result/e2f0f962-2731-4eb7-9a35-fec6088714c4/

myetherwallee.org
Fake MyEtherWallet (suspicious domain)
https://urlscan.io/result/a51c49fd-461a-493f-8662-1eca27590b9c/

myetherwalletl.org
Fake MyEtherWallet
https://urlscan.io/result/697dbf58-7ca0-427f-a8f4-edffa45cd07f/

myetherwalleu.org
Fake MyEtherWallet
https://urlscan.io/result/ab97594c-1888-4db8-b2fc-dc0d9374296c/