### PR TITLE
give-ethprize.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -331,6 +331,9 @@
     "verasity.io"
   ],
   "blacklist": [
+    "give-ethprize.com",
+    "odyssey.center",
+    "world-market.online",
     "ethereum.odyssey.center",
     "xn--eosauthorty-wcb.com",
     "etherfree.info",


### PR DESCRIPTION
give-ethprize.com
Trust trading scam site
https://urlscan.io/result/96353108-4f6c-48ff-9e84-df9d260e6f70
address: 0x257890939F7c0B758897F7Bd49A590B7190043e0

odyssey.center
Fake MyEtherWallet phishing for keys
https://urlscan.io/result/20382cc6-2d4a-4593-8535-72961957422c
https://urlscan.io/result/8e30cf3d-ac91-42d9-9bc2-5a88c91a73a9

world-market.online
Fake MyEtherWallet
https://urlscan.io/result/fd3faf2e-96fe-4fb7-8c6d-a82a2c770766