### PR TITLE
hitbtc-login.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -337,6 +337,11 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "hitbtc-login.com",
+    "promobinance.com",
+    "bittrex-ix.com",
+    "bittrex-app.com",
+    "bittrecx.com",
     "pumphash.com",
     "tronplay.network",
     "xn--mytherwalet-srb35c.com",


### PR DESCRIPTION
hitbtc-login.com
Fake Hitbtc site phishing for logins
https://urlscan.io/result/556feb89-8283-43bb-a5d8-6ebedcb9d11d/
https://urlscan.io/result/6d905b16-a7f8-4db4-a897-3e3bd88ec88d/

promobinance.com
Fake Binance site phishing for logins
https://urlscan.io/result/16215007-665e-4295-b01b-158c27b69f28/

bittrex-ix.com
Fake Bittrex site phishing for logins
https://urlscan.io/result/e48cb58b-d1f9-43c0-b14c-fa783a4f3409/

bittrex-app.com
Fake Bittrex site phishing for logins
https://urlscan.io/result/a3ba0b9b-8d10-4f7f-a55a-aced69817420/

bittrecx.com
Fakr Bittrex site phishing for logins
https://urlscan.io/result/14f00645-e1c2-4a7b-b71b-cf892e96c17d/
https://urlscan.io/result/37f41dc5-b351-4256-b3e9-0890b8aadae3/

telegra.ph/Bittrex-giving-away-5000-Ethereum-ETH-03-26
Trust trading scam site
https://urlscan.io/result/98da3cf2-09de-46bf-874e-c70e3a22a70b/
address: 0x25f754ade28ec1ed771ee22efeaed764847181e3