### PR TITLE
eth-giveaway.space + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -347,6 +347,16 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "eth-giveaway.space",
+    "claimprize.xyz",
+    "ethereum-transfer.com",
+    "ethfast.top",
+    "medium-promo.com",
+    "betaclient-wbtcgwap.cf",
+    "ethbonus-binance.com",
+    "fast.getether.xyz",
+    "getether.xyz",
+    "btcbonus-binance.com",
     "my-cry-pto.com",
     "myerthewallet.com",
     "myerthewallet.hosstinger.info",


### PR DESCRIPTION
eth-giveaway.space
Trust trading scam site
https://urlscan.io/result/9d072597-6866-48aa-8cc1-4b8a400349ff/
https://urlscan.io/result/42c9c103-2d77-43ac-bc91-a3e599dbe82a/
address: 0x7f7Be29BD339a38FAcE53918dC8cDBF6a06bC7e7

claimprize.xyz
Trust trading scam site
https://urlscan.io/result/8c1e0c1a-8050-42ed-976b-042d0b684121/
https://urlscan.io/result/704404fd-dff5-43fb-ba27-887272fb933e/
address: 0xA2922aE30Ff11c0fEf6E250b3892A451BDd533f1

ethereum-transfer.com
Trust trading scam site
https://urlscan.io/result/150fe500-8c51-42f7-baf2-60331a08137d/
address: 0xbA32570e4c276C74e6DC67BFa6F82253228BD1cD

ethfast.top
Trust trading scam site
https://urlscan.io/result/b4522b1b-c7cf-454c-bb2e-552a1a9276bd/
address: 0xa0a51563Ca933ECDf030f84425dEF24ab8cC6733

medium-promo.com
Trust trading scam site. Directing users to ethereum-transfer.com
https://urlscan.io/result/0196dda5-b119-4890-ad9d-ff0c8402aac9/
address: 0xbA32570e4c276C74e6DC67BFa6F82253228BD1cD

ethbonus-binance.com
Trust trading scam site.
https://urlscan.io/result/3d7831a4-479e-4540-8659-98da86e6109e/
address: 0xe62adc2A7F08db6230e627bb5Faf4F68bc13f88a

fast.getether.xyz
Trust trading scam site
https://urlscan.io/result/01d1e862-048f-44d8-a4ed-d331d3df7dff/
address: 0x5a504295ab80ccA776afDc6DB4f493e7c6Fa8211

getether.xyz
Trust trading scam site
https://urlscan.io/result/48e6614c-f6b0-4fb3-96ce-167f80df5b61/
address: 0x5a504295ab80ccA776afDc6DB4f493e7c6Fa8211

btcbonus-binance.com
Trust trading scam site. Bitcoin address: 12z4fAETZTXehv8Y2v3GcD7jjdgG38Ppor
https://urlscan.io/result/a59e8752-5db1-4c0d-9635-abdb9b5f2397/

betaclient-wbtcgwap.cf
Fake Waves client phishing for secrets with POST /sendwaves.php
https://urlscan.io/result/128edbb2-65cf-4767-aa2d-299bd1ffac0f/