### PR TITLE
eosauthority.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -330,6 +330,16 @@
     "verasity.io"
   ],
   "blacklist": [
+    "ethgpromo.com",
+    "eosauthority.info",
+    "eosauthority.unstake.xyz",
+    "unstake.xyz",
+    "xn--mythrwalet-c7a29cyq.com",
+    "ethgivers.com",
+    "secure.ethgivers.com",
+    "ethergift.io",
+    "suretytoken.com",
+    "getethers.org",
     "indexmaker-network.com",
     "idexmarket-corp.com",
     "idexontime.com",


### PR DESCRIPTION
eosauthority.info
Fake EOS site phishing for private keys (POST store.php)
https://urlscan.io/result/9900e2ed-5aca-4eb8-878a-49c9c6e0efdb/

eosauthority.unstake.xyz
Fake EOS site phishing for private keys
https://urlscan.io/result/a1195d2f-2317-482a-a9b2-b8c6f8e4eda0/

xn--mythrwalet-c7a29cyq.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/6d3ef995-0403-48ba-9976-74c49faa8e4a/
https://urlscan.io/result/b90a1212-973c-4fbb-8f22-ce98d3167820/

suretytoken.com
Fake airdrop (HTTrack signatures)
https://urlscan.io/result/1c3e7410-5ff8-4924-b31c-abb59cd31ca0/
https://urlscan.io/result/95307a76-c69a-4b50-b956-674b94286ff4/

getethers.org
Trust trading scam site
https://urlscan.io/result/6c1f677f-6b11-42a0-8ab4-ede93737a86a/
address: 0xBE9d75228fD01844BADA1394bfb5a4740c18C01f

ethergift.io
Trust trading scam site
https://urlscan.io/result/dcf88bb1-55b4-44bc-9796-5f9053d221fd/
address: 0xc387587a1D7cDf7Aa73e14ce03FfaC945777Aaed

secure.ethgivers.com
Trust trading scam site
https://urlscan.io/result/6d95af90-b0bb-4732-af46-755e5fadef6e/
address: 0xeB71af7Cd339832fF8d88D985035B2793042eCA8

ethgivers.com
Trust trading scam site
https://urlscan.io/result/4ede5831-b596-4d3e-b238-f8a9cb047bc9/
address: 0xeB71af7Cd339832fF8d88D985035B2793042eCA8

ethgpromo.com
Trust trading scam site (promoted via https://bitly.com/2yfGyJS+)
https://urlscan.io/result/36e17d97-f94b-48ff-9ddc-932d17bfc5fa/
address: 0x205906790a597972f97fccda132d89ee63f15c10