### PR TITLE
mfoundation.cf

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -348,6 +348,7 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "mfoundation.cf",
     "myetheatrwallet.com", 
     "myethertawallet.com", 
     "myetherwallet.com.api12.icu",


### PR DESCRIPTION
ethereu.mfoundation.cf
Trust trading scam site
https://urlscan.io/result/0dc3e861-cafc-458c-9306-92e51a41cdf6
https://urlscan.io/result/44d64698-c52c-4f1f-b516-5d0bd4ed0036/
address: 0xb5f3A62E8f0468efEc0A65b81c09E8b46D1F9158
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2205