### PR TITLE
mcafee.crypto-airdrop.space + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -456,6 +456,14 @@
     "actua.ad"
   ],
   "blacklist": [
+    "mcafee.crypto-airdrop.space",
+    "crypto-airdrop.space",
+    "teslamusk.tech",
+    "58b48d07-110c-487e-8a77-938cfaa8af18.htmlpasta.com",
+    "mcafee-promo.com",
+    "mcafee-crypto.tech",
+    "coin2coin.co",
+    "receive-ethereum.website",
     "com-eth.top",
     "binance.com-eth.top",
     "binance-trade.com",


### PR DESCRIPTION
mcafee.crypto-airdrop.space
Trust trading scam site - directed via buff.ly/2IhEK68
https://urlscan.io/result/f3c994a8-ae4c-424d-acab-40e66b49649e/
address: 0x9a8A61cFb3a3C8dD730fd74CeA1BaC109bC6759F

teslamusk.tech
Trust trading scam site
https://urlscan.io/result/9734fa78-3777-443d-9b8a-a403b50beda9/
https://urlscan.io/result/2ea915ac-fa41-4457-b466-cdf34b707640/
https://urlscan.io/result/d8e5e5d3-92aa-404a-a228-481af0d182c3/
address: 0x5400cff7Aa5537881B305D838a951C3feC123B10 (eth)
address: 15gvRgxdwMF5y3Kcc2X7WLpUMGW9wgyRB4 (btc)

58b48d07-110c-487e-8a77-938cfaa8af18.htmlpasta.com
Trust trading scam site
https://urlscan.io/result/fc5e58fc-b8d3-40a4-88ae-735fc3e939a1/
address: 0x0699B6fEF115D0F684D9d96964876183F11b231A 

mcafee-promo.com
Trust trading scam site
https://urlscan.io/result/8f938be8-9638-4ed5-a436-97144e72e69e/
https://urlscan.io/result/72f4dca7-dd41-4e50-bf81-93db2e841f2d/
https://urlscan.io/result/10692c26-68e3-47d4-a79f-6f50088c4fba/
address: 0x92370e8B926F29038104a1FbaFA024389E753FbE (eth)

mcafee-crypto.tech
Trust trading scam site
https://urlscan.io/result/95850eee-c259-4362-b444-46033bb4fa96/
https://urlscan.io/result/e3220b59-cb9f-4665-afb6-21e7d46eaf71/
address: 15gvRgxdwMF5y3Kcc2X7WLpUMGW9wgyRB4 (btc)
address: 0x5400cff7Aa5537881B305D838a951C3feC123B10 (eth)

coin2coin.co
Fake coin exchange
https://urlscan.io/result/c8d19ed7-111b-4fc4-bd06-7ef7d4300ba7/
address: 16Eyjt8V1bCk2xGqibbRP9HB9fvzjjXQrM (btc)
address: 0x0ea9bc850f78aaeDE66D473F0A8717050db26AC8 (eth)

receive-ethereum.website
Trust trading scam site
https://urlscan.io/result/c7dee36b-d457-4aab-a5f9-334a29cb8118/
address: 0x5Ad418F865540f22bB2e0D2E227cf0e47a1642fb (eth)