### PR TITLE
dexchainlaunchpad.com + xpro.icu

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -423,6 +423,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "dexchainlaunchpad.com",
+    "ethgws.com",
+    "xpro.icu",
     "airdropcampaign.com",
     "bttlaunchpad.com",
     "client-wavesx.com",


### PR DESCRIPTION
dexchainlaunchpad.com
Trust trading scam site
https://urlscan.io/result/93eac2a9-43ef-47b2-91e6-dff1084c2366/
https://urlscan.io/result/f227cf58-458e-46ae-b722-10fb4c61767e/
address: 0x603aB01878daEa6fa97bC7a02A6A4E6D6f52205c
address: 3Arwa1yebdbajQNyEMEE3Y4fCy4tGhGGZQ

xpro.icu
Trust trading scam site
https://urlscan.io/result/13a1a186-5a16-4215-b626-eb18dd619840/
https://urlscan.io/result/dfcddbc0-6666-4b48-9f4d-596dfc3e644a/
address: 0x0DcfE28d5fF99290dad01b592BD46e1DE8c5bBf0