### PR TITLE
idext.market + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -337,6 +337,11 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "idext.market",
+    "etherdelta.com.ua",
+    "etzerdelta.com",
+    "forkdelta.co",
+    "myeftervvellet.com",
     "teslaforfree.wordpress.com",
     "go.ethtake.com",
     "ethtake.com",


### PR DESCRIPTION
idext.market
Fake Idex market. Suspected address: 0x31f530b58efa42dab4bd1789184b4cc6b884dea0
https://urlscan.io/result/c85717c0-7f56-4953-81e1-0bce969e9f9f/

etherdelta.com.ua
Fake EtherDelta
https://urlscan.io/result/b2ed10fc-b177-4729-8995-faefdc5fb9b9/

etzerdelta.com
Fake EtherDelta
https://urlscan.io/result/0084d818-c498-4af1-a8e7-d4e04755632d/

forkdelta.co
Fake ForkDelta
https://urlscan.io/result/cbef90cf-7a5b-406b-aae8-35e2769adf59/

myeftervvellet.com
Fake MyEtherWallet
https://urlscan.io/result/402b4def-fa9e-4af7-98e2-23f384230e48/