### PR TITLE
blog.0xproject.co + wallet.pollux.network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -400,6 +400,10 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "blog.0xproject.co",
+    "0xproject.co",
+    "wallet.pollux.network",
+    "pollux.network",
     "mvelnerwallet.com",
     "multplatforlex.asia",
     "cryptoblackfriday.blogspot.com",


### PR DESCRIPTION
blog.0xproject.co
Fake 0xproject blog linking users to pollux.network
https://urlscan.io/result/cb57454f-6e7e-4f0b-bb85-e0538f986fca

wallet.pollux.network
Fake airdrop stealing keys with POST /prv.php
https://urlscan.io/result/35b1a979-eac6-4c01-94ff-84c1b64088d0/