### PR TITLE
getethernow.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -344,6 +344,12 @@
     "anatomia.me"
   ],
   "blacklist": [
+    "getethernow.org",
+    "binance-acess.com",
+    "officialairdrop.com",
+    "eth-event.com",
+    "ethclose.info",
+    "freecoindrop.com",
     "myeetherwallet.ga",
     "myehtlerwallet.com",
     "myetherrwallet.ga",


### PR DESCRIPTION
getethernow.org
Trust trading scam site
https://urlscan.io/result/eec0ccd1-115e-4da6-b008-3ba28a0c789a/
address: 0x7aA266963882F13eB0Ab5920E16aFeF2F26cDa8f

officialairdrop.com
Trust trading scam site
https://urlscan.io/result/b3b488c7-01e2-4dde-abf6-5d3e2dcf09dd/
https://urlscan.io/result/ef945c75-0598-48e5-8fd9-3b974ef0643f/
address: 0x451ba6133b64829398fe074ae649a7998acb16f3

eth-event.com
Trust trading scam site
https://urlscan.io/result/22bab091-fa4d-4ee0-be17-e2fa83240360/
address: 0x8729Abb00a517bBA3d615ed13E7C9C55aB311D41

ethclose.info
Trust trading scam site
https://urlscan.io/result/32ed5540-a90b-430f-8ec0-bad957bfb940/
address: 0x74a01390635D8D4016827fA3AfB1A0f6c33eD8d8

freecoindrop.com
Trust trading scam site
https://urlscan.io/result/09fecd3b-2b74-4399-9993-c112e66a585f
address: 0x82603fEc3241b319aC1a0470f2C08BD90461A355

binance-acess.com
Fake Binance phishing for logins - https://twitter.com/jmoconnor415/status/1020784200213938177


---

cryptoether.info
Trust trading scam site
https://urlscan.io/result/d0b960d4-4ef1-4c0f-871d-c9537f2b8c0c/
address: 0xA4F06F1afB7B8589D1F4609257e5010C30eD3D2b