### PR TITLE
modcrypto.online whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -6210,6 +6210,7 @@
     "eth22.mediumblog.top",
     "etoroglobal.com",
     "bcrypto.club",
-    "airdrop-bitnational.com"
+    "airdrop-bitnational.com",
+    "modcrypto.online"
   ]
 }


### PR DESCRIPTION
add "modcrypto.online" to whitelist.
It has been incorrect detected as malicious website.