### PR TITLE
iddexmarket.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -321,6 +321,12 @@
     "verasity.io"
   ],
   "blacklist": [
+    "index-marker.com",
+    "iddexmarket.com",
+    "iddexmark.et.com",
+    "iddexma.rket.com",
+    "ideexmarket.com",
+    "idexmarket.com",
     "myetherwalllet.online",
     "odyssey.plus",
     "ethereumgw.org",


### PR DESCRIPTION
iddexmarket.com
Fake Idex Market phishing for keys
https://urlscan.io/result/32dc9167-d27c-463b-8f22-f7d4b194b22c/

index-marker.com
Suspicious Idex Market domain
https://urlscan.io/result/2756c997-1ea4-4544-897f-ae2dd4f061bd/

index-markels.com
Suspicious Idex market domain
https://urlscan.io/result/fb0c0817-ec17-4342-a014-113125a86db8/

iddexmark.et.com
Suspicious Idex Market Domain
https://urlscan.io/result/a788e178-df3d-43fd-9f07-d588384d7793/

iddexma.rket.com
Suspicious Idex Market Domain
https://urlscan.io/result/9a4fbb8e-90de-41e0-bd63-2c7b49c1f687/

ideexmarket.com
Suspicious Idex Market Domain
https://urlscan.io/result/650e4fb7-6321-4166-9f57-f83e0dde8a28/

idexmarket.com
Suspicious Idex Market Domain
https://urlscan.io/result/40e4d5e3-4054-4ced-b6b6-643d2c565764/