### PR TITLE
cryptoexcoins.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "cryptoexcoins.com",
+    "bitcoin-generator.network",
     "ethtokens.store",
     "xn--bttorrent-54a.com",
     "btcaim.com",


### PR DESCRIPTION
cryptoexcoins.com
Reported fake exchange - very insecure. Blacklisting for user security - https://twitter.com/sniko_/status/1090022435116732416
address: 3QNP28LkQqsC9nVG5aothDF6oj7jixHi3Z (btc)
address: 0x5018a34c512a092a8620dea08fd0f078c71f7d92 (eth)
address: qq6qzcaphg3ygysue8lawxan5khscskgwcc6fywx7a (bsv)
address: t1R2tWtBWr7Us5PSXoLJZgEPoxPbNL8uk5C (zec)
address: 0x5d09a152f788dad9ee09a04cc8d7d933713e9cb0 (E2C)

ethtokens.store
Fake MyEtherWallet phishing for keys with POST /bot/bot.php
https://urlscan.io/result/ccaad918-59f2-4890-a4d7-603e4a1c0552/

bitcoin-generator.network
Fake Bitcoin generator (trust trading)
https://urlscan.io/result/dc7fb829-1d28-4a54-96d5-db1d54737181
address: 1GjvX7WnKTHTx1eWqjTz5b2af1huXmpyst