### PR TITLE
binance-team.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "binance-team.com",
+    "binanceteams.net",
+    "binance2.epizy.com",
+    "xrpx2july.blogspot.com",
     "binance-gives.com",
     "binance2.vip",
     "5000drop.com",


### PR DESCRIPTION
binance-team.com
Trust trading scam site
https://urlscan.io/result/b87dd5bd-0c35-4139-9bfc-4720bb4ea553/
https://urlscan.io/result/fc2c5b83-1e7b-4970-9395-d7867a51abe4/
https://urlscan.io/result/15962123-1c0b-4a85-bd4b-a2440359b2bb/
address: 0xF4c996752C0346dA4D290553fD58b3fcB6774ed6 (eth)
address: 1CDH7oUUxMyo6T5QHovu82ygUEXpQ5rgWV (btc)

binanceteams.net 
Trust trading scam site
https://urlscan.io/result/8f53cec4-e2d0-456a-8086-7556437111a1/
address: 1Mn386ue8o3mW9866octLNP8HFqcYsphJC (btc)

binance2.epizy.com 
Trust trading scam site
https://urlscan.io/result/d0770782-8b5c-4093-aade-d7f68035c025/
https://urlscan.io/result/fb2c5098-9335-4100-be11-fc04ba264fce/
address: 1CK9kT35qZHGAb7kuqZeKfKQc3j6Ezt8JZ (btc)

xrpx2july.blogspot.com
Trust trading scam site
https://urlscan.io/result/edc122ca-06a3-4da5-9987-4c720a307555/
address: rhTCdpaZQSKbHNYY85xPLMEWQbyxYr4SFY (xrp)