### PR TITLE
coinbase-getcrypto.890m.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -447,7 +447,6 @@
   ],
   "blacklist": [
     "coinbase-getcrypto.890m.com",
-    "890m.com",
     "bithextrade.com",
     "matic.work",
     "xn--bttrx-y3a5604c.com",

--- a/src/config.json
+++ b/src/config.json
@@ -446,6 +446,15 @@
     "actua.ad"
   ],
   "blacklist": [
+    "coinbase-getcrypto.890m.com",
+    "890m.com",
+    "bithextrade.com",
+    "matic.work",
+    "xn--bttrx-y3a5604c.com",
+    "blockchain-130.ru",
+    "binance-testnet.host",
+    "binance-testnet.fun",
+    "binance-dextestnet.site",
     "rnuathervatlet.com",
     "myetherwallet-bonus.info",
     "exodus-support.com",


### PR DESCRIPTION
coinbase-getcrypto.890m.com
Fake Stellar giveaway phishing for secrets with POST /2.php
https://urlscan.io/result/04c085ba-ba08-41f1-9737-773e281de02d/

bithextrade.com
Fake exchange phishing for funds and KYC documents
https://urlscan.io/result/af892d42-4b6b-4db3-9ddc-ba4121b46084/
address: 3DyRE6JHYjHZPkSZPEwAJY3h7RgLgSEpHq (btc)
address: 0xadb2f5aa3ee37bb3900db9919ab5cd8b148b5348 (eth)
address: qq6qzcaphg3ygysue8lawxan5khscskgwcc6fywx7a (bsv)
address: t1R2tWtBWr7Us5PSXoLJZgEPoxPbNL8uk5C (zec)
address: 0x0a5723d1bc889d8f755eb36fcd60483cc8bcf203 (gex)
address: 0x9afa0a129d164323965f3f5bdf5f348897c0a205 (e2c)
address: 0x0a5723d1bc889d8f755eb36fcd60483cc8bcf203 (tch)

matic.work 
Fake Matic crowdsale site
https://urlscan.io/result/87d75025-167a-4556-8007-21736c6d36da/
https://urlscan.io/result/71f65343-bffd-4d6b-a35d-b3ad1c159913/
address: 0xE3D474F3686a831BF380498D1dbd57FDf972CA30