### PR TITLE
removed rf.gd freehost

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1238,7 +1238,6 @@
     "eth-promo.webz.cz",
     "etherclaims.rf.gd",
     "5000eth.rf.gd",
-    "rf.gd",
     "eth-promo.kissr.com",
     "nmyetlerwaiiet.com",
     "getyoureth.com",


### PR DESCRIPTION
As I referenced in #1874, I realize that freehosts are used to host loads of blacklisted domains, but we shouldn't be barring access to people's ability to use a tool. But until a switch to turn off domain verification is introduced, common freehost tools shouldn't be blocked. This is akin to censorship.

Fixes: #1491 , #1597 , #1737 , #1795 .