### PR TITLE
doublebitcoin.cc + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,10 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "doublebitcoin.cc",
+    "double2btc.top",
+    "trondiscount.com",
+    "hydrowallet.io",
     "ltcpro.live",
     "ltcgiveaway.com",
     "ltcpro.xyz",


### PR DESCRIPTION
doublebitcoin.cc
Trust trading scam site
https://urlscan.io/result/8d848c4b-0e48-4c56-a1d4-48bc99863da5/
https://urlscan.io/result/832ac89b-8ac9-4507-bad5-9a4f5f94f727/
address: 3FVJwsWDYntJ5ZMDeHoRCHjeiDDeuqsp5P

trondiscount.com
Fake trx/btc exchange & hosting private key phishing POST /vechain/mailer.php
https://urlscan.io/result/b8a422a1-be4a-4674-a679-180a1c2b5f47
https://urlscan.io/result/f8403d67-f2f2-44cd-b995-b803150c21e1/
https://urlscan.io/result/1bc71d7f-3b3b-4863-abc9-1d3d1082e508/
https://urlscan.io/result/5b489413-7b93-4828-88ee-8ed975991e03/
address: 1K7oEhhW8brUxMZrD4wYKcPLSnPYUgjs29  (btc)

hydrowallet.io
Fake Wallet phishing for keys with POST /api/v1.php
https://urlscan.io/result/20fdcd17-7e24-4945-b862-665ea158c35b/