### PR TITLE
coinssafe.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -343,6 +343,8 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "coinssafe.org",
+    "idex.group",
     "mcafee.promo",
     "eth60.top",
     "getfree-eth.org",


### PR DESCRIPTION
coinssafe.org
Trust trading scam site
https://urlscan.io/result/df104578-45c5-4980-8471-4a328f5c875a/
address: 0x68AaCF41FA22ecD5ca0BB102dA46b0f503E2E168

idex.group
Fake Idex domain
https://urlscan.io/result/088fcd3d-2019-4949-ae7e-4cad6703c187/