### PR TITLE
ethersale.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -444,6 +444,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "ethersale.online",
     "huobiairdrop.com",
     "get-gift-stellar.org",
     "ethers-live.com",


### PR DESCRIPTION
ethersale.online
Fake MyEtherWallet phishing for keys with POST /send_private_key.php - redirected via https://bitly.com/senerth+
https://urlscan.io/result/d9b56743-6edb-41d9-b21c-0a026ab5161b/
https://urlscan.io/result/d5d6788b-f50c-4b3e-9fc2-bc66b3f4bc3d/