### PR TITLE
giveaway-binance.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -346,6 +346,16 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "giveaway-binance.com",
+    "myetherwallet-coinin.top",
+    "medium-promo.top",
+    "ethereumclaim.net",
+    "ethescan.info",
+    "verify.getbigeth.com",
+    "getbigeth.com",
+    "binance.bnb-token.sale",
+    "bnb-token.sale",
+    "okexgiveaway.com",
     "hitbtc.stream",
     "promohitbtc.website",
     "hitbtc.ltd",


### PR DESCRIPTION
giveaway-binance.com
Trust trading scam site
https://urlscan.io/result/7094b937-c77d-41f6-b076-028c1c5c290f/
https://urlscan.io/result/46d0c737-a73f-4560-a5df-f6dbdb957355/
address: 0x6B0A6C142905ce6c1db7276d8878a3e7846675d9

ethereumclaim.net
Trust trading scam site
https://urlscan.io/result/e7326ff1-71b2-47e0-a003-cef4eecf3a57/
address: 0xf19c11540E012227466a59cadE5F7fCf8dC1d1D1

ethescan.info
Trust trading scam site
https://urlscan.io/result/2444b8be-2094-44e1-ab25-82db15495e65/
address: 0x68e45B998240d77FbE30BE84bd8397a51F0EF962

verify.getbigeth.com
Trust trading scam site - directed via bitly.com/2mFoh0d+
https://urlscan.io/result/2a5fe3a3-eb98-4d96-a29b-981d708f5076/
address: 0x215e7E7eDEfdA37EB39df17B8b91DA9a60d85530

getbigeth.com
Trust trading scam site
https://urlscan.io/result/e2c3d46d-3ba9-4951-9b49-8c0905208b29/
address: 0x215e7E7eDEfdA37EB39df17B8b91DA9a60d85530

okexgiveaway.com
Trust trading scam site
https://urlscan.io/result/0cc1cd31-567a-415a-bf16-a6d38ba3de83/
address: 0x13B56F970b8982b1b4A76982876086ecAd4756dA

medium-promo.top
Trust trading scam site - linking to verify.medium-promo.top/payment.php (currently down)
https://urlscan.io/result/10cb28ad-865e-4fbb-b732-ccc4e2978c7f/
https://urlscan.io/result/1912d56a-6b7e-4704-8c47-86a5cd449218/
https://urlscan.io/result/d7ac3767-5a25-438c-bd23-a59d94c9f7dd/

myetherwallet-coinin.top
Suspicious MyEtherWallet domain
https://urlscan.io/result/d29eb1e2-ccc1-4e38-a996-98a1403a6071/

binance.bnb-token.sale
Fake Binance token sale site
https://urlscan.io/result/50adb464-71f5-4d28-9d3c-c844662bf1a2/
https://urlscan.io/result/265beb12-edda-4ee8-8b2e-04eb87ebab8e/
address: 0x3Fc7cA472D19F24F544fCd79bcA992019650c1Eb