### PR TITLE
Removed wavesplatform.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -348,7 +348,6 @@
     "dailycurrency.ml",
     "ethgivewaypromo.info",
     "xn--etherem-y24c.com",
-    "wavesplatform.com",
     "stellar-w.com",
     "bitfinex.im",
     "idex-markt-roosen-gmbh.com",


### PR DESCRIPTION
Removed wavesplatform.com from the list. DNS records were reverted and there is no phishing now.