### PR TITLE
cashaaprivate.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -341,6 +341,11 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "cashaaprivate.com",
+    "signcontract-etherwallet.net",
+    "ether-idex.online",
+    "mediumpost.ga",
+    "ocntoken.com",
     "rootsign.icu",
     "ether4free.com",
     "givefreecoin.com",


### PR DESCRIPTION
cashaaprivate.com
Fake KYC form redirecting users to a fake MyEtherWallet myetherwallet.com.rootsign.icu/signmsg.html via bit.ly/2ukYhLw+
https://urlscan.io/result/62c1eb23-1a08-460d-8484-fdd52c469dda
https://urlscan.io/result/582db137-208a-4e7b-bbd1-4031d35c8824/

signcontract-etherwallet.net
Fake MyEtherWallet redirected via https://bitly.com/2Mo5i5F+
https://urlscan.io/result/afd0e394-9884-4a9a-aede-c5927dff291e/

ether-idex.online
Fake MyEtherWallet phishing for keys with POST /bot/bot.php
https://urlscan.io/result/e4c2eb53-f9ae-4a3e-ba0a-cc85ff7772d1/
https://urlscan.io/result/410ec5cc-4750-42a5-809a-c062a7c3808b/

mediumpost.ga
Trust trading scam site
https://urlscan.io/result/8438b7cf-a565-4000-84fe-71416abc9043/
address: 0xff8e6af02d41a576a0c82f7835535193e1a6bccc

ocntoken.com
Fake Odyssey airdrop phishing for private keys
https://urlscan.io/result/db6eac0d-c67b-4a1f-865a-10d099e2dede/
https://urlscan.io/result/1b28f5e0-146f-45ba-80fd-5104b5d206b5/
https://urlscan.io/result/8d16000a-b580-4f76-81d8-4e35ab50cb2f/