### PR TITLE
mediumcdn.today

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -456,6 +456,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "bnb-launch.com",
+    "mediumcdn.today",
     "mcafee.crypto-airdrop.space",
     "crypto-airdrop.space",
     "teslamusk.tech",


### PR DESCRIPTION
mediumcdn.today
Trust trading scam site
https://urlscan.io/result/be902435-0946-442e-9c11-136182614dc7/
address: 0x0CD4ea9B68CEd287Fc25923B071C0b1a0a14e9c6  (eth)

--

receive-ethereum.com
Trust trading scam site
https://urlscan.io/result/ef359e38-7041-4d96-be59-6d571d833dab/
address: 0x86bEC5DAdCDa8F180391F29eF97C7C27a07013e1 (eth)