### PR TITLE
wallet.elitetreum.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -444,6 +444,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "wallet.elitetreum.com",
+    "elitetreum.com",
+    "dogx.dog",
+    "cryptoxinvest.com",
     "paxfulconfirmation.com",
     "p-eos.one",
     "idex.website",


### PR DESCRIPTION
wallet.elitetreum.com
Asking for private keys and sending to the backend via POST /import-wallet and sending it to user email in plaintext
https://urlscan.io/result/82704121-0fc5-4149-af05-155319e7621b

dogx.dog
Fake team - see https://twitter.com/ummjackson/status/1102780962918682624?s=19
https://urlscan.io/result/7553aaa6-4aaf-4dca-9148-bf12d18ccbea/

cryptoxinvest.com
Fake exchange - same kit as crypton-exchange.com
https://urlscan.io/result/aaa9be14-092d-4777-a217-7fb7d7e7b88e/
address: 3NGovcBojWQXjTc1m1YUji6NkuVwZi27i7
address: 0xEe18e156a020F2b2B2DcdEC3A9476E61fBDE1e48

![image](https://user-images.githubusercontent.com/2313704/53996478-73e2f480-4130-11e9-8688-dd9e3e5f2903.png)
