### PR TITLE
binanceee.blogspot.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,12 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "binanceee.blogspot.com",
+    "binanceee.blogspot.lt",
+    "binanceee.blogspot.com.mt",
+    "paxful.log-iin.com",
+    "log-iin.com",
+    "myehlerwal.com",
     "atomcwallet.com",
     "atomcwallet.club",
     "atomswallet.co",


### PR DESCRIPTION
binanceee.blogspot.com 
Trust trading scam site
https://urlscan.io/result/8fe248da-7c65-42bd-89f5-9637fa69aeac/
address: rnFBiAHT8yZ5PL6QbvzUr5dM7Kq6G9gPGo (xrp)

paxful.log-iin.com
Fake Paxful phishing for logins with POST /temp.php
https://urlscan.io/result/92b27708-39fd-4e5a-b091-f47829051b7c