### PR TITLE
paxful.com.autaro.tk + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -391,6 +391,14 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "paxful.com.autaro.tk",
+    "autaro.tk",
+    "ethereum-giveaway.net",
+    "bonus.ethereum-giveaway.net",
+    "go.ethereum-giveaway.net",
+    "enter.ethereum-giveaway.net",
+    "join-eth-promotion.ethereum-giveaway.net",
+    "participate.ethereum-giveaway.net",
     "etherdelta.ru",
     "ethereumgifting.com",
     "bithumb.today",


### PR DESCRIPTION
paxful.com.autaro.tk
Fake Paxful phishing for logins with POST /loginid.php
https://urlscan.io/result/ab3c7f2c-82fa-4abc-8692-328da7dd787a/

participate.ethereum-giveaway.net
Trust trading scam site
https://urlscan.io/result/9f629ed8-e062-4473-b232-4a674e43033f/
https://urlscan.io/result/c026878a-2941-4f02-b062-800155a70da7/
address: 0xDfa8e0d144B1bD7B9f08Cd05A7726cC20121292f

join-eth-promotion.ethereum-giveaway.net
Trust trading scam site
https://urlscan.io/result/d57e7abc-f2de-4fe6-9e33-b864a5b5619f/
https://urlscan.io/result/269c0cd4-95da-4f65-b01c-16cb5fb07562/
address: 0x7E8bA7B52Ae83Be8885A613c2B249Db4A2D0D06C

enter.ethereum-giveaway.net
Trust trading scam site
https://urlscan.io/result/b7544cd5-6389-43d2-ae6d-22e5580bb4ca/
address: 0xDfa8e0d144B1bD7B9f08Cd05A7726cC20121292f

go.ethereum-giveaway.net
Trust trading scam site
https://urlscan.io/result/01e15cf3-ebf2-4035-80cd-a5e6ceb28dd3/
address: 0xDfa8e0d144B1bD7B9f08Cd05A7726cC20121292f

bonus.ethereum-giveaway.net
Trust trading scam site
https://urlscan.io/result/a6f3e7d7-67f0-46fb-8123-5fedf91e1d5f/
address: 0xDfa8e0d144B1bD7B9f08Cd05A7726cC20121292f