### PR TITLE
electrumproject.org + idex.money

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -445,6 +445,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "electrumproject.org",
+    "idex.money",
     "celerc.network",
     "kraken-com.ga",
     "exoduswallet.online",


### PR DESCRIPTION
electrumproject.org
Fake Electrum site - https://www.virustotal.com/#/url/180557c8ee08b9dc8bf7b0fa191980c9150e94878260fd8ac686bbd2e704904d/detection
https://urlscan.io/result/01cc8abb-b000-4e6a-88a5-c4beb0556df0
https://urlscan.io/result/c7edf944-4dba-4224-8d91-991b11d8e715/

idex.money
Fake Idex phishing for keys with POST /send_1.php
https://urlscan.io/result/5981655e-d339-4f13-96dc-3de260bfc108/
https://urlscan.io/result/362a8f8f-edfb-4b65-9d98-17a8aa8fba3c/
https://urlscan.io/result/64caa884-b3de-4499-ad96-8bfb7615a74e