### PR TITLE
bbxotc.tech + btc-gifts.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -417,6 +417,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "bbxotc.tech",
+    "btc-gifts.net",
     "biitfiinex.com",
     "binance-dexbounty.info",
     "binance-download.com",


### PR DESCRIPTION
bbxotc.tech
Trust trading scam site
https://urlscan.io/result/6a795a69-fa70-4a77-b927-63490c738b2a/
https://urlscan.io/result/33c338f4-d407-4e6e-85d3-229bf32128b5/
address: 0x8BdA591ac93925f485cd420A47A48EBa87985ea0

btc-gifts.net
Trust trading scam site
https://urlscan.io/result/a6358246-767e-421d-9db6-771beaf75839/
https://urlscan.io/result/5e8d9a9f-79a0-4a3e-a3f6-83faa25d2498/
https://urlscan.io/result/49d82325-8fb3-4263-9645-f2f7c37e87b9/
address: 13GJitKdQKcbaiJuNRmUf8F7roh9FfSFTG 
address: 0x9404C08c6ae0cd5F1FdbC558c7A61D3D7Bff07e6

---

binance-claims.com
Trust trading scam site
https://urlscan.io/result/ab19497f-2f05-413b-94ee-8e6b84cd22de/
address: 1J75vF5koGVgKXNewrZkcMBS1eJkyLcdcC