### PR TITLE
coinbase.pro-xca.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -417,6 +417,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "coinbase.pro-xca.com",
+    "pro-xca.com",
+    "awx-ly.store",
     "binance-dex.life",
     "binance-dex.live",
     "binance-dexonline.info",


### PR DESCRIPTION
coinbase.pro-xca.com
Fake Coinbase stealing keys with POST /action.php
https://urlscan.io/result/a79d2b66-11d7-4589-84bb-3941598c372f