### PR TITLE
musk.claims + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -415,6 +415,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "musk.claims",
+    "spacex.gives",
+    "musk.click",
     "ethnew.store",
     "coinbase.pro-cax.com",
     "pro-cax.com",


### PR DESCRIPTION
musk.claims
Trust trading scam site
https://urlscan.io/result/a9db5309-babb-4d98-9a7a-8d6d9796c61b/

musk.click
Trust trading scam site - linking users to spacex.gives (not up yet)
https://urlscan.io/result/a5410d0c-07d0-46b5-9575-68cc4423017f/

spacex.gives
Trust trading scam site (not up yet)
https://urlscan.io/result/313c8eb3-a411-401a-a6dc-cedd7c949465/