### PR TITLE
idexmarketllc.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -327,6 +327,11 @@
     "verasity.io"
   ],
   "blacklist": [
+    "idexmarketllc.com",
+    "idexwebaa.com",
+    "ethfast.io",
+    "givewaypromo.org",
+    "ethereum-givaway.social",
     "personaleth.com",
     "indexmarket-inc.com",
     "mnyctervailliet.com",


### PR DESCRIPTION
idexmarketllc.com
Fake Idex Market phishing for keys
https://urlscan.io/result/da8918fb-bdbf-49ff-8843-339fa0001c9c/

idexwebaa.com
Fake Idex Market phishing for keys
https://urlscan.io/result/11279cd6-8a3f-4c8a-8095-254399b0013e/

ethfast.io
Trust trading scam site
https://urlscan.io/result/efef9eb0-781d-4613-9f9f-342738a92d76/
address: 0x679A8cF6E181EbbcD9d14D0bd9595d8cFB79eCDf

givewaypromo.org
Trust trading scam site
https://urlscan.io/result/0d9eeee9-50b0-41c3-9a49-acc57a732f41/
address: 0x83D7Cb758C30d067e99E9f52F9e4f987101aB888

ethereum-givaway.social
Trust trading scam site
https://urlscan.io/result/a5586740-36ea-4ee5-b247-c65feebe7370/
address: 0x777c6aD16B303639489a38b369e423AA2c491884