### PR TITLE
betabindex.com + bitmrtpro.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -423,6 +423,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "betabindex.com",
+    "bitmrtpro.com",
     "bonus-stellarterm.com",
     "coinbvse.com",
     "dex-hbiglobal.info",


### PR DESCRIPTION
betabindex.com
Trust trading scam site
https://urlscan.io/result/fe24c040-142f-4bd9-9e3c-2cadcf07c763/
https://urlscan.io/result/30416096-6c53-43bd-aae9-70f5482636df/
address: 3Atw5T74MLwzYoMht8T4CK6yVibngwkRjk

bitmrtpro.com
Trust trading scam site
https://urlscan.io/result/929a366b-cfd2-4aa6-bb53-df1059cdd645/
https://urlscan.io/result/e4e7eade-f60e-4d8a-8f65-0ef03ec2bade/
address: 0x870691B57198f065530e90F8e98c70D0BD545e3E