### PR TITLE
xn--myethrwllt-y4a7gf.com + giveawaypromo.byethost14.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -317,6 +317,8 @@
     "verasity.io"
   ],
   "blacklist": [
+    "xn--myethrwllt-y4a7gf.com",
+    "giveawaypromo.byethost14.com",
     "ploloneix.com",
     "porloneix1.domen-hosting.org",
     "porloneix.com",


### PR DESCRIPTION
giveawaypromo.byethost14.com
Trust trading scam site
https://urlscan.io/result/b4b99bc5-c986-4e82-8819-fc5a6e04115e/
address:  0x6a9C2EC4f4888D7338fC1b28584AaAfEb01e6Db3

xn--myethrwllt-y4a7gf.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/514607ea-ab4b-450f-8f31-b921cc5889d7