### PR TITLE
Added faceusd.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -423,6 +423,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "faceusd.com",
     "tokenshops.online",
     "janbinancexrp.blogspot.com",
     "janbinance.blogspot.com",


### PR DESCRIPTION
Attempts to mislead people into believing it is Facebook. Requires submitting KYC documents/creating profiles. These can be used to create fake accounts on other exchanges/websites in order to launder funds.

https://urlscan.io/result/dc659205-ab61-428a-a88f-d5de154173cc