### PR TITLE
kentra.tech + xn--myethrwalt-inbe64c.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -314,6 +314,8 @@
     "verasity.io"
   ],
   "blacklist": [
+    "xn--myethrwalt-inbe64c.com",
+    "kentra.tech",
     "xn--myetherwalle-mm5f.com",
     "xn--myeherwallet-4j5f.net",
     "xn--myethrwllet-q7a5h.com",


### PR DESCRIPTION
kentra.tech
Fake airdrop directing users to a fake MyEtherWallet - xn--myethrwalt-inbe64c.com
https://urlscan.io/result/5a6ac1e3-1447-4ef8-a0e8-d3f9aaf00f46/
https://urlscan.io/result/a15f09f4-5548-45e5-addc-edc3acf01648/

xn--myethrwalt-inbe64c.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/03af7e40-ebcf-4056-ad3f-57f0402d9597/
https://urlscan.io/result/0bcb0635-0977-4d72-a673-618195cbf5d1/
address: 0x0A796062214Cf4FC232Dd8538a19035Ac79a595c