### PR TITLE
bitcoingift.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -471,6 +471,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "bitcoingift.net",
     "elon-musk.xyz",
     "bllockchain.tk",
     "hiltbtc.com",


### PR DESCRIPTION
bitcoingift.net
Trust trading scam site
https://urlscan.io/result/ac826801-da0c-4de6-a02b-160d8ec6640d/
address: 1Mb3rqiT9cSFYMipdA6T4xWb4z2GAXXrJN (btc)