### PR TITLE
medium.com.7a4c7b234069.site + etherium.org.7a4c7b234069.site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -362,6 +362,9 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "medium.com.7a4c7b234069.site",
+    "etherium.org.7a4c7b234069.site",
+    "7a4c7b234069.site",
     "elctrurn.org",
     "jaxx.one",
     "lkraken.xbtxv.com",


### PR DESCRIPTION
medium.com.7a4c7b234069.site
Fake Medium site - hosting a trust trading scam
https://urlscan.io/result/b94abd41-168b-4527-b916-1db787ea302c/
address: 0x964A7C09E3dB065ece947FdB7f90bf0068a6F98e

etherium.org.7a4c7b234069.site 
Trust trading scam site
https://urlscan.io/result/6c1423c1-604d-4150-8601-99d0a5d45efc/
address: 0x964A7C09E3dB065ece947FdB7f90bf0068a6F98e