### PR TITLE
ethereum-claim.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -325,6 +325,9 @@
     "verasity.io"
   ],
   "blacklist": [
+    "ethereum-claim.org",
+    "safesteth.com",
+    "ethscan.us",
     "get.perfecteth.com",
     "rd.com",
     "perfecteth.com",


### PR DESCRIPTION
ethereum-claim.org
Trust trading scam site
https://urlscan.io/result/72994984-e750-432f-916f-785e020e1039/
address: 0x2092B75719EC6f1dfE3f0d8C73239aD0297522BE

get.safesteth.com
Trust trading scam site
https://urlscan.io/result/d4bdf505-2e40-4e97-8d48-22826ad999eb/
address: 0x37a8C55F6860e19f353686f5dd9c603ADB8448b6

safesteth.com
Trust trading scam site
https://urlscan.io/result/8d0c3081-0e94-41c0-a7f6-708f8119467a/
address: 0x37a8C55F6860e19f353686f5dd9c603ADB8448b6

secure.ethscan.us
Trust trading scam site
https://urlscan.io/result/02673a53-e59f-4113-acbc-aaec85e715d0/
address: 0x1A11585B374D5827F44e117e07941A8728a5f342