### PR TITLE
wallet.bancor.network.xbancor.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -423,6 +423,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "wallet.bancor.network.xbancor.online",
+    "xbancor.online",
     "23423myetherwallet.site",
     "33333myetherwallet.site",
     "44332myetherwallet.site",


### PR DESCRIPTION
wallet.bancor.network.xbancor.online 
Fake Bancor wallet phishing for keys with POST /javascript.php
https://urlscan.io/result/906d5b80-e8c9-405b-b3d6-f6366c17a66b