### PR TITLE
ethereumpromote.wixsite.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -341,6 +341,11 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "myetherwalilet.com",
+    "ethereumpromote.wixsite.com",
+    "ethgive.club",
+    "etherclaims22.top",
+    "officialmcafee.github.io",
     "eth10000.org",
     "safe.eth10000.org",
     "gift-eth.org",


### PR DESCRIPTION
myetherwalilet.com
Fake MyEtherWallet
https://urlscan.io/result/6ccb5ff1-391f-4267-9803-14c6d1f2fd66/
https://urlscan.io/result/3f421984-e1b7-4471-8e8a-861f0e272091/

ethereumpromote.wixsite.com
Trust trading scam site. Promoted by Twitter user id 1012075718405185538. Directed via bit.ly/2sK3rPO+
https://urlscan.io/result/86a81ee8-0925-447d-84e8-c4874a7dd680/
address: 0x159CCfFB293a06Aafaec1b254A00522A2bC40639

ethgive.club
Reported trust trading scam site. Reported address: 0x9E91ea0C442dd2B41CC7fE2d54fAEcd34f59C134
https://urlscan.io/result/50b4d5a1-460b-4eb2-82d8-519526fad919/

etherclaims22.top
Trust trading scam site
https://urlscan.io/result/b17ef239-488e-49b9-b4ab-0c99dc7a7f54/
https://urlscan.io/result/6194fca7-577e-498c-833b-985b85c10de6/
https://urlscan.io/result/420d9009-48f4-4353-a88f-1ed76624b3da/
https://urlscan.io/result/065ebdf3-8118-4a69-8e7e-d4cb2528f8c3/
https://urlscan.io/result/11c055bf-75d6-40d3-a9c4-040c94a87104/
address: 0x336a3f0c4d40b1e39cee72e2e59330daf484848c
address: 0xAB7EC7596fc05BC55AFc07008cC06c1193eD6f9a

officialmcafee.github.io
Trust trading scam site
https://urlscan.io/result/e801f0d2-cb8a-489c-85a9-482500f8ef82/
address: 0x71486336caEd5fA8E37fF8b31B9d67d08FbDC262


---

mediumdotcom.top
Trust trading scam site directing users to ethe.mediumblog.top
https://urlscan.io/result/a438adea-c056-4205-bef3-1033a0a73b11/
https://urlscan.io/result/5d2b7b43-d1ac-423e-8cb4-a8947e6474d1/
https://urlscan.io/result/202bc957-c788-4074-b356-636a492f3703/
https://urlscan.io/result/2eb2f5bc-774e-449d-b97b-6c6eca978ef1/
https://urlscan.io/result/a479a0c3-9ecf-4f50-811c-28ec58a227d6/
address: 0xAB7EC7596fc05BC55AFc07008cC06c1193eD6f9a

ethpromofree.com
Trust trading scam site
https://urlscan.io/result/8bc60ed0-957c-43b6-82d0-12bc9559898e/
address: 0x1754CebeA65AFE5CfE90eE7D393AdCe1568d2Ba4