### PR TITLE
bitcointolk.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -399,7 +399,6 @@
     "etherspin.co"
   ],
   "blacklist": [
-    "bitcointolk.org",
     "coinbase.xm-login2.com",
     "am-ov.store",
     "xm-login2.com",

--- a/src/config.json
+++ b/src/config.json
@@ -399,6 +399,11 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "bitcointolk.org",
+    "coinbase.xm-login2.com",
+    "am-ov.store",
+    "xm-login2.com",
+    "etherdesk.co",
     "immigrationpoint.co.uk",
     "ldcxmarket.com",
     "ldcxmarket.info",


### PR DESCRIPTION
bitcointolk.org
Fake Bitcoin talk forum phishing for logins
https://urlscan.io/result/7b4db913-0bd3-4b85-8948-8a87f8367bfb

coinbase.xm-login2.com
Fake Coinbase phishing for logins
https://urlscan.io/result/ea5e11dd-0134-4b7e-a158-77e4fb605757/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2642

etherdesk.co
Trust trading scam site
https://urlscan.io/result/4d5a6595-217d-4a83-8b0b-b4a219c110e2
address: 0x015f17e2851eA392351b7f259e4CFd03dc443CeF
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2636