### PR TITLE
dexbetalaunch.com + airdropxneo.blogspot.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "dexbetalaunch.com",
+    "airdropxneo.blogspot.com",
     "myetheresswallet.com",
     "bitaeon.top",
     "btrmartgve.com",


### PR DESCRIPTION
dexbetalaunch.com
Trust trading scam site
https://urlscan.io/result/1c9b66ae-8789-495a-a8ee-e7bc34596166/
https://urlscan.io/result/4a2343df-35a9-485a-a78d-f0775147aef4/
https://urlscan.io/result/d3d960be-ac50-4a97-9077-356313412c1e/
address: 0x5B2b8b9c674e67F718BB54Cc62C2a2E13308229c
address: 1MpLjpT44A5yyRbtGG61rtpgwxdJB3onsB

airdropxneo.blogspot.com
Trust trading scam site
https://urlscan.io/result/7cc9f92d-910f-43c9-9607-1c79c1a8c905/
address: ATVMaR3SXKRBtwCNgPjV5k2YzEgzMDYeaf (neo)