### PR TITLE
myetherwallett.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -324,6 +324,12 @@
     "verasity.io"
   ],
   "blacklist": [
+    "myetherwallett.net",
+    "magntech.tk",
+    "coinzzz.pro",
+    "ico.metronome.bz",
+    "metronome.bz",
+    "metronome.foundation",
     "ethereum-prize.com",
     "sharekit.io",
     "etherbonus.live",


### PR DESCRIPTION
myetherwallett.net
Fake MyEtherWallet Domain
https://urlscan.io/result/fa3e5c56-4ceb-4b4b-9572-03f03898c8c3/

magntech.tk
Hosting a fake MyEtherWallet (magntech.tk/01ef43c4b617f6/wallet/)
https://urlscan.io/result/aed35a9c-4e11-4a0d-855b-2c23984b0d1a/

coinzzz.pro
Hosting a fake Aragon giveaway (https://t.me/Aragonofficial & https://t.me/Aragonannoucement)
https://urlscan.io/result/c671b699-419f-49c1-babe-3ae336bc9ea4/
https://urlscan.io/result/e81cdbc9-812f-4937-88d3-7392b4a4cbb5/

today-ethereum.com
Trust trading scam site
https://urlscan.io/result/0deae08e-688c-414a-97e6-e3fe675b5344/
address: 0x4dD0eF53784030fA675e2677F9CdC2a3e32E956B

ico.metronome.bz
Fake Metronome crowdsale site
https://urlscan.io/result/bc9e0689-3793-4d6c-8e77-8420781f5157/
https://urlscan.io/result/c9b2fc99-4f60-4d0e-8901-0b3fd3c280dd/
address: 0x6c4f56B116E91f15E790508d4212906B75835B63

metronome.foundation
Fake Metronome crowdsale site
https://urlscan.io/result/0410d586-a46c-49ab-b9f7-2bd3b3df34e6/