### PR TITLE
bittlrex.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -419,6 +419,13 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "bittlrex.com",
+    "xn--binnce-rhc.com",
+    "binance.exchange2018.support",
+    "exchange2018.support",
+    "binancehelpdesk.com",
+    "binancetwofactorauthentication.com",
+    "pumapay.io.giveaway-user.com",
     "ether-contest.com",
     "dex-huobiglo.info",
     "xn--myetherllet-hoc47z.com", 


### PR DESCRIPTION
bittlrex.com
Fake Bittrex phishing for logins with POST /Account/Login
https://urlscan.io/result/e05e7cce-056a-4ae8-be8a-4059729ad1b8/
https://urlscan.io/result/9b3843c9-cb8f-4bd9-9c87-e1e7a72f37d1/

xn--binnce-rhc.com
Trust trading scam site - linking users to www.binance.exchange2018.support/event
https://urlscan.io/result/dbd027bf-21b2-44ca-9e40-caa6aa336120/
address: 3HzQJ3CGQKkWuxGSiWW286PePSed7tgKWp

binance.exchange2018.support
Trust trading scam site
https://urlscan.io/result/307d137b-93d9-4a07-8fa7-c78ec8ea438c/
https://urlscan.io/result/771cae8a-4b00-400e-a194-168a458c3479/
address: 3HzQJ3CGQKkWuxGSiWW286PePSed7tgKWp

binancehelpdesk.com
Fake helpdesk harvesting user emails
https://urlscan.io/result/84cdf127-f04d-46dd-a846-7c7791157b1a/

pumapay.io.giveaway-user.com 
Fake MyEtherWallet phishing for keys
https://urlscan.io/result/d00b79ca-73ad-4e6b-8e81-441c3000fd83/