### PR TITLE
electrumofficial.com + privatstuff.store

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -431,6 +431,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "electrumofficial.com",
+    "privatstuff.store",
     "ttrxtrx.blogspot.com",
     "xrpxrp.blogspot.com",
     "ldex-market.pro",


### PR DESCRIPTION
electrumofficial.com
Fake Electrum site - https://www.virustotal.com/#/url/4868b87b5b30b2e3a1de9d0fb498f0371767a1e360745778efd2d2cde376a0b7/detection
https://urlscan.io/result/02912186-187f-412d-8d63-46a4fbda3db2/
https://urlscan.io/result/31e94fa9-194b-4b58-b26a-137e6a90cd80/

privatstuff.store
Fake Electrum site - https://www.virustotal.com/#/url/fe7cccd4ce81743b377ad31fdeacc5dc7bcf112382fa656fa6f36d2b9e9dc8e4/detection
https://urlscan.io/result/5a1c590e-20cd-4ae4-8ef2-5457ce210ff2/
https://urlscan.io/result/7b6803ab-4ff6-443c-8460-b0382c19dd64/