### PR TITLE
ethmarket.store

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -455,6 +455,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "ethmarket.store",
     "btc-pro.co",
     "platform-bitmex.com",
     "constantinoplehardfork.cf",


### PR DESCRIPTION
ethmarket.store 
Fake wallet phishing for keys with POST /send_private_key.php
https://urlscan.io/result/f347e250-66e0-4922-93ea-037649d43eb6/