### PR TITLE
etherdelta.ru + ethereumgifting.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -391,6 +391,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "etherdelta.ru",
+    "ethereumgifting.com",
     "bithumb.today",
     "coinbasehotelcard.com",
     "coinbasepromo.us",


### PR DESCRIPTION
etherdelta.ru
Fake EtherDelta phishing for keys with POST /api.php
https://urlscan.io/result/2f84b6f1-8fd7-4a37-b59a-3c083a4723a7/

ethereumgifting.com
Trust trading scam site
https://urlscan.io/result/156bcaf4-978f-4239-8d8c-a645790278d1
https://urlscan.io/result/6997849b-ead6-49ea-9426-2bb61550d868/
https://urlscan.io/result/d985fcdd-4025-4b75-9c43-af67b8e9e63f/
address: 0x1865bf39ec9712f5f3d57cf423495c318939ab3e
address: 0xd79Ab5cd842c068E4F592c18EE3FaC4E806D4C31