### PR TITLE
eth4free.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -424,6 +424,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "eth4free.com",
     "giveaway-x.blogspot.com",
     "etherchange.tech",
     "claim-xyotokens.com",


### PR DESCRIPTION
eth4free.com
Trust trading scam site
https://urlscan.io/result/cb5db62b-1cd0-4529-b223-7acbe903ef9a/
address: 0x839BaaCA91Cbcf6c1632c55E1AE031C6B270df19