### PR TITLE
receive-ethereum.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -456,6 +456,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "myehtervallet.com",
+    "receive-ethereum.com",
     "goxtrade.com",
     "etbcwallet.com",
     "ildex.pw",


### PR DESCRIPTION
receive-ethereum.com
Trust trading scam site
https://urlscan.io/result/e4a2e62a-f3ae-4dbb-8f30-b47fb3ef67e1/
address: 0x0f746E54EE888E9953aDa918D4bA02AC696b1147