### PR TITLE
blovrnance.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -347,6 +347,16 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "blovrnance.com",
+    "bingmancol.com",
+    "bnbnews.org",
+    "btcdrop.top",
+    "johnmcafee.promo",
+    "safe.getbesteth.com",
+    "getbesteth.com",
+    "mediumblogsot.top",
+    "biflnex.com",
+    "blfinex.com",
     "binance-app.com",
     "binance-club.com",
     "binance-coins.com",


### PR DESCRIPTION
blovrnance.com
Fake Binance phishing for logins
https://urlscan.io/result/aeb6c222-cece-41c5-b6e4-03373d6167f7/
https://urlscan.io/result/71bb9c81-aea6-408a-bc50-0e3cc4730c8a/

bingmancol.com
Used in Google Ads (UK) to redirect to blovrnance.com - Fake Binance
https://urlscan.io/result/46cc98a3-a7eb-40c3-bfd2-e5e80475e7b8/

biflnex.com
Fake Bitfinex phishing for logins
https://urlscan.io/result/7f0a3439-ff10-475f-b2a7-ad417f64409c/

blfinex.com
Suspicious Bitfinex domain
https://urlscan.io/result/048eec5c-c0ab-494a-8e33-bb5c77193b78/

bnbnews.org
Trust trading scam site
https://urlscan.io/result/c284190c-064c-4430-a9b5-90784ca76e61/
address: 0x797Ab7505608A943A4f00E275aD6F2a514b8e038

btcdrop.top
Trust trading scam site. Bitcoin address: 187R5KKL5oT2hUrdGH3yJv8H36N3BSnsii
https://urlscan.io/result/e291cadb-e83f-48b8-8b51-dde16474278d/

johnmcafee.promo
Trust trading scam site
https://urlscan.io/result/8344f386-3c04-4c1a-b80f-c41a8723bb85/
address: 0xCe9e24Dffdb3DC08EFe33AD3DB858576C3f27D5d

safe.getbesteth.com
Trust trading scam site
https://urlscan.io/result/857d2e0d-d11e-4c3c-8eb9-4f160b7ed828/
address: 0xda5f6405808111De82084E6804aDF7153eDaA8eD

getbesteth.com
Trust trading scam site
https://urlscan.io/result/3122d3e4-5f28-4f8a-b00d-4a67a0a5c423/
address: 0xda5f6405808111De82084E6804aDF7153eDaA8eD

mediumblogsot.top
Trust trading scam site
https://urlscan.io/result/e462a5da-d919-4fb4-85ce-3532c47527ce/
address: 0xff8e6af02d41a576a0c82f7835535193e1a6bccc