### PR TITLE
btc-promo.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -423,6 +423,10 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "client-wavesx.com",
+    "btc-promo.net",
+    "waves-x.com",
+    "etcv-wallet.co",
     "faceusd.com",
     "tokenshops.online",
     "janbinancexrp.blogspot.com",


### PR DESCRIPTION
btc-promo.net
Trust trading scam site
https://urlscan.io/result/174696f7-93ea-46c5-9b7e-8e4196ee8eb4/
https://urlscan.io/result/99723685-b931-43e9-896a-7bc7c141dd03/
https://urlscan.io/result/e7bc9d2c-c5d2-4240-8272-8a2c63e72b9c/
address: 1AHkrJ55mxbUBEe1bn5MQNzH1sP8zSuKqS 
address: 0x9145Cb518FD02877FE8efA077c3EAd95235fDA22

waves-x.com
Fake waves project linking to client-wavesx.com that is stealing seed phrases
https://urlscan.io/result/0731dcc7-b3dd-4826-9518-579e99e27f7a/

etcv-wallet.co
Fake Ethereum wallet phishing for keys with POST /send.php
https://urlscan.io/result/5bc06a22-0ca5-4680-83a5-d45ec091550e/