### PR TITLE
xn--myetherwalle-mm5f.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -314,6 +314,10 @@
     "verasity.io"
   ],
   "blacklist": [
+    "xn--myetherwalle-mm5f.com",
+    "xn--myeherwallet-4j5f.net",
+    "xn--myethrwllet-q7a5h.com",
+    "xn--dexmarket-98d.com",
     "xn--mythrwalet-smb0a15c.com",
     "signmsg.info",
     "myetherwallet.com.signmsg.info",


### PR DESCRIPTION
xn--myetherwalle-mm5f.com
Fake MyEtherWallet - IDN homograph attack domain - not deployed yet
https://urlscan.io/result/b01afd50-265c-40f2-a47b-61d12b458fa4/

xn--myeherwallet-4j5f.net
Fake MyEtherWallet - IDN homograph attack domain - not deployed yet
https://urlscan.io/result/82292a41-b776-4772-bf81-ef99df50fdca/

xn--myethrwllet-q7a5h.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/6da58982-b108-46da-8ee9-2c73eb13b48b/

xn--dexmarket-98d.com
Fake Idex - IDN homograph attack domain
https://urlscan.io/result/d5e9d423-b402-4360-b8a9-fcdd1751e609/