### PR TITLE
tesla3.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -455,6 +455,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "tesla3.org",
+    "ethnocrypt.com",
+    "cashadd.org",
     "exmo.in.ua",
     "tesla-gift.space",
     "idexx.pw",


### PR DESCRIPTION
tesla3.org
Trust trading scam site
https://urlscan.io/result/b4ad6012-bee3-4784-92a5-b8f30ed087a4/
https://urlscan.io/result/ff109188-00eb-4024-b702-4230e0b02180/
https://urlscan.io/result/f8273a78-acad-439b-a556-9010b61edebd/
address: 1N2uxuMXP7RmZov8XuB13sUiKcSSAABmVf
address: 0x8BAa4757f0a110dc4E5C365E7376d8449b084d16

ethnocrypt.com
Fake exchange - pointing users to a phishing chrome extension ejhpejjgaimmflepbldndhadecmhfdec
https://urlscan.io/result/8cb54e47-3af6-4535-b165-c564c097c1fc/
address: 3NGtf8AkXN9y8HDp9wks7wbm4by2qxzkmX (btc)
address: 0x4958f1dBcac084a1b92b65F972612cfDc82AeBa0 (eth)

cashadd.org
Pointing users to a malicious chrome extension (id: ejhpejjgaimmflepbldndhadecmhfdec)
https://urlscan.io/result/65017188-299c-4162-a08d-883d238549ef/loading
https://urlscan.io/result/65017188-299c-4162-a08d-883d238549ef