### PR TITLE
ripplebounty.blogspot.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -453,6 +453,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "ripplebounty.blogspot.com",
+    "satoshilite.promo",
+    "bitmex-airdrop.com",
+    "localbitcoins-verify.com",
+    "coindecker.com",
     "everex.cash.events-erc-20.com",
     "events-erc-20.com",
     "tokenstore.store",


### PR DESCRIPTION
ripplebounty.blogspot.com
Trust trading scam site
https://urlscan.io/result/e8409a68-832c-41aa-a049-4ccb9af8f6c0/
address: rhTCdpaZQSKbHNYY85xPLMEWQbyxYr4SFY

satoshilite.promo
Trust trading scam site
https://urlscan.io/result/3f37190d-834b-4fd4-a168-4566cb0808d1/
https://urlscan.io/result/4127eb51-6985-4182-b370-a6a9823800a8/
address: 36LrLx1b7q6f2DhAhFxeBAvQxcDs5QY9oj

bitmex-airdrop.com
Trust trading scam site
https://urlscan.io/result/6b5f3f6d-5079-4d7f-bdd5-5bd7f683410b/
https://urlscan.io/result/28b657b2-1d7b-40b1-938e-bccd64544a28/
https://urlscan.io/result/39bc1966-423c-494a-8a13-7897fae389bc/
address: 1Fc8hwQrja8WZpRkyCoPyH7BBLabYFbBdN
address: 0xB9A129D98f67c90C5D788a7B5f6bA780760E17Cb

coindecker.com
Fake Coindesk
https://urlscan.io/result/d2a5c4ef-b951-4c0c-9453-71adb1c3b45a/