### PR TITLE
removed bitballoon

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1413,7 +1413,6 @@
     "check-ethpayments.kissr.com",
     "centratoken.site",
     "gramtokenico.com",
-    "bitballoon.com",
     "eth-gifting.site",
     "ethereums-promo.bitballoon.com",
     "ethereum-promo2018.bitballoon.com",


### PR DESCRIPTION
Removed Bitballoon domain. I realize that it is used to host loads of blacklisted domains, but we shouldn't be barring access to people's ability to use a tool. Until a switch to turn off domain verification is introduced, this shouldn't be blocked.

Fixes: #1873  #1521 , #1632 , #1483 , #1081 , #1368 , #1679 