### PR TITLE
circlemix.io + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "circlemix.io",
+    "jancrypto.blogspot.com",
+    "wallet-support.com",
     "airdropxrp.blogspot.com",
     "cryptoback.top",
     "cryptogene.net",


### PR DESCRIPTION
circlemix.io
Trust trading scam site - btc doubler
https://urlscan.io/result/411be7a4-f49a-4221-920a-ca371a372a49
https://urlscan.io/result/64b3ef01-91e2-4ec9-8686-4fb937c10f58
address: 33XkXTi4cPW8M3uoDYJDkPHXHZs6wVFJ6U

jancrypto.blogspot.com
Trust trading scam site
https://urlscan.io/result/0f113c1e-f3a3-4321-9777-3549eefb89b7/
address: 0x55B775Ea2CA493c082F3e17A8433e4D220FBB8d8

wallet-support.com
Hosting fake support channels for exchanges (1-844-455-0666) Twitter ID: 1077133359707500546
https://urlscan.io/result/aba63131-1aee-4d08-beb3-c49f4aa122eb/
https://urlscan.io/result/a7b71451-e9c5-4356-9e1b-0f0d4608af11/