### PR TITLE
ether-contest.com + dex-huobiglo.info

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -419,6 +419,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "ether-contest.com",
+    "dex-huobiglo.info",
     "xn--myetherllet-hoc47z.com", 
     "xn--myethewllet-hdc193a.com",
     "airgiveaway.typeform.com",


### PR DESCRIPTION
ether-contest.com
Trust trading scam site
https://urlscan.io/result/be7e8b6f-bd02-4210-bd9c-67be4aedcbf5/
https://urlscan.io/result/f9d5845d-729e-4544-a1b8-670740c90ec3/
address: 0x81E4B65b9330C5693d38430111D7Eb174615bDD6

dex-huobiglo.info
Trust trading scam site
https://urlscan.io/result/1051fc75-87ac-42b1-9587-60fae3c88f96/
https://urlscan.io/result/f4a4a41c-9f8b-401a-8ac3-36ceebfc20ed/
address: 0x57aa0ca8ddc99096d150f0dd1e1bd50616d809c8
address: bc1qw9cz3095dxnt5hkfdyltueen9g7j5w5u6c0zq9

telegra.ph/Crypto-Bible-team-are-giving-away-500-ETH-12-22-2
Trust trading scam site
https://urlscan.io/result/9aaa2953-bb03-4948-ad32-6082b8eec0c5/
address: 0x95115419b09e8cea70a9bdbca3fee8c5e118b228