### PR TITLE
myeostrust.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -330,6 +330,12 @@
     "verasity.io"
   ],
   "blacklist": [
+    "myeostrust.com",
+    "eosdrop.xn--mythrwallt-c7a86c5a.com",
+    "eth-claim.net",
+    "ethfreegift.org",
+    "myenterworlld.com",
+    "localetherwallet.info",
     "eosclassic.co",
     "ethsupport.net",
     "newsair.info",


### PR DESCRIPTION
myeostrust.com
Fake EOS web wallet phishing for keys (POST /store.php)
https://urlscan.io/result/da324895-cf75-4897-82f4-b0550061c2bd

eosdrop.xn--mythrwallt-c7a86c5a.com
Fake EOS airdrop. Directing users to a fake MyEtherWallet xn--mythrwallt-c7a86c5a.com/signmsg.html via bit.ly/2Jlh9zL+
https://urlscan.io/result/9f701baf-90d3-4cea-83d2-7db93d04230d
https://urlscan.io/result/1e5fe28a-08c0-4093-ad41-68c1b7b16440

eth-claim.net
Trust trading scam site
https://urlscan.io/result/73088752-e7cc-4e5d-a73e-5c4fb9ace29c/
address: 0x45C3eF2bc2719586Cd92766B3895868d3EE9Ef92

ethfreegift.org
Trust trading scam site
https://urlscan.io/result/b69dd93f-4478-4420-845c-f8a2b6d3294c/
address: 0x46Cbc3c3710dC4a632842e155f18f30d4AB38aaC

myenterworlld.com
Fake MyEtherWallet/MyEtherWallet
https://urlscan.io/result/6c9afc5e-5a8a-4578-83fd-b5bacf1ec881/

localetherwallet.info
Fake LocalEtherWallet/MyEtherWallet
https://urlscan.io/result/06b1dba6-ccde-4549-8d4f-9e3650a4888f/