### PR TITLE
node82.btc-giveaway.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -338,6 +338,13 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "btc-giveaway.info",
+    "node82.btc-giveaway.info",
+    "texacon-verify-547fcd.bitballoon.com",
+    "kinetictokenforms.typeform.com",
+    "etherclaim.org",
+    "xatrainvest.com",
+    "xn--myethrwalt-f7a07c4r.com",
     "trx.claims",
     "coinscrypto.info",
     "giveaway.eth-safe.net",


### PR DESCRIPTION
node82.btc-giveaway.info
Trust trading scam site. Bitcoin address: 17ntyMTNJpM6JDdS9M5G2eKgKELuGfzZkr
https://urlscan.io/result/4d027946-90dd-482d-969d-ee96d0692ff3/
https://urlscan.io/result/68b1d00d-2a10-4cac-8c0c-a0fb50d0e079/

texacon-verify-547fcd.bitballoon.com
Hosting a fake airdrop directing users to a fake MyEtherWallet xn--myethrwalt-f7a07c4r.com/signmsg.html via bitly.com/2KNuPHT+
https://urlscan.io/result/9e802a50-5530-4f04-91e1-846b86647879/
https://urlscan.io/result/591989b3-c4f1-476a-87dd-2998867182ad/

kinetictokenforms.typeform.com
Hosting a fake airdrop directing users to a fake MyEtherWallet xn--myethrwalt-f7a07c4r.com/signmsg.html via bitly.com/2KNuPHT+
https://urlscan.io/result/9e802a50-5530-4f04-91e1-846b86647879/
https://urlscan.io/result/591989b3-c4f1-476a-87dd-2998867182ad/

etherclaim.org
Trust trading scam site
https://urlscan.io/result/2466453a-cae8-4233-87c5-df46c3d1e25b/
address: 0xeC4208e6786bb63b3a204590a477585DC8152B4B

xatrainvest.com
Ponzi scheme
https://urlscan.io/result/c8cc7a38-5ff1-4d3e-9667-af5ee5de5785/

xn--myethrwalt-f7a07c4r.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/f9363161-15f5-448b-8963-f63e04b6c17d/