### PR TITLE
bigclaim.pro

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -458,6 +458,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "bigclaim.pro",
     "electrumus.com",
     "blog.decentralized-exchange.org",
     "decentralized-exchange.org",


### PR DESCRIPTION
bigclaim.pro
Fake EOS airdrop phishing for keys with POST /?
https://urlscan.io/result/396babb2-ec34-4854-b6b7-8118dd009ff0/