### PR TITLE
xn--omiseg-ul8b.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -350,6 +350,10 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "xn--omiseg-ul8b.com",
+    "xn--myethrwalle-6qb4278g.com",
+    "myethervvallet.net",
+    "myehterwelliet.com",
     "mail.myewtherwallet.pw",
     "myetherwallet.com.ip11.icu",
     "ip11.icu",

--- a/src/config.json
+++ b/src/config.json
@@ -352,7 +352,6 @@
   "blacklist": [
     "xn--omiseg-ul8b.com",
     "xn--myethrwalle-6qb4278g.com",
-    "myethervvallet.net",
     "myehterwelliet.com",
     "mail.myewtherwallet.pw",
     "myetherwallet.com.ip11.icu",


### PR DESCRIPTION
xn--omiseg-ul8b.com
Fake OmiseGo publication linking to a fake MyEtherWallet xn--myethrwalle-6qb4278g.com/#contracts
https://urlscan.io/result/2b86d579-3cac-44dd-8147-e52e9e863e8d
https://urlscan.io/result/4c6e80a7-ffce-4dc7-b707-9104669936fd

xn--myethrwalle-6qb4278g.com
Fake MyEtherWallet - IDN homograph attack - phishing for keys
https://urlscan.io/result/c3d99bd1-d309-4c42-a68a-d0fe0bf449d8

myethervvallet.net
Suspicious MyEtherWallet domain
https://urlscan.io/result/2d8b4d34-10da-4381-9cd0-6bb6617dcf9b/

myehterwelliet.com
Fake MyEtherWallet phishing for keys
https://urlscan.io/result/381b05a5-97c5-4545-9fd6-236bb65876a1/