### PR TITLE
ethnew.store

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -415,6 +415,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "ethnew.store",
     "coinbase.pro-cax.com",
     "pro-cax.com",
     "cbs-pro.com",


### PR DESCRIPTION
ethnew.store
Fake MyEtherWallet phishing for keys with POST /bot/bot.php
https://urlscan.io/result/212a5643-6987-4448-8069-4bb3d0e40b7a/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2706