### PR TITLE
xllwallet.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "xllwallet.com",
     "idexmarket.website",
     "cryptoexcoins.com",
     "bitcoin-generator.network",


### PR DESCRIPTION
xllwallet.com
Fake XLM fork phishing for keys with POST /
https://urlscan.io/result/345598be-64f5-44df-9bb7-854cad29c1ec