### PR TITLE
ethshare.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -325,6 +325,11 @@
     "verasity.io"
   ],
   "blacklist": [
+    "ethshare.org",
+    "ethergive.info",
+    "myetherwalet.heliohost.org",
+    "keyfundairdrop.typeform.com",
+    "eosdash.io",
     "ethereum-claim.org",
     "safesteth.com",
     "ethscan.us",


### PR DESCRIPTION
ethshare.org
Trust trading scam site
https://urlscan.io/result/ba9e9637-afda-4032-860a-aa14ad4048e3/
address: 0x03E115D99F005F9df8AcCeC3F3d07F54b593eE96

ethergive.info
Trust trading scam site
https://urlscan.io/result/f78872b8-15be-46be-ad8b-e77dcf1b168d/
address: 0xC71610821ac6042E52Be9d7d76df4c425F30f41f

myetherwalet.heliohost.org
Fake MyEtherWallet
https://urlscan.io/result/324c8485-c0f9-47b9-afe1-b769a109ee6a/

keyfundairdrop.typeform.com
Fake EOS airdrop directing users to myetherwallet.com.signmessage.me (https://bitly.com/2HTNWuj+)
https://urlscan.io/result/832bef2f-3cd3-46bf-95ad-e694a8879fd2/

eosdash.io
Fake EOS airdrop directing uses to myetherwallet.com.signmessage.me (https://bitly.com/2HTNWuj+)
https://urlscan.io/result/1a230f02-ae2c-406d-8a8a-238ec5365041/