### PR TITLE
whitelisting metamesh.life

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14,6 +14,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "metamesh.life",
     "crypto.business",
     "aetherwallet.io",
     "icon.community",


### PR DESCRIPTION
Metamesh.life is a domain recently acquired by a group of ex-ConsenSys staffers (many from the Solutions mesh) who are launching a consulting practice. The name is caught for its proximity to metamask.io, although the site is legit.

https://medium.com/@marclijour/launching-metamesh-consulting-d8974b7e7b8e