### PR TITLE
coinbasesecuritytokens.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -362,6 +362,14 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "coinbasesecuritytokens.com",
+    "coinbasepay.info",
+    "hitbtcrecovery.com",
+    "hitbtc-ads.com",
+    "hitbtc-adv.com",
+    "gemini-wallet.com",
+    "gemini2fa.com",
+    "geminiaccount.com",
     "binantlabsinfo.com",
     "binanetlabsinfo.com",
     "mymonerocom.com",

--- a/src/config.json
+++ b/src/config.json
@@ -365,7 +365,6 @@
     "coinbasesecuritytokens.com",
     "coinbasepay.info",
     "hitbtcrecovery.com",
-    "hitbtc-ads.com",
     "hitbtc-adv.com",
     "gemini-wallet.com",
     "gemini2fa.com",


### PR DESCRIPTION
coinbasesecuritytokens.com
Suspicious Coinbase domain
https://urlscan.io/result/13575392-6133-4d06-9d3a-662411a3b3a6/

coinbasepay.info
Ponzi scheme. Wrong company number 10829913
https://urlscan.io/result/7a23c64a-e4fd-4a0e-b45e-e257e5663022/

hitbtcrecovery.com
Suspicious hitbtc domain
https://urlscan.io/result/20f3f032-c754-4ce8-9c76-813e50f50a29/

hitbtc-ads.com
Suspicious hitbtc domain
https://urlscan.io/result/479ca000-aa45-49a5-9117-213f07c16cbb/

hitbtc-adv.com
Suspicious hitbtc domain
https://urlscan.io/result/da5b52a3-a35b-4363-a41f-c59192d251fb/

gemini-wallet.com
Suspicious Gemini domain
https://urlscan.io/result/738e1c5e-c4f5-47e6-a858-16c1a08d2f7f/

gemini2fa.com
Suspicious Gemini domain
https://urlscan.io/result/3eda48f8-f0a1-4c0a-836c-0330d60fb73f/

geminiaccount.com
Suspicious Gemini domain
https://urlscan.io/result/a5e548d0-fb5f-4181-9e0d-ec449223c4f8/