### PR TITLE
ethereumdrop.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -334,6 +334,17 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "ethereumdrop.info",
+    "ethpays.info",
+    "eth-give-away.com",
+    "safe.ethpaynet.com",
+    "ethpaynet.com",
+    "getyoureths.com",
+    "eth.fanclub.rocks",
+    "fanclub.rocks",
+    "get-bitcoins-now.com",
+    "ethsc32821.nichost.ru",
+    "gelepo.com",
     "musk-shares.com",
     "elon-gift.com",
     "elon-gifts.com",


### PR DESCRIPTION
ethereumdrop.info
Trust trading scam site
https://urlscan.io/result/2bb4f149-9123-4164-9ff3-48b60686e877/
address: 0x9386ff151225710C61747c7e314f317B6330453C

ethpays.info
Trust trading scam site
https://urlscan.io/result/13292ff3-6786-4d3f-864b-391dc0b93727/
address: 0x47d6287a9fC4A1f69c0b20dCC29928Ebb44349c6

eth-give-away.com
Trust trading scam site
https://urlscan.io/result/d2710824-a1ac-4867-af90-44bce2086348/
address: 0x8967f58f726bc35aA10223961fEEa6055a48Aae5

safe.ethpaynet.com
Trust trading scam site
https://urlscan.io/result/1054c4e2-a03c-45cd-8df2-e29a53b619b4/
address: 0x4496370B4F0993152f761bd3b3d1Dd4e7B1b3139

ethpaynet.com
Trust trading scam site
https://urlscan.io/result/8fa971b5-d8bb-44c2-aa8a-91295a5b07d7/
address: 0x4496370B4F0993152f761bd3b3d1Dd4e7B1b3139

getyoureths.com
Trust trading scam site
https://urlscan.io/result/ee5842b3-6bae-497a-9ca3-f42c4d2d25f8/
address: 0x90fb8FFf658e1BD24D274C1A1133C319e055703A

eth.fanclub.rocks
Trust trading scam site
https://urlscan.io/result/49f84413-e205-41e6-af12-8953f7a6908e/
address: 0x8Ac2D87f4308B0718AA9345B409277E01282fe03

get-bitcoins-now.com
Trust trading scam site
https://urlscan.io/result/ccdd92f1-0327-4270-a0f6-7c53acc175c6/
address: 0x8De51b248261C0e5736b412eF9FaAAf619063b7A

ethsc32821.nichost.ru
Trust trading scam site. Bitcoin address: 16VWrgdLgfF9QBab5Y6bMqHDU9h4bWHBvv
https://urlscan.io/result/1f5ab8a4-ea15-4629-bd05-bb2bc791ed0d/

gelepo.com
Trust trading scam site. Bitcoin address: 1BMWrDwudPBKoFDVJ57K6THR2QAEVkbvok
https://urlscan.io/result/10673e27-683b-43b2-b6fa-0c6ec58bdc00/