### PR TITLE
ethgift.net + ethfortune.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -334,6 +334,8 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "ethgift.net",
+    "ethfortune.com",
     "ethereumdrop.info",
     "ethpays.info",
     "eth-give-away.com",


### PR DESCRIPTION
ethgift.net
Trust trading scam site
https://urlscan.io/result/9b907bb0-5019-4e4f-a975-e31bf80341cb
address: 0x33e5d6C0447EA731Fe4e2502a881B90ee991CF3a

ethfortune.com
Trust trading scam site
https://urlscan.io/result/e93fd184-d361-432f-a713-a42d67506895/
address: 0x37e30FEe740928E8Db15d3daFd544bAAB6B87051