### PR TITLE
get.lotsofeth.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -338,6 +338,9 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "get.lotsofeth.com",
+    "lotsofeth.com",
+    "ethcountdown.ga",
     "ethpromofree.com",
     "sparkster.com.de",
     "buterineth.org",


### PR DESCRIPTION
get.lotsofeth.com
Trust trading scam site
https://urlscan.io/result/a1b771e4-d7e1-4090-9139-97552cfc81c7
address: 0x8EEad6A5776dCE374257bF7D4500CfE3C1e362a6

lotsofeth.com
Trust trading scam site
https://urlscan.io/result/aaf0c166-7d1f-4ecf-a4c6-1189017602e3
address: 0x8EEad6A5776dCE374257bF7D4500CfE3C1e362a6

ethcountdown.ga
Trust trading scam site
https://urlscan.io/result/51d4b552-9d18-4ed1-b14e-0e08ca86f9c9
address: 0x8781ebb17371D0c530285433308C02b81b895DAE