### PR TITLE
spacex.promo + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -431,6 +431,15 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "spacex.promo",
+    "paxful.com.ru",
+    "electrumbase.com",
+    "electrumcore.net",
+    "electrumapps.com",
+    "xn--blckchin-eza9o.com",
+    "idexxmarket.site",
+    "idexmarkt.store",
+    "get2802lumens.online",
     "electrumofficial.com",
     "privatstuff.store",
     "ttrxtrx.blogspot.com",


### PR DESCRIPTION
spacex.promo
Trust trading scam site
https://urlscan.io/result/c9dc5c75-3982-4bf4-a46b-5db694203243/
https://urlscan.io/result/0d380b2c-c9a6-429e-91db-6ec5ed23b141/
address: 0x7c8545ca937767362e5CC348616FfE9061Ebb78F

electrumbase.com
Fake Electrum site
https://urlscan.io/result/93226bc9-4e66-4d9f-b3d2-885a4cc8825b/

electrumcore.net
Fake Electrum site
https://urlscan.io/result/2fd2759b-de8c-473a-a511-292dac5755b0/

electrumapps.com
Fake Electrum site
https://urlscan.io/result/43d1f844-bb93-4795-bf0d-660c0182e316/

get2802lumens.online
Fake Stellar lumans giveaway phishing for keys with POST /1.php
https://urlscan.io/result/05551a06-5669-42b6-b08a-ee0f42533e95/