### PR TITLE
getbigdeals.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -317,6 +317,10 @@
     "verasity.io"
   ],
   "blacklist": [
+    "getbigdeals.org",
+    "ethpromotions.org",
+    "wincheck.org",
+    "ethfor.info",
     "hederahashgraph.tokenico.me",
     "tokenico.me",
     "secure.ethxchanges.com",


### PR DESCRIPTION
getbigdeals.org
Trust trading scam site
https://urlscan.io/result/862b618b-36fa-4597-9d51-e51ce2a95065
address: 0x1d138d1f0e8E5F67540b6054De7dB08A610F85B4

ethpromotions.org
Trust trading scam site
https://urlscan.io/result/b3160585-929f-4ecd-9155-b2d331e6293d/
address: 0x016c0261C48D089Ac26d0a48f840c9A9d5e203dd

wincheck.org
Trust trading scam site
https://urlscan.io/result/26a16ed0-f949-4835-ba56-640551ddd00b/
address: 0xF1a4b668D15F0E66543e9F1F795cC2B0f97E3ef2

ethfor.info
Trust trading scam site
https://urlscan.io/result/e97b3b14-c8bf-4811-ac6e-4815b6596ebc/
address: 0x2299c90980777Bb9ebf2D8D58a92Cb3AB7F7fAA0