### PR TITLE
paxfultrade.xyz + fetchai.eu

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "paxfultrade.xyz",
+    "fetchai.eu",
     "bitcoin-update.info",
     "brad-promo.info",
     "rnyuthevvallet.com",


### PR DESCRIPTION
paxfultrade.xyz
Fake Paxful phishing for logins with POST /login.php
https://urlscan.io/result/d65c8e98-45e1-4b78-80ae-27c9be820b1e

fetchai.eu
Fake FetchAI crowdsale site
https://urlscan.io/result/d78137ae-dbfc-4233-95f7-18ec884d4ad2/
https://urlscan.io/result/2455d387-cd9f-4283-8964-43276271be44/
address: 0x56d0644c14745db2d2cE0De5c5BEf914CedC1aEa
address: 1BzSWghdNus1FMF55HSAMdo1u3s76Uc2aw