### PR TITLE
monero-rings.org + myxrmwallet.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,8 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "monero-rings.org",
+    "myxrmwallet.com",
     "rnyuthewallet.xyz",
     "heuvellandcatering.com",
     "vlntage-myetherwallet.com",

--- a/src/config.json
+++ b/src/config.json
@@ -437,6 +437,7 @@
     "etherspin.co"
   ],
   "blacklist": [
+    "binance-testnet.site",
     "monero-rings.org",
     "myxrmwallet.com",
     "rnyuthewallet.xyz",


### PR DESCRIPTION
monero-rings.org
Linking users to a fake web wallet (https://myxrmwallet.com/) phishing for keys
https://urlscan.io/result/e57087ea-f006-4eae-b6f2-da8acd05f554/

myxrmwallet.com
Fake web wallet phishing for keys with POST /
https://urlscan.io/result/c53ed140-9679-4735-b499-3126e25b3406/

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/2934