### PR TITLE
tesla-crypto.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -399,6 +399,14 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "tesla-crypto.info",
+    "bnb-ethcompetition.com",
+    "eth.binancegift.pro",
+    "binancegift.pro",
+    "idex.com.ru",
+    "ibex.cc",
+    "t-btc.net",
+    "etherdelta.com.ru",
     "binance-mmx.com",
     "binance-tx.com",
     "binance-xm.com",


### PR DESCRIPTION
tesla-crypto.info
Trust trading scam site linking users to elon-share.info
https://urlscan.io/result/aa3fec3e-68dd-4eca-a506-09865b276692
address: 0x0ad24a61a0371d1dfe47c3b74169aaa5807efb31

eth.binancegift.pro
Trust trading scam site
https://urlscan.io/result/1689aacd-86de-4f86-b614-6f35a4692390/
address: 0x8F46233dAFd44b331753E53b8785b9D83fBba463

idex.com.ru
Fake Idex phishing for keys with POST /log.php
https://urlscan.io/result/8b87ddfe-3e35-4829-9e7d-0e52803535d8/
https://urlscan.io/result/aed69d20-ecbd-46b4-bce6-0a2cce05cfd8

ibex.cc
Fake Idex phishing for keys with POST /post.php
https://urlscan.io/result/081ffa71-1445-438d-855f-cff7907d1cd8/

etherdelta.com.ru
Fake EtherDelta phishing for keys with POST /api.php
https://urlscan.io/result/26cf7b95-688d-479e-9c65-c300c3306bec/

t-btc.net
Trust trading scam site
https://urlscan.io/result/c3292db7-49fb-4a04-833b-05be33b98d34/
address: 13wbyCj6S9V8mPtKWs9ZAiGEEfTcdYx9v7

---

btc-gift.net
Trust trading scam site
https://urlscan.io/result/bfd453f2-c6fe-4081-ac3c-d1c502fe507a/
address: 1DQme49mAdEz3XsE8fYhAYLQpT5SGpcLpJ