### PR TITLE
tortoken.io + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -456,6 +456,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "tortoken.io",
+    "secure.globalsec.icu",
+    "doublebitcoin.ga",
+    "globalsec.icu",
     "lldex.pw",
     "id-ex.pw",
     "binance-client.com",


### PR DESCRIPTION
tortoken.io
Fake TOR ICO site - https://twitter.com/bcrypt/status/1134598286600368128
https://urlscan.io/result/a3c8103b-f887-4814-bffb-7c5e7f71290a/
address: 0x388Cf3c02c034e7fe8ef164A2B414534fC212119

secure.globalsec.icu 
Trust trading scam site
https://urlscan.io/result/00b34d96-53b9-49a0-870b-433132a7f100/
https://urlscan.io/result/17a9b5dd-2239-4282-b9ba-abd8d09a3036/
https://urlscan.io/result/c0a67e5f-33d6-45de-aafb-0927f6a256e3/
address: 1JCMYAkmxibo8EKJWyqtHadCy3NfPJvJwW
address: 0xCb8f90B19E2EB56B1470d97BF9BAB64bF3f4C571

doublebitcoin.ga
Trust trading scam site - bitcoin doubler
https://urlscan.io/result/256a4c6e-2edc-449d-add6-bb042a7daeda/
https://urlscan.io/result/46181c5b-afb4-4686-a151-171796b77f7b/
address: 1J25YSaUJQT9AdEJ9rmSrKRZhCpc6Wkr7e