### PR TITLE
ecptoken.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -459,6 +459,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "ecptoken.com",
+    "zendesk-bnb.com",
+    "vitalik-gives.website",
     "stopp.com.au",
     "promo-from-buterin.site",
     "bnb-zendesk.com",


### PR DESCRIPTION
ecptoken.com
Ethereum CashPro crowdsale site but hosting a Microsoft phishing kit
https://urlscan.io/result/55853877-9ac1-432c-8acc-a3423fff07d2/
https://urlscan.io/result/a62e251b-922c-4200-a081-1a2be3e2967a/

zendesk-bnb.com
Trust trading scam site
https://urlscan.io/result/605b88c8-dbf8-4bcf-a4a8-0ec952b4461d/
https://urlscan.io/result/4f0a16c9-c300-4af5-bf9d-9c32bae6f09e/
https://urlscan.io/result/42950cd4-737d-4326-9fe8-8cf1828e9b0c/
https://urlscan.io/result/d9e17e8b-7cb1-4310-9984-2aa98cf9eabc/
address: 1CqDpW6FzdTZstondbgUZcjs3g9fTTdp9K (btc)
address: 0x5982F7D33Aa9F9d0192509E58a59dd282c454A05 (eth)
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/3137

vitalik-gives.website
Trust trading scam site
https://urlscan.io/result/baae4046-c972-418c-88bf-4786608c3e51
https://urlscan.io/result/e02bfca7-f650-41af-a244-469d5352eec3/
address: 0x2Ac03b4fc893EB3d29Bb886A16003798DD39A54d (eth)