### PR TITLE
modcrypto.online whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14,6 +14,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "modcrypto.online",
     "crypto.ad",
     "vccrypto.nu",
     "f5crypto.com",


### PR DESCRIPTION
http://www.modcrypto.online/ is the website of our team for marketing our related crypto projects such as AlphaNode, Bankitz, Brofist etc. We will provide services such as Coins information, Faucet, Masternodes, Block Explorer.
Our website has no related to ETH. 
Thank you 
@modcrypto 