### PR TITLE
international.bittrex.com8917321.ga

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -406,6 +406,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "international.bittrex.com8917321.ga",
+    "com8917321.ga",
     "spacex.delivery",
     "bibolx.com",
     "xn--metherwllt-f2d4888f9va.com",


### PR DESCRIPTION
international.bittrex.com8917321.ga
Fake Bittrex phishing for logins - https://twitter.com/ANeilan/status/1069746687550386177
https://urlscan.io/result/bc48e861-ec1a-4795-a8c5-aa7a004587a4/
https://urlscan.io/result/4127fcd8-d362-447f-b796-8cd025def2fd/