### PR TITLE
rnuethervvallet.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "rnuethervvallet.com",
     "electrumupdate.com",
     "electrumweb.net",
     "vintage-myetherwallet.com",


### PR DESCRIPTION
rnuethervvallet.com
Fake MyEtherWallet phishing for keys with POST /eth
https://urlscan.io/result/f00a2965-6ec0-49fe-badd-208b29bb31b3