### PR TITLE
idexmark.online + eth-gifting.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -353,6 +353,8 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "idexmark.online",
+    "eth-gifting.com",
     "ethereum-bonus.biz",
     "bigcryptogift.borec.cz",
     "website-events.website",


### PR DESCRIPTION
idexmark.online
Fake MyEtherWallet phishing for keys with POST /bot/bot.php
https://urlscan.io/result/5c785bb5-2fe3-4946-bf0a-b64585b7c414/
https://urlscan.io/result/5652f6ab-c39f-4755-a281-5c49911a4a89/

eth-gifting.com
Trust trading scam site
https://urlscan.io/result/13b34ee3-3fbb-4d81-ba43-dbcf299f029b/
address: 0x5d0Dbbf6460Ba020A5ab06006Ea447ffC7612b2d