### PR TITLE
getyourcoins.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -367,6 +367,17 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "getyourcoins.org",
+    "binance-giveaway.webcindario.com",
+    "gift-today.website",
+    "cryptopromo.kissr.com",
+    "etherium.org.payment.7t21-srv.site",
+    "7t21-srv.site",
+    "top-deals.pro",
+    "medium.com.7t21-srv.site",
+    "decentralizedbitcoincampaign.info",
+    "bittrexl.in.us.bix-l.com",
+    "bix-l.com",
     "binance.com18363462.ml",
     "binancebtcspecial.com",
     "brivnarnce.com",


### PR DESCRIPTION
getyourcoins.org
Trust trading scam site. Bitcoin address: 17VZwSSY5dBCfmSdF5pTRQyS44SPq6icug
https://urlscan.io/result/7a6914c5-9baf-4a55-9fd7-0752f735030d/
https://urlscan.io/result/c57cd68b-adba-4107-aae1-c7363d72e845/
https://urlscan.io/result/85123e38-9e22-4d40-83e4-ba68e1ea67a2/
address: 0x19B619237de51AF8e1CBd989Cd4E01E7299df4De

binance-giveaway.webcindario.com
Trust trading scam site
https://urlscan.io/result/939e0b87-c840-4380-9804-bb9dbe2107e7/
address: 0x4D6102BcBe452015a7D656a97dE3F30f10054Ceb

cryptopromo.kissr.com
Trust trading scam site. Linking users to ethgive.kissr.com and btcgive.kissr.com
https://urlscan.io/result/ba416d4d-0da9-4ae6-8cc6-b009e83d4692/
address: 0xCae453Eb95B584331A8A5945D8138ceEED9d5Af6

gift-today.website
Trust trading scam site
https://urlscan.io/result/0614ddaf-ab85-47db-9dc3-7f1698ff39b8/
address: 0xDf62cc136546e30BaC252196c4F623a1B36Ea8b8

etherium.org.payment.7t21-srv.site
Trust trading scam site
https://urlscan.io/result/90ac6097-8595-49d1-9b72-f2aad467082d/
https://urlscan.io/result/106a6e45-e2bd-4d1c-ad59-d3c533883541/
address: 0x2D8D2AC5f701363B17F07A46e15e2e97282F5b0a
address: 0x9FD4351644eA4C47B127EF3E237476570C01884E

top-deals.pro
Trust trading scam site. Bitcoin address: 1DNmKrDCrqvc4L4D9gtWM23QEUTRjKUH1M
https://urlscan.io/result/617a22bc-39d7-4275-91db-3ab80c3bf715/

bittrexl.in.us.bix-l.com
Fake Bittrex phishing for details with POST /indexSend.php
https://urlscan.io/result/39638228-b537-4b61-a78c-73bbf12d8e7e/

---

ether-claim.org
Trust trading scam site
https://urlscan.io/result/10eca6dc-c7e0-4c4b-a7b5-e63d5d61a8ce/
address: 0x3b99ECAd31347CDD987e8683d8076B7BdBe4dE4e