### PR TITLE
investmentdoubler.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "investmentdoubler.online",
     "bttpromo.github.io",
     "bittorrentpromo.github.io",
     "binancedexg.com",


### PR DESCRIPTION
investmentdoubler.online
Trust trading scam site - btc doubler
https://urlscan.io/result/5a3de078-ce8f-4950-aae4-26f452475da3
https://urlscan.io/result/eec085ab-16e0-4195-956d-56dd2fe31691
address: 1Ly3S2qsQgzAKPqkL8CXhiM7gozhqmSh47