### PR TITLE
eosauthority.com.globatalent.network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -338,6 +338,8 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "eosauthority.com.globatalent.network",
+    "globatalent.network",
     "eth-gift.club",
     "buterin-giveaway.org",
     "freegiveaway-eth.com",


### PR DESCRIPTION
eosauthority.com.globatalent.network
Fake EOS site phishing for keys with POST /store.php
https://urlscan.io/result/701a8b5d-b14f-4b1e-8157-c3c4b047233a/
https://urlscan.io/result/31efdb00-6ec1-4b1d-84dd-f47a1a391569/

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2010