### PR TITLE
okexpro.icu + poetairdrop.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -420,6 +420,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "okexpro.icu",
+    "poetairdrop.com",
     "coinbankatm.com",
     "coinbasedex.online",
     "coinsbankcom.com",


### PR DESCRIPTION
okexpro.icu
Trust trading scam site
https://urlscan.io/result/943d1eb5-4a11-4f01-b4ac-b6f5489652a5/
https://urlscan.io/result/d922814f-c549-4bf9-8557-0cfea6140f5f/
address: 0xBb90125091Fd7c7953FB98b59f6ce75E2500e5DB

poetairdrop.com
Fake airdrop phishing for keys with POST /signed.php
https://urlscan.io/result/802a7cf0-2daa-464b-8647-9c1bcdd994d9/
https://urlscan.io/result/274ce288-e104-4d54-895b-e68daae662e2/