### PR TITLE
s-msg-myetherwallet.com + xn--mythrwallt-fnbcf.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -325,7 +325,6 @@
   ],
   "blacklist": [
     "s-msg-myetherwallet.com",
-    "xn--mythrwallt-fnbcf.com",
     "elon-shares.com",
     "xn--myeterwallet-o0b.com",
     "myetherwallett.net",

--- a/src/config.json
+++ b/src/config.json
@@ -324,6 +324,8 @@
     "verasity.io"
   ],
   "blacklist": [
+    "s-msg-myetherwallet.com",
+    "xn--mythrwallt-fnbcf.com",
     "elon-shares.com",
     "xn--myeterwallet-o0b.com",
     "myetherwallett.net",


### PR DESCRIPTION
s-msg-myetherwallet.com
Fake  MyEtherWallet
https://urlscan.io/result/561c9224-f156-4874-8ec3-d4970ebbde8e

xn--mythrwallt-fnbcf.com
Fake MyEtherWallet - IDN homograph attack domain. Directed through https://bitly.com/2MrbZnO+
https://urlscan.io/result/797ae5ea-74e4-455b-9124-5e32918c80d1
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1882