### PR TITLE
binancesuper.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -471,6 +471,17 @@
     "actua.ad"
   ],
   "blacklist": [
+    "livebinance.com",
+    "btcfast.org",
+    "binancesuper.net",
+    "bitcoindrop.org",
+    "eth10.top",
+    "binancefree.net",
+    "official-drop.club",
+    "promocrypto.net",
+    "binancepromo.epizy.com",
+    "airdropbtc.epizy.com",
+    "binanceclub.rf.gd",
     "crypto-promo.com",
     "giveaway-btc.net",
     "promocrypto.net",

--- a/src/config.json
+++ b/src/config.json
@@ -478,7 +478,6 @@
     "eth10.top",
     "binancefree.net",
     "official-drop.club",
-    "promocrypto.net",
     "binancepromo.epizy.com",
     "airdropbtc.epizy.com",
     "binanceclub.rf.gd",


### PR DESCRIPTION
binancesuper.net
Trust trading scam site
https://urlscan.io/result/3a325516-ca95-4fe8-92c2-d382d23f95e9/
address: 1Psm6mUeG24FKBMMphhRQ78WSJL2LFbBvu (btc)

bitcoindrop.org
Trust trading scam site
https://urlscan.io/result/ab4d3188-b948-41d3-914e-909cc610b49f/
address: 16NkgJtzvi3K7f2LwiaWmrgZhcqxjP9JMe (btc)

eth10.top
Trust trading scam site
https://urlscan.io/result/26786bc0-7abc-4723-90ae-dd9edc564892/
address: 0x457f4Aa8525CAaf4a4343988bb18Ff6610450bEF (eth)

binancefree.net
Trust trading scam site
https://urlscan.io/result/6159678e-f5ab-4e63-8126-a1cb12b29dc4/
address: 1HFkg9sb3qzG1H4GdE3Rh4zJF8rd3D5tyi (btc)

binanceclub.rf.gd
Trust trading scam site
https://urlscan.io/result/c97a43b4-6b32-4025-8583-5864c36d6522/
address: 1LyupAqrNSes3XjnoVhjzLf235tVVqPKHv (btc)

official-drop.club 
Trust trading scam site
https://urlscan.io/result/a5ef5149-7bfa-49d0-940a-9c4242299bf6/
address: 1A72oXVqv2t3mzir26tFNrtCXZ8MyvzaDa (btc)

airdropbtc.epizy.com
Trust trading scam site
https://urlscan.io/result/189d3618-fb14-4924-b297-836a953a2a1f/
address: 1GgSuPknSLNPP4GCiGJfkvW71WHp1sK2zF (btc)