### PR TITLE
bttpromotion.github.io + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "bttpromotion.github.io",
+    "telos-foundation.io",
+    "binancegive.com",
     "ethereum-advanced.com",    
     "investmentdoubler.online",
     "bttpromo.github.io",


### PR DESCRIPTION
bttpromotion.github.io
Fake Tron/Bittorrent promotion
https://urlscan.io/result/2ea68909-d513-4a7e-b118-76236172ecf8
https://urlscan.io/result/80ed833b-cfd0-479d-ba0b-cc6ee545fc82
address: TXRMhqQjhG5tauwP2XPdspWdKsJm5qh81e
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2840

telos-foundation.io
Fake Telos foundation
https://urlscan.io/result/1e332137-378a-4c16-804f-6d26cd1951fb/
https://urlscan.io/result/30c354db-4d33-49eb-9874-7ac4e9cb19d5

binancegive.com
Trust trading scam site
https://urlscan.io/result/eeb3055e-9c15-46d6-9964-27f188fed12d/
https://urlscan.io/result/d7cfac9d-2b84-47b6-8417-dd22a0d93c5c/
address: 0x2f8debdCF62eB537871dAEDe11F790D84DDF35cf