### PR TITLE
btc-gift.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -455,6 +455,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "btc-gift.com",
     "bin-testnet.com",
     "4-xrp.com",
     "live-ethers.com",


### PR DESCRIPTION
btc-gift.com
Trust trading scam site
https://urlscan.io/result/ce46540e-e452-4c69-81bd-9c7752170084/
https://urlscan.io/result/8e5ca287-0a83-4e82-af69-b113a882b8ca/
address: 121p6887pfo6Fx1axCapkuvdqHdWMcYKp1