### PR TITLE
kucoin-activity.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -446,7 +446,6 @@
     "actua.ad"
   ],
   "blacklist": [
-    "myethantiwallcafe.club",
     "myethschoolclass.pw",
     "kucoin-activity.com",
     "mtc-ico.online",

--- a/src/config.json
+++ b/src/config.json
@@ -446,6 +446,12 @@
     "actua.ad"
   ],
   "blacklist": [
+    "myethantiwallcafe.club",
+    "myethschoolclass.pw",
+    "kucoin-activity.com",
+    "mtc-ico.online",
+    "ethereum2.online",
+    "cryptoempireinc.co",
     "ripplebonus.blogspot.com",
     "idexx.site",
     "myethantiwallcafe.club",


### PR DESCRIPTION
kucoin-activity.com
Trust trading scam site
https://urlscan.io/result/7bc2e956-3b89-44f3-885c-761166473871/
address: 0x6f431A1B6c368cD3ABB7BAcDCf0625D6749F1980

ethereum2.online
Phishing for secrets with POST /send_private_key.php
https://urlscan.io/result/7ffbb6fe-6c91-47ff-ba45-9ecd02234c71/

cryptoempireinc.co
HYIP/daily returns scam (Telegram bot)
https://urlscan.io/result/2f3bc500-1b7e-4ae0-8c70-0ad0caa947cd/