### PR TITLE
etherfree.tech

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -325,6 +325,7 @@
     "verasity.io"
   ],
   "blacklist": [
+    "etherfree.tech",
     "waves-platform.net",
     "myefherwaliet.com",
     "ethsafe.net",


### PR DESCRIPTION
etherfree.tech
Trust trading scam site
https://urlscan.io/result/f683c28e-f8ae-4d25-9fb0-019631c24933
address: 0x53DB08c95D0D6De34d8318970Bbcb063f82Fcc41