### PR TITLE
binance-margin.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -456,6 +456,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "binance-margin.com",
     "cryptogiveaways.top",
     "lidex.pw",
     "tokensmarket.online",


### PR DESCRIPTION
binance-margin.com
Trust trading scam site
https://urlscan.io/result/08ba4fd9-160e-479a-9d8e-1a318fdc97cf/
https://urlscan.io/result/d62612e4-e4cf-49d4-9d11-ad596815ebb8/
https://urlscan.io/result/d21fec12-60aa-4088-bf63-f3becfff4b1a/
address: 13YacKcXWpeFgEwY3M5EMnZVZn8A84mu5D
address: 0x59CbD436237318F7Cb9C92ddB060b1a023598363