### PR TITLE
idex.xyz + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -341,6 +341,9 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "idex.xyz",
+    "teslagifts.tumblr.com",
+    "brinannce.com",
     "bittrexl.com",
     "getethtoday.com",
     "safe.getethtoday.com",


### PR DESCRIPTION
idex.xyz
Fake Idex phishing for keys with POST /sendkey.php
https://urlscan.io/result/f8ab0ddb-1e86-4f9d-89e4-074a663d8fd8/

teslagifts.tumblr.com
Promoting trust trading scam sites directing users to http://etherclaims22.top/payment.php
https://urlscan.io/result/d4bf8844-4e8c-4a19-a670-97ca05d8da8a/
address: 0xAB7EC7596fc05BC55AFc07008cC06c1193eD6f9a

brinannce.com
Fake Binance phishing for logins
https://urlscan.io/result/8f424bbb-6ae1-4c41-8540-75ded8c985c7/
https://urlscan.io/result/8de488f7-df50-498c-941d-7358943117ab/