### PR TITLE
ubex.us + bnbdex-ethcampaign.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -362,6 +362,8 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "ubex.us",
+    "bnbdex-ethcampaign.com",
     "binance-ether.online",
     "binance.win",
     "binanceethevent.net",


### PR DESCRIPTION
ubex.us
Fake Ubex crowdsale site
https://urlscan.io/result/72bfdd26-0e73-4d29-8d97-f5429ef5660c
address: 0x1b7bdc46Fb5d65c6d688bFAdCfb7D3A434413956

bnbdex-ethcampaign.com
Trust trading scam site
https://urlscan.io/result/6d22817f-7976-41f6-8f9b-999d18567c90/
https://urlscan.io/result/66310eaf-5177-4ab8-ad10-0872074b0918/
address: 0x0cBFf6C0365083f20C9De72084Be7FB11278Aa86