### PR TITLE
coinpromo.fund + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -455,6 +455,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "coinpromo.fund",
+    "bitcoin-btc-qr-code-generator.com",
+    "thundercore.space",
     "xn--mrcatox-bya.com",
     "trustswallet.xyz",
     "electrum.la",


### PR DESCRIPTION
coinpromo.fund
Trust trading scam site
https://urlscan.io/result/fee23e44-bb39-4787-b317-0ce0d1d5ab0b/
https://urlscan.io/result/896ba613-2082-440f-b908-ead2410e2b9b/
https://urlscan.io/result/db282e63-5050-4cc6-8d73-afec361f2569/
https://urlscan.io/result/cb13e2df-b8b7-4e2d-87d7-28bbacb771e9/
address: 1JCMYAkmxibo8EKJWyqtHadCy3NfPJvJwW
address: 0xCb8f90B19E2EB56B1470d97BF9BAB64bF3f4C571
address: rPkuNViVhRCQhHyNgjQaiRTzJqeESTsok3

bitcoin-btc-qr-code-generator.com
Fake QR code generator - https://twitter.com/ercwl/status/1123737265560268806?s=21
https://urlscan.io/result/ac2843c5-2c2e-4e44-8871-0ed5cb533d16/
address: 1HrNjjgtSzdbCEMKwzVQgLuKa3JjF8fSEQ

thundercore.space 
Fake Thunderscore crowdsale site
https://urlscan.io/result/5a8c9199-cfb2-42dc-8ab0-cd3fa7a19660/
address: 0xeb411d5df13ac7020992306e78955fb7cba5f260