### PR TITLE
get.personaleth.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -327,6 +327,10 @@
     "verasity.io"
   ],
   "blacklist": [
+    "personaleth.com",
+    "indexmarket-inc.com",
+    "mnyctervailliet.com",
+    "mnyidthewallot.com",
     "c-kamowski.fr",
     "eosprivate.io",
     "signmessage.me",


### PR DESCRIPTION
get.personaleth.com
Trust trading scam site
https://urlscan.io/result/5c516db6-b791-45bf-83c0-46c90c9edfb9/
address: 0x9d03A3AD580cC2fb820349d3FF002Fb2FC7a6b19

personaleth.com
Trust trading scam site
https://urlscan.io/result/efb5b67e-2e26-4b85-b065-507d2379b648/
address: 0x9d03A3AD580cC2fb820349d3FF002Fb2FC7a6b19

indexmarket-inc.com
Suspicious Idex Market domain
https://urlscan.io/result/9955cac9-cc6f-44a7-acdb-3af8d164d2f4/

mnyctervailliet.com
Suspicious MyEtherWallet domain
https://urlscan.io/result/ceac9e6e-3234-44e5-a112-037f19208329/

mnyidthewallot.com
Fake MyEtherWallet
https://urlscan.io/result/7947fc2a-73c3-47ba-aded-ec99f8cd1ced/