### PR TITLE
ethereum-event.com + ethereum-giveaway.safe-eth.top

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -331,6 +331,9 @@
     "verasity.io"
   ],
   "blacklist": [
+    "ethereum-event.com",
+    "ethereum-giveaway.safe-eth.top",
+    "safe-eth.top",
     "myautocentmarks.com",
     "io-tron.com",
     "ethereum-platform.org",


### PR DESCRIPTION
ethereum-event.com
Trust trading scam site
https://urlscan.io/result/0412668a-97ac-4452-aeba-d26d466ea789/
address: 0x6668bD45B15E2775F03e738Ef6257637A9745287

ethereum-giveaway.safe-eth.top
Trust trading scam site
https://urlscan.io/result/0dce4106-5b81-4e70-824d-a3b09960d8db/
address: 0x637336064f49074587a15cFD785D17Ed02Aebf25