### PR TITLE
google.com.tokensale.ws

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -356,6 +356,9 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "tokensale.ws",
+    "google.com.tokensale.ws",
+    "google-coin.io",
     "airdrop-binance.com",
     "auroradao.co.uk",
     "binanceethereum.com",


### PR DESCRIPTION
google.com.tokensale.ws
Fake Google crowdsale site
https://urlscan.io/result/51df4bee-f037-43be-8561-892e70a28dd5/
https://urlscan.io/result/c5804ad2-d3f1-4197-9dcb-ea248c7a11e5/
address: 0x89f4d39667Aa080502c517B613A6c92786aa14Bd

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2294