### PR TITLE
masterthecrypto.org + xn--myetherwllet-ncb.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -317,6 +317,8 @@
     "verasity.io"
   ],
   "blacklist": [
+    "masterthecrypto.org",
+    "xn--myetherwllet-ncb.org",
     "ethpromoaction.com",
     "ethinfo.org",
     "airgws.org",


### PR DESCRIPTION
masterthecrypto.org
Directing users to a fake MyEtherWallet (https://bitly.com/2sK9fJW+) - xn--myetherwllet-ncb.org
https://urlscan.io/result/7e09ccd6-f3cb-4f1a-bf23-cf4f639ccadc/
https://urlscan.io/result/e453d4e4-7cad-4be7-ba2a-5f87f47a533b/

xn--myetherwllet-ncb.org
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/53853539-5bdd-4458-9b3d-3f03d496d94c/