### PR TITLE
ethtw.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -353,6 +353,17 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "ethtw.info",
+    "ethertake.org",
+    "ethereum-giveaway.czweb.org",
+    "ethshift.website",
+    "gathereth.com",
+    "hugedrop.eu",
+    "ethertake.org",
+    "ethpromo-give.info",
+    "elonmusk.racing",
+    "hitbtc.cc",
+    "hitb-tco.com",
     "myethervvallet.pw",
     "myetherwallet.co.za",
     "myetherwallett.fhapp.xyz",

--- a/src/config.json
+++ b/src/config.json
@@ -359,7 +359,6 @@
     "ethshift.website",
     "gathereth.com",
     "hugedrop.eu",
-    "ethertake.org",
     "ethpromo-give.info",
     "elonmusk.racing",
     "hitbtc.cc",


### PR DESCRIPTION
ethtw.info
Trust trading scam site
https://urlscan.io/result/35bb01ee-d99e-4a0a-922a-f77987b8aee9/
address: 0x813ca840322E3795702300bB3eBAF7aEE9aF9536
address: 0x26A022e559eC404C142eC873F1cde696ac97915B

ethertake.org
Trust trading scam site
https://urlscan.io/result/eb9b855b-2b91-4e25-962c-5bc03a9e1d29/
address: 0xf6fc6941643384Ccd56ad8f084beEB338B77128A

ethereum-giveaway.czweb.org
Trust trading scam site
https://urlscan.io/result/78f1c6f1-17d9-4c3c-8b86-c38f24ae2685/
address: 0x31fca2139b07c2a97287de51f0219a34f4181710

ethshift.website
Trust trading scam site
https://urlscan.io/result/fa41a13b-3cf6-4543-a8a6-75723e81c545/
address: 0xA9A53dCD4C6BC74Ae56cC52CE48390D85BE98c80

gathereth.com
Trust trading scam site
https://urlscan.io/result/3d3f5052-3bcb-44e6-87cc-341794b4e5bc/
address: 0x982F12f899A37759A3426165eCE2224df21bE241

hugedrop.eu
Trust trading scam site
https://urlscan.io/result/aa7dfab6-7918-4568-9a3e-b34cd31b9b31/
address: 0x273730ff234b4Bd238cE9751BEDdA309A946D6A6

ethpromo-give.info
Trust trading scam site
https://urlscan.io/result/62bc8161-4dff-450b-beb2-346348e7b1c6/
address: 0x6bed8445ADa86419243f95A5BB14BC599D62B295

elonmusk.racing
Trust trading scam site. Linking users to giveawaypromo.byethost14.com
https://urlscan.io/result/82d8fa79-3122-47a2-95d7-86e63ef28e30/
address: 0x6a9c2ec4f4888d7338fc1b28584aaafeb01e6db3

hitbtc.cc
Fake HitBTC phishing for logins with POST /_loginSend.php
https://urlscan.io/result/afb8ed82-de23-467f-b406-9eeacd17095e/
https://urlscan.io/result/576df6d7-606c-4850-b158-3631560a075d/

hitb-tco.com
Fake HitBTC phishing for logins
https://urlscan.io/result/321f21ae-5050-4b5f-ad3a-7ad03ef842a4/

---

airdrop.credit
Trust trading scam site
https://urlscan.io/result/be864c09-6a93-4aed-b3d7-3be738eec01c/
addresS: 0x3Ea41dc576Ccf70706Aeece363833A26D9529C38