### PR TITLE
bttlaunchpad.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -423,6 +423,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "airdropcampaign.com",
+    "bttlaunchpad.com",
     "client-wavesx.com",
     "btc-promo.net",
     "waves-x.com",


### PR DESCRIPTION
bttlaunchpad.com
Trust trading scam site
https://urlscan.io/result/2ce24d5c-92b2-4ce8-96d9-93384e429416/
https://urlscan.io/result/04868730-60b5-43da-9f93-9ce5e62ad1e7/
https://urlscan.io/result/bbf1e3f7-b706-46d7-8a9f-c9558600e422/
address: 0x8324676C7cd3a99391d1D69ce3d8A7c2b51c1f59
address: 3BgCXqtL8uh54XfB6TSbRkrA7dryBdSjA6