### PR TITLE
www-bitfinex.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -343,6 +343,7 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "www-bitfinex.com",
     "blvonance.com",
     "airdrop-event.info",
     "currency.promo",


### PR DESCRIPTION
www-bitfinex.com
Fake Bitfinex phishing for private keys
https://urlscan.io/result/8ac56fd4-b00c-4369-8d0e-61627e1c06f2/
https://twitter.com/sniko_/status/1020078544922214400