### PR TITLE
dexairdropevent.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -399,6 +399,11 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "dexairdropevent.com",
+    "eth.tronnetwork.pw",
+    "btc.tronnetwork.pw",
+    "tronnetwork.pw",
+    "pool-neo.blogspot.com",
     "lbexm.com", 
     "lbexmarnet.com", 
     "lbexmet.com", 


### PR DESCRIPTION
dexairdropevent.com
Trust trading scam site
https://urlscan.io/result/ec48e5f6-ef22-41d7-90cf-a646fe9877e8/
https://urlscan.io/result/3c6ad9ae-1eb9-44c5-a1a7-41ad411f7617/
address: 3HcX7kMQnn5QpaRvKyCgPSGa8MLfDYT2Sm

eth.tronnetwork.pw
Trust trading scam site
https://urlscan.io/result/1565156a-720c-45d6-bd86-bd28fe808f40/
address: 0x8B0e77fE177d555408339E26921bE7d76D398d8a

btc.tronnetwork.pw
Trust trading scam site
https://urlscan.io/result/7b69b3ac-36dd-49f0-bb9f-54fc266d0f27/
address: 1EBp8h9BGh4pJ4ZcE17Fo5pp7CRDd48y9u

pool-neo.blogspot.com
Trust trading scam site
https://urlscan.io/result/c1e0313e-dbfc-4d57-9bf5-7215f7d675f3/
address: ATVMaR3SXKRBtwCNgPjV5k2YzEgzMDYeaf