### PR TITLE
paraetherwallet.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -445,6 +445,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "paraetherwallet.com",
     "binancecz.blogspot.com",
     "bttorent.com",
     "xn--coinbse-en4c.com",


### PR DESCRIPTION
paraetherwallet.com
Fake MyEtherWallet phishing for keys with POST /paramining.php
https://urlscan.io/result/a39c1872-3113-4262-bfb1-7c8723682fce
https://urlscan.io/result/ceb53bd7-aee1-4549-bee3-ae40785f2fc8/loading