### PR TITLE
bitcoindrop.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -459,6 +459,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "myetherewallet.io",
+    "giveaway-crypto.tech",
+    "binancepromo-now.online",
+    "bitcoindrop.net",
     "binance-claims.netlify.com",
     "eth-btcpromotion.online",
     "ethcharity.net",


### PR DESCRIPTION
bitcoindrop.net
Trust trading scam site
https://urlscan.io/result/d2dc6e31-6d5a-4c7c-971b-acc26e76a939/
address: 1LUUyyRDP6AjDUJ7D7iG2LA1jPGoTnKamy (btc)

binancepromo-now.online
Trust trading scam site
https://urlscan.io/result/b36fd22e-adb6-41e0-88a8-fbfa5cdceb50/
https://urlscan.io/result/8e27c233-8708-4a7d-bef6-3f64afc52a90/
https://urlscan.io/result/f1294e3e-7277-4f3b-b9a8-5b7f18bc31fd/
https://urlscan.io/result/6d0c6bed-d25a-4807-8ff3-e6adf0c7a528/
address: 0xe33086e461749C687c2DDC3ec4EB24EA591c0dc7 (eth)
address: 1BiyLYjfDNQSP81uvr5gzNW77P2viGWi8m (btc)

giveaway-crypto.tech
Trust trading scam site
https://urlscan.io/result/adb8fc08-18fb-43eb-8314-a50c6cf05c1f/
https://urlscan.io/result/e2240663-35fa-4fd9-9e2e-5272d2c8e65b/
address: 0x6DE7ee53947515Fa163BdcB7e63411449eCe2C82 (eth)
address: 3QiMNzCcMgWEgEavZac9t7NqA4FjN5Do2v (btc)