### PR TITLE
top-ethereum.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -341,6 +341,11 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "top-ethereum.com",
+    "ethpromotion.info",
+    "secure.ethgiftnow.com",
+    "btcpromotion.info",
+    "betaclient-rzcoinwaps.cf",
     "ethmore.live",
     "myehtewallet.com",
     "meyehterwallet.com",

--- a/src/config.json
+++ b/src/config.json
@@ -341,7 +341,6 @@
     "anatomia.me"
   ],
   "blacklist": [
-    "top-ethereum.com",
     "ethpromotion.info",
     "secure.ethgiftnow.com",
     "btcpromotion.info",


### PR DESCRIPTION
top-ethereum.com
Trust trading scam site. Promoted via bit.ly/2ucOkPJ+ (redirected from zero-tds.tk)
https://urlscan.io/result/ec2d0434-24f7-46ac-ae3f-8b1933280982
address: 0x61cbEf9dB89E5D397Bdde7Ff9095bEDe35d4eeb5

ethpromotion.info
Trust trading scam site
https://urlscan.io/result/a2d72540-c0cb-4d3e-9f11-c26d0f27a983/
address: 0xbde430F54A63016D8A5F31F243761653728086A2

secure.ethgiftnow.com
Trust trading scam site
https://urlscan.io/result/85a13cd1-9411-4e5d-9319-2228d276884f/
address: 0x3d075995577c0C3c65a466Fee47FfB1bA6a41B02

btcpromotion.info
Trust trading scam site. Bitcoin address: 1FEt2GWxEidTKz1PkFuiccKTMD5AHkdRdq
https://urlscan.io/result/6e552901-cc4f-4267-b42b-358ab99e69f7/

betaclient-rzcoinwaps.cf
Fake Waves client phishing for seed words with POST /sendwaves.php
https://urlscan.io/result/63e559be-ffc3-4bde-8c61-fbad439cbeb1/


----

elon-gift.com
Trust trading scam site
https://urlscan.io/result/a5630c07-f073-46ab-b340-a45a1266b625/

5000eth-giving.online
Trust trading scam site
https://urlscan.io/result/740bcdfc-2db3-4f63-8194-5322b8cc3c1c/
address: 0xfc0fD9C3d1Acc91fEB84fbbDfC1Fa8721CBBcAA2