### PR TITLE
hmqfoundation.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -444,6 +444,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "hmqfoundation.com",
+    "onixcrypt.com",
+    "ldexmarket.pro",
+    "vintage-metherwallet.co",
     "bitcoinvest.tech",
     "bestcdanje.org.ru",
     "kraken-login.ml",


### PR DESCRIPTION
hmqfoundation.com
Fake HMQ crowdsale site
https://urlscan.io/result/eb0cc621-2006-4872-bc6f-a50972304486/
address: 1LvNgSpd58Dj8oujCJHr9PsVBFch71Y9Me (BTC)
address: 0xc1b439273B8Ba8ab5489d5Ed945F559f90d92988 (ETH)
address: 47v1cXsUdPN6vLeCwzCFAbAw8VjNEoMXSfLMpGkg76z9jPVM1wxxpmmjUvGDxnZQak4TqDM15MPbcPnhMcFu8TXAB6wugV1 (XMR)

onixcrypt.com
Fake exchange. Same kit as firecrypto.info
https://urlscan.io/result/4100abdc-0c7e-49e9-bbfe-123b03fe0cf5/
address: 3Hzp7NVMyBgkPeQHPUNYgBLbaRsuU2eYER
address: 0x8Db2eC6CBE35062A3F30DCBF7F281604820490EE

ldexmarket.pro
Fake Idex phishing for secrets with POST /log.php
https://urlscan.io/result/9c080ba3-d3e8-4294-9c70-a7b5655cc5aa/
https://urlscan.io/result/b97f4bb6-9c7e-4a62-8631-f5ac89cf781d/

vintage-metherwallet.co
Fake MyEtherWallet phishing for keys with POST /sending.php
https://urlscan.io/result/b07c3c3a-7f6c-4cd8-9aa4-00d35db95862/