### PR TITLE
Remove btcManager.com from block-list

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -340,7 +340,6 @@
     "xn--mytherallet-3qb2119g.com",
     "xn--myethewllet-738en7a.com",
     "myetferwellet.com",
-    "btcmanager.com",
     "myetherethwallet.com",
     "myethervualet.gq",
     "myetherwallea.org",


### PR DESCRIPTION
The phishing scam has been taken down, and btcmanager.com does in fact have a long history of being a real news source, we even have friends who have written there.

Their sysadmin appears to be investigating the issue, I think we can safely unblock for now. If there is another breech, we should perhaps not forgive as easily.