### PR TITLE
refundcontract-etherwallet.net + idexr.market

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -343,6 +343,8 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "refundcontract-etherwallet.net",
+    "idexr.market",
     "autodiscover.mvetherwallet.ml",
     "etherwallet.ethsign.icu",
     "mvetherwallet.ml",


### PR DESCRIPTION
refundcontract-etherwallet.net
Fake MyEtherWallet. Users redirected over email via https://bitly.com/2L3Ua1a+
https://urlscan.io/result/6b13d39e-005e-40bd-ae29-b45bfc88573b/


idexr.market
Fake Idex market phishing for keys
https://urlscan.io/result/e4951908-3628-491f-98d0-961ebbb422dc/
https://urlscan.io/result/b2db3889-9b3e-48b3-8226-38c284c4ff8d/