### PR TITLE
b-crypto.me + apexone.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -381,6 +381,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "b-crypto.me",
+    "apexone.online",
     "moyluchshiyremont.top",
     "pizzaobaldinidostavka.site",
     "binanse.ch",


### PR DESCRIPTION
b-crypto.me
Trust trading scam site. Bitcoin address: 1AZXBeoGtCnK5jVHaDBoNphsND2dLWtRE2
https://urlscan.io/result/390bc165-05e9-4873-96fa-ef24c8f5db86/

arbitragecoins.com
Scam bot - steals deposits - many many online reports
https://urlscan.io/result/0c42ceaf-833c-4b7e-b328-2c448bcc4303/
address: 0x3258674d5eb5cfca42c18585b95fff50e098ebd4

apexone.online
Clone of apexone.io
https://urlscan.io/result/1feff908-d6d2-439d-8d42-eac0e7236e58/
https://urlscan.io/result/afb0eb6a-a522-4d77-b3f4-b0937000762b/
address: 0x23f1909f7a65cba4d2a4a42ee1ba7d9772c3ba93
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2557