### PR TITLE
idexgroup.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "idexgroup.online",
     "bttpromotion.github.io",
     "telos-foundation.io",
     "binancegive.com",


### PR DESCRIPTION
idexgroup.online
Fake MyEtherWallet phishing keys with POST /bot/bot.php
https://urlscan.io/result/5e13b9fc-67c8-46da-afbb-52600d0c9e83
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2842