### PR TITLE
bitcointolk.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -4239,6 +4239,7 @@
     "keytron.io",
     "xn--mytherwalt-smbh17c.com",
     "bitcointalk.to",
+    "bitcointolk.org",
     "ethbonus.net",
     "etherspromo.org",
     "ethergiving.org",


### PR DESCRIPTION
Fake version of the bitcoin forum bitcointalk.org
https://urlscan.io/result/7b4db913-0bd3-4b85-8948-8a87f8367bfb