### PR TITLE
myethantiwallcafe.club

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -446,6 +446,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "myethantiwallcafe.club",
     "coinbase-getcrypto.890m.com",
     "bithextrade.com",
     "matic.work",


### PR DESCRIPTION
myethantiwallcafe.club
Fake MyEtherWallet phishing for keys. Suspected address: 0x18ffda6e10338378159411135f78bfa98f18298a
https://urlscan.io/result/b70e9f54-1c31-45c9-9660-d07c34f669c4