### PR TITLE
binanxrp.blogspot.com + binannn.blogspot.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "binannn.blogspot.com",
+    "binanxrp.blogspot.com",
     "unfreeze-paxful.com",
     "rnuetharwallet.com",
     "bintrx.blogspot.com",


### PR DESCRIPTION
binanxrp.blogspot.com
Trust trading scam site
https://urlscan.io/result/13e8ae8a-2816-4f57-9f2c-b3fd78d6570a/
address: rne6bY8h8SFEdvSezLADvVDfTiAcVov6js (xrp)

binannn.blogspot.com
Trust trading scam site
https://urlscan.io/result/2c546991-e024-4410-8ab9-c41616343d5b/
address: 0x55B775Ea2CA493c082F3e17A8433e4D220FBB8d8