### PR TITLE
enjin.pro + tronxcash.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -431,6 +431,9 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "enjin.pro",
+    "tronxwallet.com",
+    "tronxcash.com",
     "electrumupgrade.org",
     "wwwmycrypto.com",
     "coindesk.me.16640.aqq.ru",


### PR DESCRIPTION
enjin.pro
Fake airdrop phishing for keys with POST /sign.php
https://urlscan.io/result/cac3684c-1488-4125-98b4-4c4711d1cc39/
https://urlscan.io/result/51f1ac14-c9ce-414f-b749-ab4c80849c4b/
https://urlscan.io/result/64c06f2a-2c35-4aaf-ae27-9700ab32bf85/

tronxcash.com
Fake exchange - see cryptoxwallet.net
https://urlscan.io/result/c5b49075-ff25-4baa-91be-c4ff932f16e0/
address: 3832HHXdLGBDeHWjE7VkFmWnjeJhAXAYQ2
address: 0xEe18e156a020F2b2B2DcdEC3A9476E61fBDE1e48