### PR TITLE
ltcpro.live + ltcpro.xyz

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -423,6 +423,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "ltcpro.live",
+    "ltcgiveaway.com",
+    "ltcpro.xyz",
     "dexchainlaunchpad.com",
     "ethgws.com",
     "xpro.icu",


### PR DESCRIPTION
ltcpro.live
Trust trading scam site
https://urlscan.io/result/cba0573b-f0e1-4854-9cef-fc906e9bd940/
https://urlscan.io/result/4cc760e8-2a31-4ef9-9661-3e19a2b3c5b1/
address: MMdDAFeUu7saKRZKzy6H855jp5sWvP7zUp

ltcpro.xyz
Trust trading scam site
https://urlscan.io/result/e0c5b202-019b-422a-9209-9385bbb329a1/
https://urlscan.io/result/32cdde11-3c08-4c75-8e62-38ffab8e9ce7/
address: MU1X2NuRCPC43h71KKLns3gve6Ust9Zghe

----

get-eth-now.online
Trust trading scam site
https://urlscan.io/result/e05c31f8-31b2-4748-9cc7-f505bf49ef56/
address: 0x1a8479634bA4f57533b48719f9d2b20c5fCDFa9D