### PR TITLE
btc-promo.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -405,6 +405,11 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "btc-promo.info",
+    "crypto-return.online",
+    "tesla-promo.top",
+    "myetherwallet.16mb.com",
+    "16mb.com",
     "blog.0xproject.co",
     "0xproject.co",
     "wallet.pollux.network",

--- a/src/config.json
+++ b/src/config.json
@@ -406,8 +406,6 @@
   ],
   "blacklist": [
     "btc-promo.info",
-    "crypto-return.online",
-    "tesla-promo.top",
     "myetherwallet.16mb.com",
     "16mb.com",
     "blog.0xproject.co",


### PR DESCRIPTION
btc-promo.info
Trust trading scam site
https://urlscan.io/result/5232e402-d8d5-47ad-b38f-a5270418ba2c/
https://urlscan.io/result/9fc64e6f-67ca-4471-801d-e56f0981cadc/
address: 15pkYouQ8mPLSXKH7iNiZ6XBxtDvjzdzG8
address: 0x579C0Fcc6D58731fD94de76A13390ABe330d9106

myetherwallet.16mb.com
Fake MyEtherWallet phishing for keys with POST /mail-area2.php
https://urlscan.io/result/3bd733d6-b02c-43ab-85d4-8643472f3b42/


---

crypto-giveaway.xyz
Trust trading scam site
https://urlscan.io/result/36d8a11c-a64c-4e12-860b-6deb9b2f9302/
https://urlscan.io/result/588e2857-0397-4d68-8667-53d350532e1d/
address: 0x579C0Fcc6D58731fD94de76A13390ABe330d9106
address: 1LfmegbyxqufhZQA5eBR6P6YZ2VF54K1kK