### PR TITLE
Removed geocities.ws

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1639,7 +1639,6 @@
     "ethereum-giveaway.info",
     "xn--bnanc-fsax.com",
     "xn--binnce-y0a.com",
-    "geocities.ws",
     "eth-giveaway-209.statichtmlapp.com",
     "binance.bitballoon.com",
     "binance-give.com",


### PR DESCRIPTION
This website was blocked even though it is just a web hoster. Originally blocked in #1124 

Currently we can cant blacklist individual urls, only domains. This has been raised in #1848

Fixes: #1785