### PR TITLE
Added mycrypto.store to whitelist.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14,6 +14,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "mycrypto.store",
     "etherwan.com",
     "cactus.tv",
     "victus.be",


### PR DESCRIPTION
Mycrypto.store has been blocked but does not seem malicious in nature. Added to whitelist.

Fixes: #1736