### PR TITLE
get-10000-ethereum.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -399,6 +399,13 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "get-10000-ethereum.org",
+    "crypto-giveaway.org",
+    "btc-crypto.me",
+    "crypto-return.online",
+    "crypto-share.online",
+    "tesla-gift.com",
+    "tesla-promo.top",
     "ldex-market.host",
     "xn--blocchn-4ya8tls.com",
     "xn--myeterwaliet-fs4f.com",


### PR DESCRIPTION
get-10000-ethereum.org
Trust trading scam site
https://urlscan.io/result/0f0c86ad-eeb6-4206-8a79-0296a1913a85/
address: 0x8D630073940fDE8112C6a5295Ba3e490cA992ee8

btc-crypto.me
Trust trading scam site
https://urlscan.io/result/da646732-aca9-46a5-b0cd-4e19cc099437/
address: 1GiJEkXQevPAoeuLALo2cVh2WPFxQfu21E

tesla-gift.com
Trust trading scam site - linking to crypto-giveaway.net
https://urlscan.io/result/520b4f18-81ad-4c3a-a77a-9663a501a95c/
address: 0x579C0Fcc6D58731fD94de76A13390ABe330d9106

---

crypto-giveaway.net
Trust trading scam site
https://urlscan.io/result/2d2c61bf-c8af-470b-a98a-a8db4e85a0b2/
address: 0x579C0Fcc6D58731fD94de76A13390ABe330d9106