### PR TITLE
binancepromos.typeform.com/to/ZRE0mt

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -350,6 +350,7 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "binancepromos.typeform.com",
     "bliovnarnce.com",
     "meyhferwallet.com",
     "ethereum-giveaway.tech",


### PR DESCRIPTION
binancepromos.typeform.com
Form is removed now, but see https://github.com/MetaMask/eth-phishing-detect/issues/2228
https://urlscan.io/result/a8f5c558-9283-42a9-8c0c-95cb0ca99b27