### PR TITLE
xrp-ripple.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -453,6 +453,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "xrp-ripple.org",
+    "idex.dev",
+    "get-ltc-now.online",
     "hellogoldcontract.com",
     "the-spectrumnetwork.com",
     "paxfuiverify.info",


### PR DESCRIPTION
xrp-ripple.org
Trust trading scam - linking to a fake explorer - blthomp.com
https://urlscan.io/result/3e1840cc-b209-47ac-b4e0-c98edef54252/
address: rajkbxHzwaA1g3q8CST9hiKUyc9GDLh74u

idex.dev
Fake Idex phishing for keys with POST /key
https://urlscan.io/result/5d3beaa2-97ba-41a7-97d8-77393da95753/
https://urlscan.io/result/95e244ff-d252-4ce1-b300-4ba35bf58105/

get-ltc-now.online
Trust trading scam site
https://urlscan.io/result/983b01aa-c23e-4229-9fda-f66c18dd631f/
https://urlscan.io/result/39863686-6e72-4ebc-bd03-6f15617b7e35/
address: 3E8XidwZPe4BPym7CjqmNPvehetsRV326W (ltc)