### PR TITLE
etherdeltha.info + forcdelta.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -338,6 +338,8 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "etherdeltha.info",
+    "forcdelta.com",
     "ethereumfoundationgift.tumblr.com",
     "btcpramengyve.com",
     "claim-btc.org",


### PR DESCRIPTION
etherdeltha.info
Suspicious EtherDelta domain
https://urlscan.io/result/3a5f8674-dbe4-4948-a826-f294f19bdecf

forcdelta.com
Fake ForkDelta stealing keys
https://urlscan.io/result/d5b7c135-fc49-4671-b333-5be19d944e64