### PR TITLE
electrum.org.uk + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,11 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "electrum.org.uk",
+    "rnyuthevallet.xyz",
+    "fetch-ai.net",
+    "paxfull.ga",
+    "musk.center",
     "telegram.systems",
     "fetchai.co",
     "fetchai.org",

--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "bttairdrop.com",
     "electrum.org.uk",
     "rnyuthevallet.xyz",
     "fetch-ai.net",


### PR DESCRIPTION
electrum.org.uk
Fake Electrum site - https://www.virustotal.com/#/url/65ec39474cfe0827c87a650cf885552101a78f52aa3a8b30e37ccd5ac2bbf8ff/detection
https://urlscan.io/result/0195e96b-775c-4275-9cfd-8025e981b263/
https://urlscan.io/result/38ed73af-47e3-4fb7-b4de-b3b01b7aa283/

rnyuthevallet.xyz
Fake MyEtherWallet
https://urlscan.io/result/f757caf8-d5ff-4c7d-86d4-293f1da2aaf4/

fetch-ai.net
Fake FetchAI crowdsale site
https://urlscan.io/result/81b6abd3-32e7-41b0-ad74-f6bdab01857f/
address: 1BzSWghdNus1FMF55HSAMdo1u3s76Uc2aw
address: 0x56d0644c14745db2d2cE0De5c5BEf914CedC1aEa

paxfull.ga
Fake Paxful phishing for logins with POST /index.php
https://urlscan.io/result/f5f7dbb6-2ea9-495c-bd0a-86ff6ea0161a/

musk.center
Trust trading scam site
https://urlscan.io/result/5fc0f4af-c26d-472e-afa0-03d32ef28b9a/
https://urlscan.io/result/09d2e3ce-1a9d-4efd-9b1a-8abc260f5e0c/
https://urlscan.io/result/53e96b06-8713-40f2-ab61-5ffac2a2b12f/
address: 0xF34bDF2c9057b186499A7BC8aFad1629c808e263
address: 15MVbkG7SRXa49wZ9r3eQGtKTyYwroMcqh

bttairdrop.com
Fake airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/030ba17b-e4d2-4be3-b717-cbb4ef26770f
https://urlscan.io/result/3f1c6d82-931b-4e93-976e-afff08e9e4ab
https://urlscan.io/result/6316a8a1-d405-49de-ad19-d4630df60c80
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2921