### PR TITLE
huobiairdrop.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -444,6 +444,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "huobiairdrop.com",
+    "get-gift-stellar.org",
+    "ethers-live.com",
+    "forexetoro.com",
     "huobi-airdrop.org",
     "huobiairdrop.co",
     "electrumcircle.com",


### PR DESCRIPTION
huobiairdrop.com
Using fake MetaMask alerts to get users to install a CX coigcglbjbcoklkkfnombicaacmkphcm
https://urlscan.io/result/5ca20875-4a30-4870-a396-83af762c192a

get-gift-stellar.org
Fake Stellar airdrop with POST /kapuyuak.php
https://urlscan.io/result/216817aa-e43c-488c-bed2-9d3d8d90d688/
https://urlscan.io/result/2eee1474-6903-4c95-8e0c-0822f412319d/

ethers-live.com
Trust trading scam site
https://urlscan.io/result/8c5cfe97-be1a-4949-ba7d-808493f232bf/
address: 0xd51B910A21F091995a2fDBc54f8ae2F981506B5f