### PR TITLE
claimprize.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -354,7 +354,7 @@
     "api7.icu",
     "api8.icu",
     "api9.icu",
-    "api10,uicu",
+    "api10.uicu",
     "myetherwallet.com.api5.icu",
     "api5.icu",
     "nuetheriumllet.com",

--- a/src/config.json
+++ b/src/config.json
@@ -347,6 +347,14 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "claimprize.org",
+    "eosgas.net",
+    "myetherwallet.com.api6.icu",
+    "api6.icu",
+    "api7.icu",
+    "api8.icu",
+    "api9.icu",
+    "api10,uicu",
     "myetherwallet.com.api5.icu",
     "api5.icu",
     "nuetheriumllet.com",


### PR DESCRIPTION
claimprize.org
Trust trading scam site
https://urlscan.io/result/5e4f3c33-1ca8-450b-bc00-76ac1909bfd9/
address: 0xaE34b154ADA796cFEbE8a60D265d266eF809Fb05

eosgas.net
Fake EOS KYC form directing users to a fake MyEtherWallet myetherwallet.com.api6.icu/signmsg.html via bit.ly/2LrOL4a+
https://urlscan.io/result/4cf40f3b-6ce0-4180-8b57-59d7708138cf/
https://urlscan.io/result/fdc2c7c0-6e1f-4531-bd33-d63381338239/

myetherwallet.com.api6.icu
Fake MyEtherWallet phishing for keys