### PR TITLE
eth-claim.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -318,6 +318,10 @@
     "verasity.io"
   ],
   "blacklist": [
+    "ethpays.org",
+    "safe.ethpaynow.com",
+    "ethpaynow.com",
+    "elon-gives.com",
     "index-markels.com",
     "etherbonus.win",
     "getethpro.com",


### PR DESCRIPTION
eth-claim.org
Trust trading scam site
https://urlscan.io/result/b9e0175d-1627-42f7-8e07-1b1e5b314d18/
address: 0x87F655E887827eD11Eb3fBC74767B18E142cCced

ethpays.org
Trust trading scam site
https://urlscan.io/result/f0f39673-df5d-422b-b4e6-9b582d4bea77/
address: 0x56ccaA034A0bDb7D3A9515CB580FB5448EfB584C

verify.officialeth.com
Trust trading scam site
https://urlscan.io/result/5c496a5a-cb55-44e6-b355-7b0f58f013e4/
address: 0x6eC56FB2436BA6706CeCD42403B6a1b69fF0817F

safe.ethpaynow.com
Trust trading scam site
https://urlscan.io/result/06ec366f-5e8c-4817-9e80-cbc1ba90027a/
address: 0xa23203C466A57649b83687A3D9129D3EC427C50a

elon-gives.com
Trust trading scam site
https://urlscan.io/result/619af9c7-8cac-4989-a64c-5ddb62ca7997/
address: 0xeb6a066D30c55609fB9f3f6446C6Ef8f27033D2A