### PR TITLE
tron-network.info + electrumwallet.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -368,6 +368,8 @@
     "orionprotocol.io"
   ],
   "blacklist": [
+    "tron-network.info",
+    "electrumwallet.org",
     "cew.safewallet.replayattack.us",
     "replayattack.us",
     "medium.com.7t23-srv.site",


### PR DESCRIPTION
tron-network.info
Suspicious Tron wallet domain (Google Ad)
https://urlscan.io/result/f8e5fc74-4c5c-460f-9c99-338d03062ab1

electrumwallet.org
Fake Electrum wallet
https://urlscan.io/result/592aaac2-76b3-446a-aef0-148d15defc7f/