### PR TITLE
gowincoin.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -421,6 +421,12 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "gowincoin.com",
+    "delta.money",
+    "coinsupergive.live",
+    "ethers-claim.com",
+    "binanceevent.net",
+    "huobilive.icu",
     "cryptocashback.org",
     "cryptocashback.info",
     "cryptoback.one",


### PR DESCRIPTION
gowincoin.com
Trust trading scam site
https://urlscan.io/result/765f29f5-7f6c-47b5-8173-0e96ee266938/
https://urlscan.io/result/af65279f-2211-456e-b990-9ddaf3315b14/
https://urlscan.io/result/7ccced8c-4fe5-4e90-8463-eadbdd418cfe/
address: 1ApXtisCrsykSmzCXsRFL6mhtKQUdN6eQB 
address: 0x8583EE650C6566503d1d9DD3FaE76498e7E4CcAA

delta.money
Phishing for keys with POST /api/auth/generate_info
https://urlscan.io/result/34e77b3c-a8f9-4bb7-b199-27259f4d158e/

coinsupergive.live 
Trust trading scam site
https://urlscan.io/result/3518e07a-afd1-4f81-9079-d5722d9380c1/
https://urlscan.io/result/068290b9-de6a-4d7c-83c7-31929c1ad0d8/
address: 0x9d79AeEce49694B01B2d2A44Ba2c240De48959C9

ethers-claim.com
Trust trading scam site
https://urlscan.io/result/94822477-9469-41d7-89be-509ca5903d6c/
address: 0xA3eFA3aEB27711B51b8bd12D8BF0885D4949F065