### PR TITLE
rnuathervvalfet.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -431,6 +431,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "rnuathervvalfet.com",
     "spacex.promo",
     "paxful.com.ru",
     "electrumbase.com",


### PR DESCRIPTION
rnuathervvalfet.com
Fake MyEtherWallet phishing for keys with POST /eth
https://urlscan.io/result/190cfdec-4fe0-499b-bdff-ef1a41df3b18/