### PR TITLE
xn--mythrwalet-smb0a15c.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -314,6 +314,17 @@
     "verasity.io"
   ],
   "blacklist": [
+    "xn--mythrwalet-smb0a15c.com",
+    "signmsg.info",
+    "myetherwallet.com.signmsg.info",
+    "oracon.io",
+    "eth-bonus.org",
+    "piscorealestate.com",
+    "myethrwatt.info",
+    "defraggler-code.com",
+    "ethbonus.io",
+    "ethxpromo.com",
+    "omise-go.info",
     "xn--myetherrwalet-5hc.net",
     "idice.epizy.com",
     "gene.network",


### PR DESCRIPTION
xn--mythrwalet-smb0a15c.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/27f206f0-01e2-4599-9ef6-d0b89a99682f/
https://urlscan.io/result/a37d1745-c7fc-4e97-b3fb-dc7171acd38e

myetherwallet.com.signmsg.info
Fake MyEtherWallet
https://urlscan.io/result/4b28d824-708d-4cf2-be9e-377457c13ec7/
https://urlscan.io/result/025711cb-53cb-4c6e-9c42-ae271ede4d4c/

oracon.io
Fake airdrop directing users to a fake MyEtherWallet - myetherwallet.com.signmsg.info
https://urlscan.io/result/a5e0c558-338c-4ca4-8194-fad5e2130b66/

eth-bonus.org
Trust trading scam site
https://urlscan.io/result/6719abca-cc48-42fc-b0e1-00b123d7efff/
address: 0x577cad8D4C0511AC704cc2d4D0a01d20917A3035

piscorealestate.com
Hosting a fake MyEtherWallet on GoogleAds (cloaked redirect) - https://prnt.sc/jsp3ns
https://urlscan.io/result/2fef837f-51c6-48a3-bf61-50d458cecdde/

myethrwatt.info
Fake MyEtherWallet
https://urlscan.io/result/3f7e1d65-62c1-47a4-837e-5ac7724086d2/

defraggler-code.com
Fake NEO web wallet
https://urlscan.io/result/e83ea3bc-8d27-4f10-bc6d-875d2149f25e/

ethbonus.io
Trust trading scam site
https://urlscan.io/result/6eafb77d-58e0-4097-956c-3c56e54ecb02/
address: 0xcEe56C3d77d814d29b9410c0f74c12781fcE03ff

ethxpromo.com
Trust trading scam site
https://urlscan.io/result/e92d1660-5bee-4374-92a3-1d9cbe076fcd/
address: 0x9D4B62503b4b7993182323EFFE6245f6D77E4413

omise-go.info
Fake OmiseGo web wallet
https://urlscan.io/result/cbdc8648-7625-49f9-8fe2-8d8c07c5815e/