### PR TITLE
ethbig.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -338,6 +338,9 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "ethbig.net",
+    "vechain-platform.org",
+    "vechain-block.com",
     "eosauthority.com.globatalent.network",
     "globatalent.network",
     "eth-gift.club",


### PR DESCRIPTION
ethbig.net
Trust trading scam site. Being promoted by Twitter user 321652568
https://urlscan.io/result/64816934-168f-4e31-8245-48359ba33d2e
address: 0xA22270850FabDE01E1f5c5879ea65DD82890AF31

vechain-platform.org
Fake VeChain web wallet
https://urlscan.io/result/af61a7f8-45de-4d5e-9ab4-cf5c08900b80/
address: 0xEaAaF85E36267d4a44532E4df628254D6cE7f9cD

vechain-block.com
Fake VeChain web wallet
https://urlscan.io/result/64cc6bd1-65cf-4b4b-91bf-a7f2bbc113ae/
address: 0xaf48cfd4eee2b9f185fda12bf0cbbec5b90ed8c9

----

eth.blogmedium.top
Trust trading scam site
https://urlscan.io/result/e585f1f3-72b4-46ac-8a4c-4d93b97d5edc/
address: 0xAeD20775C1d0D64796C9D023c8a7ac84557BA1Ad

celebration-eth.com
Trust trading scam site
https://urlscan.io/result/29f0f450-ffe5-4e33-aa4a-47f55683f428/
address: 0x79B570F107F07589244C76Ad8fd9a7cca0fb80ef 
reported address: 0xB6eCd180F5CBB9167147394841D31f94EfF77DBf