### PR TITLE
paxfulconfirmation.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -444,6 +444,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "paxfulconfirmation.com",
     "p-eos.one",
     "idex.website",
     "x-crypto.info",


### PR DESCRIPTION
paxfulconfirmation.com
Fake paxful phishing for logins with POST /
https://urlscan.io/result/674b2d74-4701-425d-b645-0423c20bd424/