### PR TITLE
removal of ponzi schemes

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -368,7 +368,6 @@
   ],
   "blacklist": [
     "3dayprofits.info",
-    "doubleroi.surge.sh",
     "etherium.org.payment.7d19-srv.site",
     "7d19-srv.site",
     "atmbtc.biz",


### PR DESCRIPTION
Committing ponzi schemes to the list without having the option to turn off the hardblock does also affect those who have previously put into the contract as it disables them from withdrawing.

The ones removed have changed their wording to not include "guaranteed" profits, verified the contract, and the contract has no admin back doors (such as changing the dev fee/user referrer/withdrawing everything).

I will be going through the list today and reviewing the blacklists I made in wrt to these ponzi schemes.

I will be pushing for an option to bypass grey-area blacklists as to minimise the impact of people already invested.