### PR TITLE
eossauthorithy.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -337,6 +337,9 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "eossauthorithy.com",
+    "electrum.ink",
+    "electrumwallet.ml",
     "myethenrwallet.site",
     "myetherium.ru",
     "myetherwalleft.ru",


### PR DESCRIPTION
eossauthorithy.com
Fake EOS domain - phishing for private keys with POST /store.php
https://urlscan.io/result/aeba16af-9a74-4d4e-b1f5-bffd855ea479

electrum.ink
Fake Electrum site
https://urlscan.io/result/5afe85ec-6c6b-4cb5-9013-00afd1f96f0c/

electrumwallet.ml
Fake Electrum site
https://urlscan.io/result/93e5ccea-db95-4fe4-86dc-5c3045b840fc/