### PR TITLE
usddex.io + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -445,6 +445,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "usddex.io",
+    "mithril.pro",
+    "cryptoxfan.website",
     "wbscoins.com",
     "neotracker.me",
     "gift-wallet-stellar.org",


### PR DESCRIPTION
usddex.io
Token sale of stablecoin, now ghosting everyone
https://urlscan.io/result/d146bb91-9723-493d-ac8d-a2ae4dfeef84/
address: 0xaEa3846E14beC1ba8F562844d39b1215A1D588C6

mithril.pro
Fake airdrop phishing for keys with POST /sign.php
https://urlscan.io/result/a9ac548f-876a-4551-8bac-3f9e8c8e1fad/
https://urlscan.io/result/d977af8c-e309-4feb-bc42-f01073aae2fd
https://urlscan.io/result/d01b4846-9829-417a-8b00-be7e88f03753

cryptoxfan.website
Trust trading scam site
https://urlscan.io/result/b022f4c5-8322-4d4f-95cf-6549e4e9e147/
address: 1L5zxpkAuh5sVx8aoMvLFegf59jk2NSyty (btc)

doubly.io
Trust trading scam site (doubler)
https://urlscan.io/result/769b51f0-3500-4221-9eeb-fc869b2d7490/
address: 3KCqXpZKJUMm1ZDkXDoRbmf6efaj7qaRaZ (btc)
address: 0x0a2020dae40fe0ebe1ad79c9fc692455c962d43d (eth)