### PR TITLE
blogbibox.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -446,6 +446,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "blogbibox.com",
     "binance-testnet.com",
     "earnfreebitcoins.org",
     "myethyogawallclass.icu",


### PR DESCRIPTION
blogbibox.com
Trust trading scam site
https://urlscan.io/result/b973d81e-4387-4b73-a51e-0e616fb5300a/
https://urlscan.io/result/db923ae5-5d99-4078-a30d-b3d9ee769dac/
address: 0x53645080083e0037976455ef903BC88679D1029F