### PR TITLE
digitexfutures.com.claim-token-dgtx.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -453,6 +453,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "claim-token-dgtx.com",
+    "digitexfutures.com.claim-token-dgtx.com",
     "dex-launch.com",
     "dexbetalaunchcampaign.com",
     "bitcoin-btc-adder.com",


### PR DESCRIPTION
digitexfutures.com.claim-token-dgtx.com
Hosting a fake MyEtherWallet phishing for secrets with POST /claim.php - see https://twitter.com/myetherwallet/status/1118207507455889409
https://urlscan.io/result/0820fd82-244d-4659-a745-42e1d01c44e4/
https://urlscan.io/result/18ce2b13-39ca-4ba1-9cce-317adf42d3d2/