### PR TITLE
cryptophonesupport.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -406,6 +406,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "cryptophonesupport.com",
     "keepstake.github.io",
     "msg.xn--metherwllt-zmb5581g94a.com",
     "xn--metherwllt-zmb5581g94a.com",


### PR DESCRIPTION
cryptophonesupport.com
Fake phone support for multiple cryptocurrency products
https://urlscan.io/result/50faf3dd-fc0e-45ad-b3f5-01665389ca9c/