### PR TITLE
ethmore.live + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -343,7 +343,7 @@
   "blacklist": [
     "ethmore.live",
     "myehtewallet.com",
-    "myehtewallet.com",
+    "meyehterwallet.com",
     "indexmarkket-site.com",
     "idexnetone.com",
     "myetherwallet.com.verifymsg.icu",

--- a/src/config.json
+++ b/src/config.json
@@ -341,6 +341,9 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "ethmore.live",
+    "myehtewallet.com",
+    "myehtewallet.com",
     "indexmarkket-site.com",
     "idexnetone.com",
     "myetherwallet.com.verifymsg.icu",


### PR DESCRIPTION
ethmore.live
Trust trading scam site. Promoted by twitter id 59058979
https://urlscan.io/result/f717080f-2d14-4332-b68d-981ab8978ddd/
address: 0x68E2EF6244Be67fE149C8309e1c5E978fa1a3Cab

myehtewallet.com
Fake MyEtherWallet
https://urlscan.io/result/f208e7fc-7508-4b6e-b53d-be20fd832b51/

myehtewallet.com
Fake MyEtherWallet
https://urlscan.io/result/e45b56d3-3173-4b96-915b-be9eb6803bf5/