### PR TITLE
myetherwallet.auth.slgnmsg.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -367,6 +367,16 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "myetherwallet.auth.slgnmsg.info",
+    "slgnmsg.info",
+    "spectrocoinlog-in.com",
+    "giftethnow.website",
+    "etherium.org.payment.7t20-srv.site",
+    "7t20-srv.site",
+    "x-gives.blogspot.com",
+    "ethgive.kissr.com",
+    "ico-neon.exchange",
+    "myetherairdrop.com",
     "myetnerwallet.com.send-status.info",
     "send-status.info",
     "paxful.com.pl",


### PR DESCRIPTION
myetherwallet.auth.slgnmsg.info
Fake MyEtherWallet phishing for keys
https://urlscan.io/result/263b7cad-6d4f-469b-93d1-a41c251438fc/

giftethnow.website
Trust trading scam site
https://urlscan.io/result/6c9a7294-f1a0-4360-b05b-43eb797bdc7a/
address: 0xc57597f5fC469386AB8C53740b5Cf6c4A78e8EeC

etherium.org.payment.7t20-srv.site
Trust trading scam site
https://urlscan.io/result/1d558e94-7aa8-4fbe-9655-5695c06e9a19/
address:0x75B60BA032cf8eE0b4BBd78bfbD7D99caF70A176

x-gives.blogspot.com
Trust trading scam site. Tron address: TPcDNYz4AxCaLCY2Xx4i95jGYwCjUrxg5r
https://urlscan.io/result/6ec9ff11-d50f-438c-9c79-d8aee4b9f3e3/
https://urlscan.io/result/544fdd78-35d2-419e-a437-8edaf8a1fdec/
address: 0x55B775Ea2CA493c082F3e17A8433e4D220FBB8d8

btcgive.kissr.com
Trust trading scam site. bitcoin address: 19Q7FZ4FLNYP4rW1fewzR3v2fcBzRVHZ9f
https://urlscan.io/result/c8707846-4373-410c-828e-f8dc5ac77f81/

ethgive.kissr.com
Trust trading scam site
https://phishcheck.me/117289/details
address: 0xCae453Eb95B584331A8A5945D8138ceEED9d5Af6

ico-neon.exchange
Fake Neon crowdsale site. Neo address: AdNXNexCTgRMeLEiWxqE2zPpfpmfWuyeWe
https://urlscan.io/result/dda1acb5-4749-4d5f-8299-556529f77a76/#summary

myetherairdrop.com
Trust trading scam site
https://urlscan.io/result/71f86cbd-1484-4ce1-a456-2a7805f5da62/
address: 0x3157C0650BD0C85Ca276318DE70382F98bE79490