### PR TITLE
binance-giveaway.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -317,6 +317,7 @@
     "verasity.io"
   ],
   "blacklist": [
+    "binance-giveaway.com",
     "walleteos.io",
     "myefhervvallet.com",
     "sparkster.be",


### PR DESCRIPTION
binance-giveaway.com
Trust trading scam site
https://urlscan.io/result/79b97afe-c7e8-4712-9962-e5a12d7bf561/
address: 0x15B4E32d5026A5A9Ad3b68BEcAdceB00B4eB9729