### PR TITLE
crypto-promo.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -471,6 +471,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "crypto-promo.com",
+    "giveaway-btc.net",
+    "promocrypto.net",
+    "binancev2.live",
+    "binance-btc.neocities.org",
     "eth30.org",
     "binance-promo.netlify.com",
     "x2neojuly.blogspot.com",


### PR DESCRIPTION
crypto-promo.com
Trust trading scam site
https://urlscan.io/result/52e13833-716e-476a-9c9d-2a7de7eeec22/
address: 1M71ywatR8TCZQqS61Rh3soEn4eiEaDKoN (btc)
address: 0x71D663DE2Df38D61A1871Bb8eF503d18D19964d6 (eth)

giveaway-btc.net
Trust trading scam site
https://urlscan.io/result/5518e59e-8fb3-4db8-9887-340891fa60f0/
address: 1WsvoEkx1rTq9c61U68UxAKsdNi5X7AJT (btc)

promocrypto.net
Trust trading scam site
https://urlscan.io/result/925175e3-8464-43d0-b00f-13f7c048a5ec/
address: 1M71ywatR8TCZQqS61Rh3soEn4eiEaDKoN (btc)
address: 0x71D663DE2Df38D61A1871Bb8eF503d18D19964d6 (eth)

binancev2.live
Trust trading scam site
https://urlscan.io/result/5d645c36-4dcb-4aae-b2ca-3b7d67d181ab/
address: 1Q7TjFii9fPj1gnXMXkssjDkTFniXEjYBZ (btc)

binance-btc.neocities.org 
Trust trading scam site
https://urlscan.io/result/4437be8f-d9a4-4d85-ade3-10fc84efb6a5/
address: 16eqQ1NrnrSKcAgKdG1AXP357qZuWkRoCj (btc)