### PR TITLE
Removed m.famalk.net from whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -290,7 +290,6 @@
     "etherbtc.io",
     "ethereal.capital",
     "etherisc.com",
-    "m.famalk.net",
     "etherecho.com",
     "ethereum.os.tc",
     "theethereum.wiki",


### PR DESCRIPTION
Removed m.famalk.net from whitelist because it's a dead site. Potential security issue in the future. Recommend a brief once-over to audit the whitelist's validity these days.