### PR TITLE
etcvwallet.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -421,6 +421,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "bitmartpro.live",
+    "etcvwallet.com",
     "coinibase.pro", 
     "myetherwallet-ne.space", 
     "trezor-sales.online",


### PR DESCRIPTION
etcvwallet.com
Fake ETCV wallet phishing for keys with POST /api - reported address: 0x144826ded37a161f4d0aa7e5884131750022703c
https://urlscan.io/result/44deccff-e384-434b-95f5-a850bb4d6ef4/
https://urlscan.io/result/cb6a6411-54f4-4e77-9004-e80c3efbe0f3/

telegra.ph/Manual-unblocking-procedure-for-block-of-transaction-due-to-jam-on-mempool-01-09
Fake announcement from dx.exchange to phish funds
https://urlscan.io/result/5a0ce984-dca6-435b-92e4-d6fb3c5a1c7f/
address: 0xd808259Ca07fdF4d8Fa825c4704f624352e2Dc14