### PR TITLE
pumphash.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -337,6 +337,10 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "pumphash.com",
+    "tronplay.network",
+    "xn--mytherwalet-srb35c.com",
+    "eosauthority.bitballoon.com",
     "better-hash.com",
     "promo.ethtake.com",
     "myetherwallet-sign.top",


### PR DESCRIPTION
pumphash.com
Trust trading scam site
https://urlscan.io/result/7d85cea8-0667-4fdb-a5b3-69cc6b091cdb
address: 0xDd1f234967913C25f176bda85A9825BA880e447E

tronplay.network
Fake Tron airdrop directing users to a fake MyEtherWallet xn--mytherwalet-srb35c.com/signmsg.html via bitly.com/2K90ioo+
https://urlscan.io/result/8e826d40-2b07-43f3-ade4-f14faadd9746/
https://urlscan.io/result/08473218-370c-4d36-8233-8a6fdd4759b8/

xn--mytherwalet-srb35c.com
Fake MyEtherWallet phishing users keys
https://urlscan.io/result/9f6b9d9c-671e-4afd-9d52-aa5983fba80e/

eosauthority.bitballoon.com
Fake EOS site phishing for keys
https://urlscan.io/result/f4756abc-47b0-438e-8d2b-18d66b8c575b/

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2003