### PR TITLE
etherdelta.pro

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -419,6 +419,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "etherdelta.pro",
     "quarkairdrop.com",
     "crypterium.site",
     "bittfinex.com",


### PR DESCRIPTION
etherdelta.pro
Fake EtherDelta phishing for keys with POST /api.php
https://urlscan.io/result/cd7cab90-fd09-41c4-aaaa-c0b7c8d02db6