### PR TITLE
indexmarkett-corp.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -321,6 +321,13 @@
     "verasity.io"
   ],
   "blacklist": [
+    "indexmarkett-corp.com",
+    "giveth.ws",
+    "giveeth.org",
+    "ethereum.org.give-eth.today",
+    "give-eth.today",
+    "collect-ethaway.com",
+    "aireth.today",
     "index-marker.com",
     "iddexmarket.com",
     "iddexmark.et.com",


### PR DESCRIPTION
indexmarkett-corp.com
Suspicious Idex market site
https://urlscan.io/result/aec5f487-a91d-4dc7-b57a-3c4aeb7f4655/

giveth.ws
Trust trading scam site
https://urlscan.io/result/92d763ea-49f0-4b03-9f03-208cea4cdfd1/
address: 0x89271335DB9d0024F725Ab23415678CdEA3EB368

giveeth.org
Trust trading scam site
https://urlscan.io/result/eb736756-e0d7-494a-b30f-9f07703069a6/
address: 0xA6f2814C0020c38882e82D9bFde7B485a7297a1D

ethereum.org.give-eth.today
Trust trading scam site
https://urlscan.io/result/103b8e43-cfec-467f-bdd6-c5f9ae974743/
address: 0xA213344262535D3EA5EFeAA7f7Cf74e792dA6258

give-eth.today
Trust trading scam site
https://urlscan.io/result/f28cbe7d-fb2e-4162-961c-e04aa7f8a1cf/
address: 0xA213344262535D3EA5EFeAA7f7Cf74e792dA6258

collect-ethaway.com
Trust trading scam site
https://urlscan.io/result/4dee93d2-4337-446c-9987-d856f2169dee/
address: 0xe432D9a9be076334474a6a35ede39b278686F923

aireth.today
Trust trading scam site
https://urlscan.io/result/bce53107-ddf0-4220-9252-02cde7c577ed/
address: 0xF1a4b668D15F0E66543e9F1F795cC2B0f97E3ef2