### PR TITLE
ehitbtc.com.viptempobetgirisi.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -391,6 +391,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "ehitbtc.com.viptempobetgirisi.com",
+    "hit-blentf-com.blogspot.com",
     "paxful.com.autaro.tk",
     "autaro.tk",
     "ethereum-giveaway.net",


### PR DESCRIPTION
ehitbtc.com.viptempobetgirisi.com
Fake HitBtc phishing for logins with POST /index--_.php
https://urlscan.io/result/de4e77e1-8cd1-4ae8-b87d-159cc40b43e2/
https://urlscan.io/result/15c6fb4e-2a54-4091-ab71-387a4f3ccb42/