### PR TITLE
eloncity.sale + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,10 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "binancegiveaways.com",
+    "eloncity.sale",
+    "mana-gift.com",
+    "digitexfutures.site",
     "localbitcoins.com.support-ticket-report.com",
     "paxful.co.in",
     "paxfulwallets.com",


### PR DESCRIPTION
eloncity.sale
Fake ElonCity crowdsale site
https://urlscan.io/result/237088f9-a3ee-446a-933c-62a3bc23e7e9/
https://urlscan.io/result/c7bf3b6e-298a-4c2d-8b65-b51b789c1946/
address: 0xA82E2B7EE7c92d6062db14de092A4838a816b1f0

mana-gift.com
Fake Decentraland giveaway (fake MANA contract)
https://urlscan.io/result/bd09f1da-51bd-432b-add0-c9f124791a21/
https://urlscan.io/result/bce15e47-f63d-4600-a2c3-962fbb0989d6/
address: 0x65440e4CE8a9a596a20EC8f910DfC8b1a20c5f7a

digitexfutures.site
Fake airdrop phishing for keys with POST /sign.php
https://urlscan.io/result/0d1cb8a2-f3a6-4b74-b659-a6f6d2f7466d/
https://urlscan.io/result/616dd778-77bd-4e64-9f53-416eef649971/
https://urlscan.io/result/fd1a20fe-5281-4e10-9ef4-a94b80d425b1/