### PR TITLE
eosauthority.website

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -337,6 +337,7 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "eosauthority.website",
     "yobit.tilda.ws",
     "eth2018.net",
     "ethtwitter.com",


### PR DESCRIPTION
eosauthority.website
Fake EOS site phishing for keys (POST /store.php)
https://urlscan.io/result/de7e0387-f090-4ec9-9dd0-280912c3dae0/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/1993