### PR TITLE
blvonance.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -343,6 +343,18 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "blvonance.com",
+    "airdrop-event.info",
+    "currency.promo",
+    "czgive.site",
+    "verify.bonuseth.info",
+    "bonuseth.info",
+    "get.bigethgift.com",
+    "bigethgift.com",
+    "ethsafe.info",
+    "ethnewpromoaway.com",
+    "btcgiveaway.org",
+    "btcpromogivegroup.com",
     "metamaskpro.io",
     "idexchange.pro",
     "mye1herwallet.co",


### PR DESCRIPTION
blvonance.com
Reported as a fake Binance phishing for logins
https://urlscan.io/result/f375909a-da1b-4a76-8629-2d0f86b4b63a/


airdrop-event.info
Trust trading scam site
https://urlscan.io/result/e02449e4-1459-4290-96df-0af1f6cfc70c/
address: 0xb0d46Eb7e6Aac501BcCE47F05aCe37527B8B329a

currency.promo
Trust trading scam site
https://urlscan.io/result/1e64b341-7609-46fd-9d3e-cd5d6370c9b0/
address: 0xD8D0506ED425364EE126819E8b73Fc3160C39D49

czgive.site
Trust trading scam site
https://urlscan.io/result/79ab4bcf-c270-4453-b1e3-911c0b35cb77/
address: 0x44610ceE8C56D34e80468243065e3a319250e32a

verify.bonuseth.info
Trust trading scam site
https://urlscan.io/result/23a94987-48a7-4972-a225-7aee40cf8413/
address: 0x429D386Adc915adE21593609B1b89b976B2F2af4

get.bigethgift.com
Trust trading scam site
https://urlscan.io/result/66a19ec6-3312-4454-9d2c-d52cb5357770/
address: 0xC71943c6411DD88aAD1E5b69Da551F16596d73cC

bigethgift.com
Trust trading scam site
https://urlscan.io/result/36bd24bd-ac7e-496b-9123-f09700735971/
address: 0xC71943c6411DD88aAD1E5b69Da551F16596d73cC

ethsafe.info
Trust trading scam site
https://urlscan.io/result/90b2395f-7370-4728-8973-7081178cae4f/
address: 0x1cBc864EA74e0f23F103dF8623Ba56a01b1eDa59

ethnewpromoaway.com
Trust trading scam site
https://urlscan.io/result/3eee9724-8506-4f02-94fe-7ecba13cdf39/
address: 0xB75Be435Ee985Ab09f99299A90b03937B33855c6

btcgiveaway.org
Trust trading scam site. Bitcoin address: 17mKwVQHq7YXk9bwocPjnnypbzPEWTnN2o
https://urlscan.io/result/64ea113d-86e9-448e-b26c-df0c9ae90f2c/

btcpromogivegroup.com
Trust trading scam site. Bitcoin address: 3LfmhNmuE3vXuruFG9nHwT9heMYvceahhQ
https://urlscan.io/result/e415673c-24a5-4fe9-ad67-f971a4695aff/