### PR TITLE
kraken-ixz.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -348,6 +348,9 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "kraken-ixz.com",
+    "kraken-check.com",
+    "airdrops.delivery",
     "buzovacoin.io",
     "buz-coin.io",
     "buzcoinio.com",


### PR DESCRIPTION
kraken-ixz.com
Fake Kraken phishing for logins
https://urlscan.io/result/f3e9370a-661c-40c7-9a19-56ddbe04befa/

kraken-check.com
Fake Kraken phishing for logins
https://urlscan.io/result/1c0a2bae-af8b-4c4f-b78b-1b97cd80e2e0/

airdrops.delivery
Trust trading scam site
https://urlscan.io/result/3ebe277c-a5b0-42db-bb96-4d709709be0c/
address: 0xCe9e24Dffdb3DC08EFe33AD3DB858576C3f27D5d