### PR TITLE
cryptocashback.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -421,6 +421,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "cryptocashback.org",
+    "cryptocashback.info",
+    "cryptoback.one",
     "newyearcrypto.blogspot.com",
     "newyearneo.blogspot.com",
     "cryptobridge.su",


### PR DESCRIPTION
cryptocashback.org
Directing users to a Malware chrome extension (liachincjagnalnmahhaioaogkngbmhf) to target Binance users
https://urlscan.io/result/02d0c550-7eeb-4240-b4b9-43dd46969967/

cryptocashback.info
Directing users to a Malware chrome extension (liachincjagnalnmahhaioaogkngbmhf) to target Binance users
https://urlscan.io/result/2108a824-6437-41b1-a781-666f64b5296c/

cryptoback.one
Directing users to a Malware chrome extension (liachincjagnalnmahhaioaogkngbmhf) to target Binance users
https://urlscan.io/result/9110134f-f334-4487-87ca-1f906bc80734/