### PR TITLE
cryptokucoin.blogspot.com + neokucoin.blogspot.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -415,6 +415,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "cryptokucoin.blogspot.com",
+    "neokucoin.blogspot.com",
     "blockchain-update.bounceme.net",
     "coinbene.net",
     "hitbtcwalet.com",


### PR DESCRIPTION
cryptokucoin.blogspot.com
Trust trading scam site (XRP)
https://urlscan.io/result/63213174-2f94-4888-a8d0-c9cea85acfa4/
address: rGD1q9qfHd9gYbm9VUdcBXjumAaMZen8tr

neokucoin.blogspot.com
Trust trading scam site (NEO)
https://urlscan.io/result/68e65ea7-f33b-4b84-9b83-d24467bb3ca4/
address: ATVMaR3SXKRBtwCNgPjV5k2YzEgzMDYeaf