### PR TITLE
electrumupgrade.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -431,6 +431,11 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "electrumupgrade.org",
+    "wwwmycrypto.com",
+    "coindesk.me.16640.aqq.ru",
+    "electrumdownload.com",
+    "ldexmarket.com",
     "ldex.exchange",
     "bittrex-m.com",
     "rnuathervvalfet.com",


### PR DESCRIPTION
electrumupgrade.org
Fake Electrum site
https://urlscan.io/result/a840554b-3958-496d-b15b-850fca2ae146/

electrumdownload.com
Fake Electrum site
https://urlscan.io/result/fa785e0e-3dda-49db-a784-0e2be8842051/

ldexmarket.com
Fake Idex Market phishing for keys with GET /c.php?data=xxx
https://urlscan.io/result/9162af61-3937-4271-954d-f0e8cc4835c5/