### PR TITLE
myetherwallet.notextbook.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -384,7 +384,6 @@
   "blacklist": [
     "myetherwallet.byethost11.com",
     "googl-access.com",
-    "binance.com-log-in.googl-access.com",
     "binance.com13867347.ml",
     "com13867347.ml",
     "com1735835.gq",

--- a/src/config.json
+++ b/src/config.json
@@ -382,6 +382,18 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "googl-access.com",
+    "binance.com-log-in.googl-access.com",
+    "binance.com13867347.ml",
+    "com13867347.ml",
+    "com1735835.gq",
+    "binance.com1735835.gq",
+    "com56457.ml",
+    "binance.com56457.ml",
+    "myetherwallet.notextbook.net",
+    "sslsecure-verifyid.tk",
+    "coinsender.tech",
+    "walmartleaf.com",
     "1dex.market",
     "binance.co",
     "birhumb.com",

--- a/src/config.json
+++ b/src/config.json
@@ -382,6 +382,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "myetherwallet.byethost11.com",
     "googl-access.com",
     "binance.com-log-in.googl-access.com",
     "binance.com13867347.ml",


### PR DESCRIPTION
myetherwallet.notextbook.net
Fake MyEtherWallet phishing for keys with POST /store.php
https://urlscan.io/result/e643d75e-3a61-442e-8769-44591f09c91d/

coinsender.tech
Trust trading scam site. Bitcoin address: 13v7acoch2p4otKN8cpvp3n2LHxbSB1XdE
https://urlscan.io/result/366f12c4-0c59-4f5e-9d04-6cd2f2612b44/
https://urlscan.io/result/5c651b82-1942-4cca-82eb-6deaf1476ddf/
https://urlscan.io/result/1980b69b-59d9-452c-94bc-d7d7e2514a1b/
address: 0xC0EcBcd3a5977921FaFEcffdf96b4Bcae1573B99