### PR TITLE
ethextra.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -331,6 +331,7 @@
     "verasity.io"
   ],
   "blacklist": [
+    "ethextra.net",
     "ethofficialpage.us",
     "ethers-free.org",
     "claimethers.org",


### PR DESCRIPTION
ethextra.net
Trust trading scam site
https://urlscan.io/result/12556668-a423-4090-bf6b-6c04b02c7918/
address: 0xA1FF3Bc95D29C7DFCcD60C2226697b9C9aC0a16b