### PR TITLE
myetherwallet.com-7da3a890-214u-23c1-14a19-87536g0f4cd4.site + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -431,6 +431,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "myetherwallet.com-7da3a890-214u-23c1-14a19-87536g0f4cd4.site",
+    "myetherwallet.com-7da3a890-214u-23c1-14a19-87536g0f4cb2.site",
+    "bittorrent.foundation",
     "getfree-neo.blogspot.my",
     "getfree-neo.blogspot.com",
     "binjerseygbpeur.com",


### PR DESCRIPTION
myetherwallet.com-7da3a890-214u-23c1-14a19-87536g0f4cd4.site
Fake MyEtherWallet phishing for keys with POST /mail-area2.php
https://urlscan.io/result/3e257e39-dfa4-4499-b4e0-863136daf1f1/

myetherwallet.com-7da3a890-214u-23c1-14a19-87536g0f4cb2.site
Fake MyEtherWallet phishing for keys with POST /mail-area2.php
https://urlscan.io/result/51bca8ed-beb4-4baa-b3b2-11982d4883e8/

bittorrent.foundation 
Trust trading scam site
https://urlscan.io/result/979afd5e-5e40-46b3-b30d-086fcc8833b9
https://urlscan.io/result/5a179820-968a-4af1-baaa-9ecaeca0eaa0
address: TDLcipJPJMT6iCFava8B9A1gGiKJvBRWzn (trx)
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2875