### PR TITLE
unfreeze-paxful.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -431,6 +431,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "unfreeze-paxful.com",
+    "rnuetharwallet.com",
     "bintrx.blogspot.com",
     "bin-ance.blogspot.com.tr",
     "binaxrp.blogspot.com",


### PR DESCRIPTION
unfreeze-paxful.com
Fake Paxful phishing for logins with POST /post.php
https://urlscan.io/result/4524f97e-6938-4842-ba2c-d6965a478409/
https://urlscan.io/result/bcddd030-db3f-40b6-b72b-5b62ae05618f

rnuetharwallet.com
Fake MyEtherWallet phishing for keys with POST /eth
https://urlscan.io/result/181433f6-b155-4469-bbff-53d2903e4298/

---

spacex.promo
Trust trading scam site
https://urlscan.io/result/6936756c-1765-4b70-9e53-64a6bb45db67/
address: 0xf33142f5bb228516f93e4267fb5a7241dc241614