### PR TITLE
giveaway-promo.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -347,6 +347,16 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "giveaway-promo.net",
+    "eth-pro.co.nf",
+    "blokckchian.com",
+    "coinbaselogin.com.ru",
+    "hub.xn--myterwallet-3qb9087g.com",
+    "binconarnce.com",
+    "binconamce.com",
+    "hitbtc.mobi",
+    "kraken-portal.com",
+    "kraken-validation.com",
     "grabeth.cf",
     "eos-airdrop.info",
     "ether-claim.com",


### PR DESCRIPTION
giveaway-promo.net
Trust trading scam site
https://urlscan.io/result/685f2aa3-c846-44a0-82a3-95f1a93b8a73
https://urlscan.io/result/476016ac-a26e-496e-b963-9b5ec5382ace
address: 0xbc345238F87abE2978456a3F1c04483e0B63932B

eth-pro.co.nf
Trust trading scam site
https://urlscan.io/result/58461b58-9af8-489e-8e55-cb86e943805e/
address: 0x3a0086083aa90c4692507Bb82Dc14B8754ebC663

blokckchian.com
Fake Blockchain wallet
https://urlscan.io/result/c4d4e90c-cd17-4ec4-86cf-b4c0f4805012/
https://urlscan.io/result/1cfdaf98-afe5-4973-97f1-dc733c325911

coinbaselogin.com.ru
Suspicious coinbase domain
https://urlscan.io/result/0e8be1ac-e31c-4237-b208-3c5c27580691/

binconarnce.com
Fake Binance phishing for logins
https://urlscan.io/result/148612a3-1aa4-4f55-8626-c901b88b4e7d/
https://urlscan.io/result/0dd1917e-15cd-4a7a-bc9d-6fe065053110/

binconamce.com
Fake Binance phishing for logins
https://urlscan.io/result/065995d8-6e45-4789-8f68-48c5fe872e51/
https://urlscan.io/result/cda6a1f2-d290-4cbc-a827-dd9337759da9/

hitbtc.mobi
Fake HitBtc phishing for logins
https://urlscan.io/result/21e81826-0637-4d0b-ae7f-b8c26357ff4e/

kraken-validation.com
Fake Kraken phishing for logins
https://urlscan.io/result/e7186f61-ec98-48e7-8245-def9d330ed1b/

kraken-portal.com
Fake Kraken phishing for logins
https://urlscan.io/result/54549d1d-2fab-427a-870c-f031b40fc3c0/

---

xn--myterwallet-3qb9087g.com
Fake MyEtherWallet
https://urlscan.io/result/0b1488e7-68d9-4573-8260-90b6fa96b250/
https://urlscan.io/result/c39d0af2-9d76-4242-9ef6-277173392c4b/
https://urlscan.io/result/783ca1a3-9758-4ef5-9e46-9168eccb9562/