### PR TITLE
cash-bitcoin.online + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -420,6 +420,13 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "cash-bitcoin.online",
+    "yobitex.info",
+    "yobit-admin.net",
+    "yobit--net.com",
+    "supportyobit.net",
+    "xn--ybit-gra.net",
+    "xn--yobt-sya.net",
     "bankcor.network",
     "bankor.network",
     "binance-tr.com",


### PR DESCRIPTION
cash-bitcoin.online
Trust trading scam site
https://urlscan.io/result/05ce8702-5326-4088-9294-3340319ac4fd/
address: 3CnqzLzkrHwCoi94y8Caq2Yw1pQQA94Wvk

yobit--net.com
Fake Yobit phishing for logins with POST /en/_loginSend.php
https://urlscan.io/result/57afad75-bfa0-4cb6-9f98-3c38cc6d8bbe/

supportyobit.net
Fake YoBit phihsing for Yobicodes with POST /login.php
https://urlscan.io/result/eb2706be-2677-4a5b-8ada-13a4c6a5367e/