### PR TITLE
bittrcex.com + binance.promoting.world

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -340,6 +340,9 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "bittrcex.com",
+    "binance.promoting.world",
+    "promoting.world",
     "ether-promotion.info",
     "eventeth.com",
     "btcpromofree.com",


### PR DESCRIPTION
bittrcex.com
Fake Bittrex phishing for logins
https://urlscan.io/result/e936a073-f919-4d9b-be38-cf83c42a6672/
https://urlscan.io/result/f6ac9bc2-36da-4ca3-ac0d-12c8b5c84a6d/

binance.promoting.world
Trust trading scam site
https://urlscan.io/result/2c7baa0d-8c8c-4eb9-a1cc-dcb63fc66a6e/
https://urlscan.io/result/dcd6260a-b18a-4794-9193-4e53f47b5b22/
address: 0x4BC69a335D353dce4De09399b24079aEd48F7865