### PR TITLE
medeum-airdrop-news.com + ethereum-transfer.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -348,6 +348,8 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "medeum-airdrop-news.com",
+    "ethereum-transfer.net",
     "safeclaim.info",
     "tesla-giveaway.getforge.io",
     "eth.getforge.io",


### PR DESCRIPTION
medeum-airdrop-news.com
Trust trading scam site - linking users to ethereum-transfer.net
https://urlscan.io/result/f163756e-08db-46b1-8528-bcb749d4e6e5/
address: 0x43FA247764BfBe1Beba49111e4ed215524f02c41

ethereum-transfer.net
Trust trading scam site
https://urlscan.io/result/d84279a4-9e1e-414f-a5c3-9752f89c88a3/
address: 0x43FA247764BfBe1Beba49111e4ed215524f02c41