### PR TITLE
myetheresswallet.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "myetheresswallet.com",
+    "bitaeon.top",
+    "btrmartgve.com",
     "stellar-lightning.org",
     "xllwallet.com",
     "idexmarket.website",


### PR DESCRIPTION
myetheresswallet.com
Fake MyEtherWallet phishing for keys with GET /en/c.php?data=xxx
https://urlscan.io/result/909ed882-ac1b-41fe-b403-6e1a9bd0093f/

bitaeon.top
Fake BitAeon phishing for logins with POST /send.php
https://urlscan.io/result/97140333-cd7f-4790-967d-59e09013d3fd/
https://urlscan.io/result/db5f4e19-cb8a-4da0-ac1c-6422a6dd2d87

btrmartgve.com
Trust trading scam site
https://urlscan.io/result/5cbcea63-dbc7-4b97-ae46-f1592297bff4/
https://urlscan.io/result/70effb7c-4594-4691-808f-602c87660f9e/
address: 0xa1B04A60a35854d0749aE39B0346BCEb55247ecC