### PR TITLE
bitcoinvest.tech + bestcdanje.org.ru

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -444,6 +444,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "bitcoinvest.tech",
+    "bestcdanje.org.ru",
     "kraken-login.ml",
     "kraken-login.ga",
     "gram-network.net",


### PR DESCRIPTION
bitcoinvest.tech
Trust trading scam site - fake investment harvesting addresses and emails
https://urlscan.io/result/07b35ad3-c32e-478d-8c3c-ca33411cc73f
https://urlscan.io/result/73932ead-805d-4fd9-8072-bd98d1d2b562/
https://urlscan.io/result/3c5e169e-72d0-4d5b-b42d-2db128accfd7/
https://urlscan.io/result/934683b1-67b5-48a2-8bda-5c2a0aca63dc/

bestcdanje.org.ru
Fake BestChange - reported address 0xe0eEC9b102facC20e299b3adAFB20B5003a4350f
https://urlscan.io/result/87a8ec8d-7ef4-4fed-80cc-c4a6ecfc80ee