### PR TITLE
elon-musk.xyz + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -471,6 +471,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "elon-musk.xyz",
+    "bllockchain.tk",
+    "hiltbtc.com",
+    "login.bilockcnain.com",
+    "bilockcnain.com",
     "starkdex.net",
     "mew.starkapp.net",
     "starkapp.net",


### PR DESCRIPTION
elon-musk.xyz 
Trust trading scam site
https://urlscan.io/result/e5269bcd-a21c-46e8-8464-fe34576ae0a0/
https://urlscan.io/result/3c601577-5762-43ae-bf27-e57c5f0f0fd9/
https://urlscan.io/result/fa8708ab-ffc9-419f-bc67-9236088a7bc5/
address: 0xaaddf2d14ef347360f50c50f2337a1fb8a673eb1 (eth)
address: 134BbK9A35erMCMvn8khA7JxkSoohwGTRq (btc)

bllockchain.tk
Fake BlockchainInfo phishing for logins with POST /hitler
https://urlscan.io/result/b214dd1e-09f0-4da0-97aa-ccb4dd347f6d/

hiltbtc.com
Fake HitBTC phishing for logins with POST /login.php
https://urlscan.io/result/dd2835f3-f86b-4e3d-a6fa-de810e9934b5/

login.bilockcnain.com
Fake BlockchainInfo phishing for logins with POST /sess.php. Suspected addresses: ETH:0xE8f42CB54991a25EAe58d2602F21C8d5d5105a7D BTC:1Hg5ahckVEJRLC3Y4hcMkPYTgw8V2cCRpd BCH:14NP3eYNYVvS8KxzsFCtZP4rqPev8w4FzZ
https://urlscan.io/result/731cb00a-9bf7-4fbb-9c8d-cccdd266415a/