### PR TITLE
airdropxrp.blogspot.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "airdropxrp.blogspot.com",
+    "cryptoback.top",
+    "cryptogene.net",
     "buteringift.com",
     "quick2xbtc.com",
     "doublecrypto.ml",


### PR DESCRIPTION
airdropxrp.blogspot.com
Trust trading scam site
https://urlscan.io/result/6930c402-f8a5-4a99-a6c0-c8a2cb176276/#summary
address: rGD1q9qfHd9gYbm9VUdcBXjumAaMZen8tr (xrp)

cryptoback.top
Linking users to a malicious browser extension (id: gampoaejpomkjegbfogebhdkfhacelod)
https://urlscan.io/result/382f9690-b58e-4df2-8f76-d09ebda34e6c/

cryptogene.net
Linking users to cryptoback.top and land on malicious browser extension (id: gampoaejpomkjegbfogebhdkfhacelod) - linked addresses are deposit addresses for the exchange
https://urlscan.io/result/27970e62-1e4f-43b6-8ca4-e0d05af3b19b/
https://urlscan.io/result/3c2de02f-5cc0-46d8-a3c1-4f7bac8a9a63/
address: 3Kdk3socys5sc9omQFewsB9jdsA3hnxXTi
address: 0xEe18e156a020F2b2B2DcdEC3A9476E61fBDE1e48

---

ethereumcv.io
Reported address: 0xe6BF49E5BA7787A3550BE485f074EC07F9c86403