### PR TITLE
airdropeos.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -330,6 +330,7 @@
     "verasity.io"
   ],
   "blacklist": [
+    "airdropeos.com",
     "neo-x.info",
     "myetherplace.com",
     "ether-give.live",


### PR DESCRIPTION
e.airdropeos.com
Fake EOS Airdrop phishing for private keys
https://urlscan.io/result/d004a1c0-fa50-4c54-9159-d9ebaab5f024/
https://urlscan.io/result/8f9019f7-78ac-43eb-81d7-3ebfd76f6b50/