### PR TITLE
hitbtc.co.ua

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -459,6 +459,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "hitbtc.co.ua",
     "coinbasepro10000.webcindario.com",
     "neojulyx2.blogspot.com",
     "ethdrop.net",


### PR DESCRIPTION
hitbtc.co.ua
Fake Hitbtc phishing for logins with POST /login.php
https://urlscan.io/result/4943ee46-374b-4ca2-84a6-092d3d1620e1/
https://urlscan.io/result/d2b44d2a-1713-450c-94a2-e230da093598/