### PR TITLE
electrumweb.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,10 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "electrumupdate.com",
+    "electrumweb.net",
+    "vintage-myetherwallet.com",
+    "wedderbergen.com",
     "myetherwallet.com.access-wallet.info",
     "access-wallet.info",
     "electrumfix.com",


### PR DESCRIPTION
electrumweb.net
Fake Electrum - malware clone of Electrum - reported address: bc1qhsrl6ywvwx44zycz2tylpexza4xvtqkv6d903q
https://urlscan.io/result/202e38d9-8674-49cc-8088-1814d92177e2/

electrumupdate.com
Fake Electrum - malware clone of Electrum - see https://blog.coinbase.com/electrohunt-part-1-hunting-for-the-phishing-campaigns-on-the-electrum-network-b10529162e63
https://urlscan.io/result/93685275-5ba4-4138-9368-801465df80b9/

vintage-myetherwallet.com
Fake MyEtherWallet phishing for keys with GET /c.php?data=xxx
https://urlscan.io/result/a8ec302d-21c4-4b23-a5dd-e428e600e7ea

wedderbergen.com 
Fake MyEtherWallet phishing for keys with POST /eth
https://urlscan.io/result/21ba6de7-07b8-4324-bcf5-25ab7d70df28/