### PR TITLE
xn--myetherwale-jb9e.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -346,6 +346,7 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "xn--myetherwale-jb9e.com",
     "promo.etherpay.site",
     "etherpay.site",
     "bnb-token.org",


### PR DESCRIPTION
xn--myetherwale-jb9e.com
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/b6397cb5-4b3f-40a9-9f77-18648f344011/