### PR TITLE
eoscountdown.co + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -318,6 +318,16 @@
     "verasity.io"
   ],
   "blacklist": [
+    "eoscountdown.co",
+    "xn--mythrwalet-smb0a05c.com",
+    "go.boosteth.com",
+    "boosteth.com",
+    "claims.payeth.promo",
+    "payeth.promo",
+    "get-eth-now.com",
+    "ethpromo.win",
+    "ethereumgift.org",
+    "get-btc-now.com",    
     "ethpays.org",
     "trakt.tv",
     "safe.ethpaynow.com",


### PR DESCRIPTION
eoscountdown.co
Fake EOS countdown directing users to xn--mythrwalet-smb0a05c.com
https://urlscan.io/result/e7423951-27e5-40bd-bfa7-4bb8327fc247/

xn--mythrwalet-smb0a05c.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/4fd4747f-3c2f-4b3a-b0cd-6649643b3327/
https://urlscan.io/result/1609449c-f653-4711-b66a-2db4e8077905/

go.boosteth.com
Trust trading scam site
https://urlscan.io/result/b003ee43-4d5f-4988-a26c-16d5e1a6887d/
address: 0xF7A5a8A2d0D46377a7F9607dF66FF963A23034C2

boosteth.com
Trust trading scam site
https://urlscan.io/result/3605947e-06b8-4e57-939b-a2d24737e2a7/
address: 0xF7A5a8A2d0D46377a7F9607dF66FF963A23034C2

claims.payeth.promo
Trust trading scam site
https://urlscan.io/result/60c13ad5-3269-474f-b026-0ac0e0c31d61/
address: 0xc2dc7B86a5cFbC89e20d5D03026E973958D8E3b3

payeth.promo
Trust trading scam site
https://urlscan.io/result/11b2f9f5-a252-403e-879e-365f7244aa3d/
address: 0xc2dc7B86a5cFbC89e20d5D03026E973958D8E3b3

get-eth-now.com
Trust trading scam site
https://urlscan.io/result/d11f95e0-b75f-42c6-819b-98878cd445ac/
address: 0x2779554418f66834a811f2BeABB0151474b9C67d

ethpromo.win
Trust trading scam site
https://urlscan.io/result/d012f94e-93c3-4f08-92ea-f0b13dff1c2b/
address: 0x0e9e90eD10c6F1714bF87307D95b604288C5D4C5

ethereumgift.org
Trust trading scam site
https://urlscan.io/result/9d934d5c-c26f-4de2-92f9-863a86f78a3b/
address: 0xb9C0179f1F0f19e11586D4D252BC46D88c1713A9

get-btc-now.com
Trust trading scam site - btc address: 1NhFeurTzc9tqWVNpN9fU1M49NvDeEwt9a
https://urlscan.io/result/84f3ddae-8453-4bff-97c9-ef4f2d4e3a53/