### PR TITLE
index-markett-network.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -343,6 +343,9 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "index-markett-network.com",
+    "idexmarkketslogin.com",
+    "ideeweb1.com",
     "myetherwalle.net",
     "myetherwallet-send.top",
     "myetherwallet.com.verify.apisign.me",


### PR DESCRIPTION
index-markett-network.com
Fake Idex market redirecting to idexmarkketslogin.com
https://urlscan.io/result/00b77930-ebd4-4685-924a-69372d0624bc

idexmarkketslogin.com
Fake Idex market phishing for private keys (iframing ideeweb1.com)
https://urlscan.io/result/064098d1-05c2-40b1-96f1-d2312fa5edba/

ideeweb1.com
Fake Idex market phishing for private keys
https://urlscan.io/result/d1876449-32c8-49a5-92bb-e8969f31fac6/
https://urlscan.io/result/35ce3c7e-04f5-4cd5-ba36-7eabd96c01e5/