### PR TITLE
huobi-airdrop.org + huobiairdrop.co

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -444,6 +444,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "huobi-airdrop.org",
+    "huobiairdrop.co",
     "electrumcircle.com",
     "l-electrum.org",
     "paxful-dashboard.com",


### PR DESCRIPTION
huobi-airdrop.org
Using fake MetaMask alerts to get users to install a CX coigcglbjbcoklkkfnombicaacmkphcm
https://urlscan.io/result/fd40aced-2b20-46bb-a0e2-966112d86662

huobiairdrop.co
Fake airdrop phishing for keys - https://twitter.com/sniko_/status/1105176682523254789
https://urlscan.io/result/0a8ac7e7-1a15-4674-96c6-aab12db2acc7
https://urlscan.io/result/35caabc4-f5b9-4a3f-90b3-73f219b51f8e