### PR TITLE
mcafee.promo + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -343,6 +343,14 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "mcafee.promo",
+    "eth60.top",
+    "getfree-eth.org",
+    "vaxx.co",
+    "cryptoether.info",
+    "coincapitals.org",
+    "bonancre.com",
+    "blvonance.com",
     "login.blockchaim.co",
     "blockchaim.co",
     "transactionlist.info",

--- a/src/config.json
+++ b/src/config.json
@@ -350,7 +350,6 @@
     "cryptoether.info",
     "coincapitals.org",
     "bonancre.com",
-    "blvonance.com",
     "login.blockchaim.co",
     "blockchaim.co",
     "transactionlist.info",


### PR DESCRIPTION
mcafee.promo
Trust trading scam site
https://urlscan.io/result/53a9bb6f-cc47-44d6-b5ae-a473ec5bc93b/
address: 0xD8D0506ED425364EE126819E8b73Fc3160C39D49

eth60.top
Trust trading scam site
https://urlscan.io/result/cf408e48-82d3-4bc8-a77c-b6aaade8d155
address: 0xab7ec7596fc05bc55afc07008cc06c1193ed6f9a

getfree-eth.org
Trust trading scam site
https://urlscan.io/result/7b0125bd-957d-4eb5-a0f9-f7860340e575/
address: 0x2B1C266E2a39a7a30aED472Fad47d6b6AB953F7e

vaxx.co
Trust trading scam site
https://urlscan.io/result/a62acc3a-d00f-47ed-8915-697e8804c243/
address: 0xD8D0506ED425364EE126819E8b73Fc3160C39D49

cryptoether.info
Trust trading scam site
https://urlscan.io/result/005d3c60-0798-428d-92b1-0225f4c271c3/
address: 0xA4F06F1afB7B8589D1F4609257e5010C30eD3D2b

coincapitals.org
Trust trading scam site
https://urlscan.io/result/e3dc8448-673e-4b41-bb45-df4f45211edc/
address: 0x68AaCF41FA22ecD5ca0BB102dA46b0f503E2E168

bonancre.com
Fake Binance phishing for logins
https://urlscan.io/result/8e113764-5e25-4563-82f1-4654589e5ca5/
https://urlscan.io/result/488e664d-4488-42ba-8162-e8e16d5bd67c/

blvonance.com
Fake Binance phishing for logins
https://urlscan.io/result/cea433a4-3c13-4f31-a692-453b491ef5d7/
https://urlscan.io/result/2e2e6bd0-4bbe-4ccc-90bc-257c09d4f5c2/