### PR TITLE
creteprint-driveways.co.uk + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -316,6 +316,9 @@
     "verasity.io"
   ],
   "blacklist": [
+    "creteprint-driveways.co.uk",
+    "ethype.org",
+    "etherpromotion.org",
     "idexs.market",
     "itex.market",
     "ideh.market",


### PR DESCRIPTION
creteprint-driveways.co.uk
Trust trading scam site
https://urlscan.io/result/fc1a6bf3-235d-458e-a55f-85c1a8d6a88f
address: 0x607c78AeAaBADb84AdC3298fb3077fc75429e8bD

ethype.org
Trust trading scam site
https://urlscan.io/result/6f03f717-aa58-4b9f-a92c-0b88c0e78d1b/
address: 0xB9b848702a47AE78A70D18c45e552aB1637B5908

etherpromotion.org
Trust trading scam site
https://urlscan.io/result/f67991dc-a3e4-4221-b9bf-ef59c39850f7/
address: 0x32Ea6b24675349EDb6dF2896457819289Aad180E