### PR TITLE
idex-market.biz.pl + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -347,6 +347,10 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "getethereumforfree.com",
+    "idex-market.biz.pl",
+    "medium-hitbtc.tumblr.com",
+    "ethereum-return.com",
     "btc-binance.com",
     "descentx.com",
     "eth-away.com",


### PR DESCRIPTION
idex-market.biz.pl
Fake Idex market phishing for keys
https://urlscan.io/result/203a5dfa-5488-4956-b219-3a0dc039b917
https://urlscan.io/result/8b2e6516-ffcd-481b-a7b8-dcaa29d037f3

getethereumforfree.com
Trust trading scam site
https://urlscan.io/result/80a28520-7403-442a-b235-f5467e12e626/
address: 0xC7566BA63f39bA75B56EAdc0328F9A76Dbd1ADf3

medium-hitbtc.tumblr.com
Trust trading scam site linking to http://ethereum-return.com/hitbtc/payment.php
https://urlscan.io/result/5b63be29-8112-4707-b451-5f96bf72b1df/
address: 0x8C500BD17174e8604ff9aD3399bD13af245EeF52

ethereum-return.com
Trust trading scam site
https://urlscan.io/result/491ef95c-935f-4541-8a1e-24d207bfea45/
https://urlscan.io/result/f47b89a0-f631-43be-8ed6-885234acf4de/
address: 0x8C500BD17174e8604ff9aD3399bD13af245EeF52