### PR TITLE
get.ethsupport.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -330,6 +330,7 @@
     "verasity.io"
   ],
   "blacklist": [
+    "eosclassic.co",
     "ethsupport.net",
     "newsair.info",
     "officialgiveaway.org",

--- a/src/config.json
+++ b/src/config.json
@@ -330,6 +330,10 @@
     "verasity.io"
   ],
   "blacklist": [
+    "ethsupport.net",
+    "newsair.info",
+    "officialgiveaway.org",
+    "collectionseth.com",
     "airdropeos.com",
     "neo-x.info",
     "myetherplace.com",


### PR DESCRIPTION
get.ethsupport.net
Trust trading scam site
https://urlscan.io/result/0c7e0e14-420e-4537-aa68-0acbd782025d/
address: 0xC0095047d767857Bb40CC77EF54569d4124984C3

ethsupport.net
Trust trading scam site
https://urlscan.io/result/0818f599-4ac3-44fb-83a7-2ac55c913224/
address: 0xC0095047d767857Bb40CC77EF54569d4124984C3

newsair.info
Trust trading scam site
https://urlscan.io/result/23544306-fe1c-4f6e-8148-6d3fb2dcec82/
address: 0xF1a4b668D15F0E66543e9F1F795cC2B0f97E3ef2

officialgiveaway.org
Trust trading scam site
https://urlscan.io/result/974ca124-e17b-4f55-adf3-d6cfe591e831/
address: 0x83D7Cb758C30d067e99E9f52F9e4f987101aB888

collectionseth.com
Trust trading scam site
https://urlscan.io/result/98d4c6c1-2eff-45a1-8fb3-dce3fbde1c1d/
address: 0xfb997Ea4c102fAd4ec67f8bb069752030C0C0531