### PR TITLE
xlm-wallet.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -391,6 +391,10 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "xlm-wallet.com",
+    "getpetrocoin.com",
+    "paxosbounty.com",
+    "etoro-exchange.com",    
     "musk.plus",
     "spacex.plus",
     "elongift.space",


### PR DESCRIPTION
xlm-wallet.com
Fake MyEtherWallet phishing for keys with POST /send.php and POST /sign.php (lumens/claim.html)
https://urlscan.io/result/e9d7df2f-29bd-4765-aee1-5e0800405f3c/
https://urlscan.io/result/0a0ae860-02d6-487a-bcd8-41664438ff8e/

getpetrocoin.com
Fake PetroCoin crowdsale site
https://urlscan.io/result/caf41eb5-91ff-462c-b1e7-3c645e03fce4/
address: 0x02fd82cba3bae39484d5eb7f75b5f3d5f418c691

paxosbounty.com
Fake Paxos bounty program
https://urlscan.io/result/024c08f8-1463-455c-b503-82b992dfe28d/
address: 0xF31b4F7550833a746f788b36f2b292E5fA49a248

---

bigcoingift.club
Trust trading scam site
https://urlscan.io/result/bf0d8273-0a58-422b-b5f6-84930db74198/#summary
address: 0x7513C584E280Fd9F5f3a38F83fbA342CE70fFD79

omisego-network.io
Fake OmiseGo. Suspected addresses: 0x3c3284e18511e6fadb62be6e090991540dc8972e 0x0c626D05Fb5805362F2fbd5F4291211B691f129b 0xB6eD7644C69416d67B522e20bC294A9a9B405B31
https://urlscan.io/result/2e3c882f-8965-44d9-8eb9-b58248486171/