### PR TITLE
thewayhere.accesshealthautism.com.au

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -444,6 +444,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "thewayhere.accesshealthautism.com.au",
     "hmqfoundation.com",
     "onixcrypt.com",
     "ldexmarket.pro",


### PR DESCRIPTION
thewayhere.accesshealthautism.com.au
Hosting a Bitpanda phishing login - see https://redd.it/b1t0m5
https://urlscan.io/result/7f300849-1707-4c17-9257-4b0e579bcabb