### PR TITLE
bnb-ethcampaign.com + cryptobtc.club

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -363,6 +363,8 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "idex-market.pro",
+    "biboyx.com",
     "bnb-ethcampaign.com",
     "cryptobtc.club",
     "perlin.global",

--- a/src/config.json
+++ b/src/config.json
@@ -363,6 +363,8 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "bnb-ethcampaign.com",
+    "cryptobtc.club",
     "perlin.global",
     "tesla-giveaways.space",
     "top-ethereum.info",


### PR DESCRIPTION
bnb-ethcampaign.com
Trust trading scam site
https://urlscan.io/result/720fb9ff-9e15-40d3-a235-ae49e5c56539/
https://urlscan.io/result/be5e36eb-fcbd-4976-8d87-ee497ea1ef02/
address: 0xb119eA0fA97C926DD55ff11CB90a1A0d578dC57E

cryptobtc.club
Trust trading scam site. Bitcoin address: 1NZrzg9CPa5hMQkJBYrY9v6ReitdNgSFJE
https://urlscan.io/result/11819e76-e862-4bf7-8af6-75bcbf1f67d8