### PR TITLE
firecrypto.info

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -367,6 +367,7 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "firecrypto.info",
     "bitbakocffice.site", 
     "santechstroywalker.site",
     "airdrop-event.com",


### PR DESCRIPTION
firecrypto.info
Fake exchange asking for 0.01BTC deposit to verify. See full scam at https://redd.it/9ks9ux. Bitcoin address: 1PTAaVk6onxkgU1ZXxMfcPG9txgQ6rYVef
https://urlscan.io/result/0a61a824-2dd8-433c-b75c-3c78e9d336f8
address: 0x1E711A766cD4EC07C590EeF54A112190B4826b4e