### PR TITLE
dexlauncch.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -383,6 +383,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "dexlauncch.com",
     "line-crypto.com",
     "etherdelta.icu",
     "xtrony.blogspot.com",


### PR DESCRIPTION
dexlauncch.com
Trust trading scam site
https://urlscan.io/result/f6733eb0-1129-4e98-8504-3bdbc31c7f6b/
https://urlscan.io/result/944df75c-441b-47e2-8f32-3ac3419a981b/
address: 0xd22066c4e511698b626aea89cf70FbA5Fd3f37d4

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2574