### PR TITLE
ethertoken.online + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -358,7 +358,7 @@
     "orionprotocol.io"
   ],
   "blacklist": [
-    "ethertoken.online",
+    "ethertoken.online", 
     "mywindorwallert.space",
     "binance-ether.org",
     "neostracker.com",

--- a/src/config.json
+++ b/src/config.json
@@ -358,6 +358,10 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "ethertoken.online",
+    "mywindorwallert.space",
+    "binance-ether.org",
+    "neostracker.com",
     "elonmusk.ltd",
     "elonmusk.fund",
     "loginbinance-com.umbler.net",


### PR DESCRIPTION
ethertoken.online
Fake MyEtherWallet phishing for keys with POST /bot/bot.php
https://urlscan.io/result/21ae7db2-4abc-43f4-a800-0df782112fde/

binance-ether.org
Trust trading scam site
https://urlscan.io/result/bbf4c9d6-e344-4c6d-9d76-6348f87812a3/
address: 0x2784574e2405A7d3be1259B5F00412Ae652018f4

mywindorwallert.space
Fake MyEtherWallet
https://urlscan.io/result/0940becd-7e67-493d-a12a-ae26348f3660/

neostracker.com
Fake NEO tracker phishing for keys - https://twitter.com/jmoconnor415/status/1035688910188212224
https://urlscan.io/result/c0865dd6-b334-42af-9a1a-927769de0f4b/