### PR TITLE
cryptobridge.su + xrp-giveaway.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -420,6 +420,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "cryptobridge.su",
+    "xrp-giveaway.com",
     "biboxpr.icu",
     "myetheresvallet.com",
     "paxfu1.com.mx",


### PR DESCRIPTION
cryptobridge.su
Fake CryptoBridge exchange phishing for details with POST /login/login.php
https://urlscan.io/result/29b000e4-dd0d-4fe7-9302-485f0276a55f/

xrp-giveaway.com
Trust trading scam site
https://urlscan.io/result/88344037-b595-47f6-b0c1-304181116dce/
https://urlscan.io/result/c5d24623-4bd8-4e4c-a60d-bb4a639c01a8/
address: raBesxXx7QQ1RdboXXZHhjaKSyW19JptMt