### PR TITLE
eth-private-key.webz.cz + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -444,6 +444,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "eth-private-key.webz.cz",
+    "blockchein.lpgirn.com",
+    "lpgirn.com",
     "thewayhere.accesshealthautism.com.au",
     "hmqfoundation.com",
     "onixcrypt.com",

--- a/src/config.json
+++ b/src/config.json
@@ -444,7 +444,6 @@
     "actua.ad"
   ],
   "blacklist": [
-    "eth-private-key.webz.cz",
     "blockchein.lpgirn.com",
     "lpgirn.com",
     "thewayhere.accesshealthautism.com.au",


### PR DESCRIPTION
eth-private-key.webz.cz
Trust trading scam site
https://urlscan.io/result/3226c9c0-a3cc-48db-b097-3bc9d525dea2/
address: 0xe00e1f7117a69c34694ac1815177c93491fc448f

blockchein.lpgirn.com
Fake Blockchain phishing for logins
https://urlscan.io/result/865cc9f0-1ed7-4bcb-b33f-edecba4df40f/