### PR TITLE
eth.elon-musk.space + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -445,6 +445,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "eth.elon-musk.space",
+    "btc.elon-musk.space",
+    "elon-musk.space",
+    "rnuathervaltet.com",
+    "rnyetherwaliet.com",
     "celer.work",
     "electrumproject.org",
     "idex.money",


### PR DESCRIPTION
eth.elon-musk.space
Trust trading scam site
https://urlscan.io/result/47a39871-003c-4c57-a516-108bb663499d/
https://urlscan.io/result/e1e7cc42-596b-4a0e-acbe-40426745e08e/
address: 0x18341b373C795736C09BeF6beF09BcEcBA4d27fF

btc.elon-musk.space
Trust trading scam site
https://urlscan.io/result/e944cc48-0e84-4fae-bccd-535d15a899e7/
address: 1B6AHA8G56GaDnothSmUiesBcGW9jnYLN5

rnuathervaltet.com
Fake MyEtherWallet phishing for keys with POST /eth (Google Ad redirected via www.buytelaer.com)
https://urlscan.io/result/d9344c6d-6748-4391-a967-8d50774ff61a/
https://urlscan.io/result/b88f4c15-bd5c-4892-a622-1c156f3ca777/

rnyetherwaliet.com
Fake MyEtherWallet phishing for keys with GET /en/c.php?data=xxx
https://urlscan.io/result/8be3ddf6-4ac6-4b78-8b02-344fbe48d98b/
address: 0x9826cac2a9fc7dd43c6d3713694b20b036895be6