### PR TITLE
neojune.blogspot.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -456,6 +456,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "blog.decentralized-exchange.org",
+    "decentralized-exchange.org",
+    "neojune.blogspot.com",
+    "medium.bitcoin-gain.org",
+    "bitcoin-gain.org",
     "sf520pk.com",
     "lianjiedu.com",
     "coinexminer.site",


### PR DESCRIPTION
neojune.blogspot.com
Trust trading scam site
https://urlscan.io/result/c6aea971-f1da-4739-8e30-2daff05a7a20/
address: ATVMaR3SXKRBtwCNgPjV5k2YzEgzMDYeaf (neo)

medium.bitcoin-gain.org
Trust trading scam site
https://urlscan.io/result/e8859043-86c8-49f7-b26b-1b42b0724058/
address: 1Q7gS7fi7R26kYRBXEcNeK7f2foi3BfkkE (btc)

bitcoin-gain.org
Trust trading scam site
https://urlscan.io/result/dc3bb261-320a-42d2-b3de-c01e3fec6edb/
address: 1Q7gS7fi7R26kYRBXEcNeK7f2foi3BfkkE (btc)