### PR TITLE
binance-promo.netlify.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -471,6 +471,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "eth30.org",
+    "binance-promo.netlify.com",
     "x2neojuly.blogspot.com",
     "celebration-binance.netlify.com",
     "bitcoingift.net",


### PR DESCRIPTION
binance-promo.netlify.com
Trust trading scam site
https://urlscan.io/result/cf921f23-b5ac-420b-9979-4e5b3ae0efc9/
https://urlscan.io/result/30439018-f356-46af-ac97-3d765be5a87d/
address: 0xB93184F8cFd3012E77114c93BF6ef08e9D6779A3 (eth)
address: 13kg4Ah7vhMXeaHhDhqRVkETnWscTTFMv2