### PR TITLE
ether-event.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -344,7 +344,6 @@
   ],
   "blacklist": [
     "ether-event.com",
-    "top-ethereum.com",
     "w-eos.com",
     "idexmarket.me",
     "johnmcafee.ethgivings.net",

--- a/src/config.json
+++ b/src/config.json
@@ -343,6 +343,9 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "ether-event.com",
+    "top-ethereum.com",
+    "w-eos.com",
     "idexmarket.me",
     "johnmcafee.ethgivings.net",
     "ethpays99.top",


### PR DESCRIPTION
ether-event.com
Trust trading scam site
https://urlscan.io/result/49acbd6f-d2fe-4dc2-bab6-1c7d07440aa7/
address: 0x8729Abb00a517bBA3d615ed13E7C9C55aB311D41

top-ethereum.com
Trust trading scam site
https://urlscan.io/result/d79c68ea-90fa-41d7-b33d-97bd9df45d0d/
address: 0x9844F5C5F9aA7146a74ffC7b9227742acFA71dEa

w-eos.com
Fake EOS web wallet
https://urlscan.io/result/925c99e3-2f68-4926-b28f-bb90f2267934
address: 0x5Ef4EC670246Af663F64aFf354a30Ca54B43DAFD