### PR TITLE
buy7000btc.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -455,6 +455,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "buy7000btc.online",
     "idexmarket.pw",
     "exodus-wallet.net",
     "trezor-wallet.la",


### PR DESCRIPTION
buy7000btc.online 
Trust trading scam site
https://urlscan.io/result/d2929178-4024-4fba-ae1f-d1e6152efdf1
address: 0x46bA8394210EB32e50943bC963E300ED8B804d30