### PR TITLE
rntherwallet.xyz

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "rntherwallet.xyz",
     "xrpbinan.blogspot.com",
     "musk.credit",
     "musk.fyi",


### PR DESCRIPTION
rntherwallet.xyz
Fake MyEtherWallet phishing for keys with POST https://smtpjs.com/v2/smtp.aspx? (emails to davidwatson00712345@gmail.com)
https://urlscan.io/result/7b3b1e33-a53f-4799-bb75-ff5193f9b420/

![image](https://user-images.githubusercontent.com/2313704/53210680-93f5bc80-3636-11e9-8c07-8a0efaee26ca.png)
