### PR TITLE
mycyrptto.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -347,6 +347,7 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "mycyrptto.com",
     "blgem.blogspot.com",
     "airdrop.delivery",
     "giveawayofficial.info",


### PR DESCRIPTION
mycyrptto.com 
Fake MyCrypto phishing for keys
https://urlscan.io/result/2ce89e6b-f899-49e9-9b2a-385e1c948046