### PR TITLE
giveaway2018.org + bullrun2018.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -417,6 +417,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "giveaway2018.org",
+    "bullrun2018.com",
     "doublecoinio.jdevcloud.com",
     "mediium.org",
     "myetherwallet-be.space",


### PR DESCRIPTION
giveaway2018.org
Trust trading scam site
https://urlscan.io/result/85e4804c-d8dd-4a67-b35a-2595521a6a4e/
https://urlscan.io/result/46b53918-ce27-4a6f-9b27-1a94c7b6a1b0
https://urlscan.io/result/6cdd05da-9264-45c1-ba3f-a224b7eaafa7
https://urlscan.io/result/29f770f7-fc0b-4d64-a58f-8e1471150c8c
https://urlscan.io/result/2357ee97-5dc6-453d-9c0f-fa84dc9c31be/
address: rK3thhBkPFfsnSZgNo3Ajuuw6NK3gGUNeN (Xrp)
address: 0x39AF5503788A637984Ddf583A8e5128dce765172 (Eth)
address: 1JQW3R96LiqpNJmf386toMu5aQNANxqt8r (Btc)