### PR TITLE
binancecz.blogspot.com + bttorent.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -445,6 +445,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "binancecz.blogspot.com",
+    "bttorent.com",
     "xn--coinbse-en4c.com",
     "your-btc.co.uk",
     "cryptotis.com",


### PR DESCRIPTION
binancecz.blogspot.com
Trust trading scam site
https://urlscan.io/result/3a7203bb-46b5-4a99-b198-7802495aa4a5
address: rnFBiAHT8yZ5PL6QbvzUr5dM7Kq6G9gPGo (xrp)

bttorent.com
Fake Bittorent site (BTT token) harvesting user emails and 0x addresses
https://urlscan.io/result/26122ff0-1554-4e12-9124-a414656794e2/