### PR TITLE
ethmixdrop.pro

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -360,6 +360,7 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "ethmixdrop.pro",
     "axibovs.blogspot.com",
     "send.ethparty.us",
     "ethparty.us",


### PR DESCRIPTION
ethmixdrop.pro
Trust trading scam site
https://urlscan.io/result/a3e8aa00-5421-4ae1-b51e-9cb5058b75f7/
https://urlscan.io/result/b29d0d62-4a04-44de-af6d-705b869cc1d3/
address: 0x0aB4Fc631d194BB135dc7a3f99580Cf7df3eEAE0