### PR TITLE
ethereumgw.org + epromo.cc

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -318,6 +318,8 @@
     "verasity.io"
   ],
   "blacklist": [
+    "ethereumgw.org",
+    "epromo.cc",
     "index-marketz.com",
     "68.168.123.85",
     "eth-promos.org",


### PR DESCRIPTION
ethereumgw.org
Trust trading scam site
https://urlscan.io/result/606005ea-97da-44a0-8b90-00c568b4543b/
address: 0xA6f2814C0020c38882e82D9bFde7B485a7297a1D

epromo.cc
Trust trading scam site
https://urlscan.io/result/c1788f18-d7e8-4f3c-9b09-8907e1ff2ba6/
address: 0xc9194a772c23A595dFAB28E30376f2e16eC39E01