### PR TITLE
btcldn.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -445,6 +445,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "btcldn.com",
     "ildexmarket.info",
     "bitcoin-gold-blockchain.info",
     "international-bittrex-login.com",


### PR DESCRIPTION
btcldn.com
Fake exchange
https://urlscan.io/result/386db484-aa4d-4b23-9fc3-52342f8acce1/
address: 3FzwWhqW1MDNxS6AUwX6CPF5RPgodtkYqY (btc)
address: 0x7c9001c50ea57c1b2ec1e3e63cf04c297534bfc1 (eth)
address: LgcoHv7MkESD5EYe6qjJGtA2cse7LeAZnx (ltc)