### PR TITLE
ethcryptocomp.cx + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -347,6 +347,15 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "ethcryptocomp.cx",
+    "ethpromoui.com",
+    "ethpromonow.com",
+    "eth-give-away-promo.com",
+    "eth-promo-give-away.com",
+    "eth-pronogive.com",
+    "eth-promosgivex.com",
+    "ethpramengive.com",
+    "et-gi.net",
     "getethereumforfree.com",
     "idex-market.biz.pl",
     "medium-hitbtc.tumblr.com",


### PR DESCRIPTION
ethcryptocomp.cx
Trust trading scam site
https://urlscan.io/result/511ccdbb-7838-4b78-9ab8-ee5d87d4b97d/
address: 0xBe3E5cBa8cb230678a7bF5ECdaE37783C8dF89bd

ethpromoui.com
Trust trading scam site
https://urlscan.io/result/a40eeb63-d9c9-4a56-9681-70e09a2fc4cb/
address: 0xBe3E5cBa8cb230678a7bF5ECdaE37783C8dF89bd

ethpromonow.com
Trust trading scam site
https://urlscan.io/result/88c0d14b-6c6c-43c1-a00c-45d4860e273b/
address: 0x8e8f4161c9c3D2D8857230A048DF1Fc6F4326948

eth-give-away-promo.com
Trust trading scam site
https://urlscan.io/result/eb7cd6a8-9530-46e7-a58d-85246f0d0352/
address: 0x14B7716c688875Bcf54D5Ff47cAd4FcA6B3834fA

eth-promo-give-away.com
Trust trading scam site
https://urlscan.io/result/5a1d2736-2b46-4465-9ed1-5aef0d3a3938/
address: 0x14B7716c688875Bcf54D5Ff47cAd4FcA6B3834fA

eth-pronogive.com
Trust trading scam site
https://urlscan.io/result/dfed76bf-1baa-496d-95ff-cedec5eb9786/
address: 0xB75Be435Ee985Ab09f99299A90b03937B33855c6

eth-promosgivex.com
Trust trading scam site
https://urlscan.io/result/dc8fa22e-53fd-459c-8dbf-4f08cdd66977/
address: 0xf276C0aD29363689792702986667D562a3CB7C04

ethpramengive.com
Trust trading scam site
https://urlscan.io/result/ddddad29-639b-42b1-a27c-b88d4086790e/
address: 0x70f36e78224389C462dd0FC7Fe1627A2928031c7

et-gi.net
Trust trading scam site
https://urlscan.io/result/2d2fe5f6-ded3-4c92-95b3-24248eee9264/
address: 0x70f36e78224389C462dd0FC7Fe1627A2928031c7