### PR TITLE
grabeth.cf + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -347,6 +347,11 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "grabeth.cf",
+    "eos-airdrop.info",
+    "ether-claim.com",
+    "myethervallet.000webhostapp.com",
+    "myetheruvvalet.com",
     "mail.mynetherwallet.site",
     "mycryrptto.com",
     "myetherwallet.com.api7.icu",


### PR DESCRIPTION
grabeth.cf
Trust trading scam site
https://urlscan.io/result/fb58aa6e-cc11-462f-a76a-9c85979b55e9/
address: 0x827216bd50d13B3e1daC8686e85f8B6B1bf2e856

ether-claim.com
Trust trading scam site
https://urlscan.io/result/acccb957-ce0e-4ab7-a142-042494e47ea5/
address: 0x2dfc601dB0C0b5EEfc302249acDf936Dce83cFb3

eos-airdrop.info
Fake airdrop linking users to myetheruvvalet.com. Reported address: 0x81fbb23ce259d141339e49ece91599ed97cc8b49
https://urlscan.io/result/6ad84b0a-27ac-4221-9406-ca7d5e086946/

myethervallet.000webhostapp.com
Fake MyEtherWallet stealing keys
https://urlscan.io/result/8a2baecb-d55a-4935-b123-889d594dc6b1/

myetheruvvalet.com
Fake MyEtherWallet. Reported address: 0x81fbb23ce259d141339e49ece91599ed97cc8b49
https://urlscan.io/result/c1216b0d-be3e-474f-9f5c-dff5b4ba9424/