### PR TITLE
Whitelist etherean.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -162,6 +162,7 @@
     "mycrypto.store",
     "etherwan.com",
     "etherean.com",
+    "etherean.org",
     "cactus.tv",
     "victus.be",
     "crypto.gratis",


### PR DESCRIPTION
See #2598 and https://github.com/MetaMask/eth-phishing-detect/commit/f24c038b120fe4a17ad1384b91b2811677b57030 - I'm still getting this at `etherean.org`!