### PR TITLE
etheroll.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -312,6 +312,7 @@
     "verasity.io"
   ],
   "blacklist": [
+    "etheroll.io",
     "meta-mask.com",
     "metamaskwallet.com",
     "myethertrust.com",


### PR DESCRIPTION
etheroll.io
Fake Etheroll
https://urlscan.io/result/10c2378c-fb28-4556-a97d-07f793f42586/
address: 0x521ff702e1eed9e48cbe17e2dae6efd77b9d6876

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1796