### PR TITLE
musk-prize.info

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -362,6 +362,7 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "musk-prize.info",
     "medium-io.site",
     "claim.safepaycoins.com",
     "safepaycoins.com",


### PR DESCRIPTION
musk-prize.info
Trust trading scam site
https://urlscan.io/result/1544e9e4-084f-4efe-b058-b9cbc6b80f76/dom/
address: 0xbEeea2f6499Ebc15256905c8284fAbF2d9653582