### PR TITLE
binance-lgin.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -357,6 +357,13 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "binance-lgin.com",
+    "ibx-l.com",
+    "mvetnerwalletr.online",
+    "mvetnerwalletr.site",
+    "mvyetherwallett.online",
+    "xn--methewallet-v48e1x.com",
+    "info-myetherwallet.com",
     "xn--myeherwllet-wte7564g.com",
     "enternow.info",
     "claim-event-eth.com",


### PR DESCRIPTION
binance-lgin.com
Suspicious Binance domain (same infra as log-in-binance.com)
https://urlscan.io/result/d6d60680-720d-4c33-af19-617572b71cf6/

xn--methewallet-v48e1x.com
Suspicious MyEtherWallet domain - nothing deployed yet
https://urlscan.io/result/42d75e4f-18dd-40a5-a015-d5a605123374/

xn--myethrewalle-xoc.com
Suspicious MyEtherWallet domain - nothing deployed yet
https://urlscan.io/result/95537436-47d1-4903-aae1-5a376e34ecb5/