### PR TITLE
news-bnb.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -456,6 +456,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "news-bnb.com",
+    "origin.foundation",
+    "cloudtokenexchange.com",
+    "blockchaincomexplorer.z13.web.core.windows.net",
+    "cryptotronx.com",
     "xn--coinbse-dwa.com",
     "no-replycoinbase.com",
     "hmrcmeclaim.com",


### PR DESCRIPTION
news-bnb.com
Trust trading scam site
https://urlscan.io/result/e5c77820-dd6a-4ee5-b4d9-c17f1a7344eb/
https://urlscan.io/result/51ba59f1-8c46-44fe-aaae-956a7e713397/
address: 0xf1c058ae62f2d25efebdd809eedc609cbb9a5090

origin.foundation
Fake ICO harvesting KYC data - see https://bitcointalk.org/index.php?topic=5150358.0
https://urlscan.io/result/0f203fa2-eb3c-4de3-858d-f81ee1421455/

cloudtokenexchange.com
Fake CloudTokenWallet
https://urlscan.io/result/e8cf0ee7-9e0a-4497-9bc5-f683dab38f70/
address: 0xD9D550823C20315D62C1ceE49b93825bA31cEE43

blockchaincomexplorer.z13.web.core.windows.net
Fake blockchain phishing for logins with POST rcreddyiasstudycircle.com/archive_190603_020529/auth.php
https://urlscan.io/result/3509f3c6-1a29-4a82-8751-66d9dd76ae1e

cryptotronx.com 
Fake exchange - linking users to chrome extension peolldddfhhcflcjlaghcnemabfiomch
https://urlscan.io/result/db7a067b-9af7-4147-abd2-5ed658b4a7a1/
address: 1HfkQH6kCCQqrAXU1PtBakPN9Cc1HhgyeM
address: 0xEe18e156a020F2b2B2DcdEC3A9476E61fBDE1e48