### PR TITLE
Trycrypto.net is not a phishing phrase

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -78,6 +78,7 @@
     "msgcrypto.com",
     "vethorscan.io",
     "mykrypto.io",
+    "trycrypto.net",
     "trycrypto.com",
     "atatus.com",
     "acuitus.com",


### PR DESCRIPTION
Trycrypto.net is not a phishing phrase but new exchange. Registered in Estonia with legal company and crypto license.