### PR TITLE
ethereumcv.io + ethereumcv.info

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -423,6 +423,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "ethereumcv.io",
+    "ethereumcv.info",
     "ethnowawallet.com", 
     "myetherwallet-dfz.space", 
     "sdf34myetherwallet.site",


### PR DESCRIPTION
ethereumcv.io
Linking users to a phishing wallet https://ethereumcv.io/
https://urlscan.io/result/e07c38cb-ea8e-45b3-8bc5-573f164a3398/

ethereumcv.info
Scamming users for ETH
https://urlscan.io/result/ae7be8ac-3108-411f-a637-c19a7386d039/
https://urlscan.io/result/241e0b96-24a3-4ae4-99a1-17c50bece295/
address: 0x237abde05ac2f992a44436bfee8b3219a329c5a0