### PR TITLE
dropfestextravaganza.tech + fly-promo.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "dropfestextravaganza.tech",
+    "fly-promo.online",
     "binpromo.net",
     "cbn-project.com",
     "biltmain.com",


### PR DESCRIPTION
dropfestextravaganza.tech
Trust trading scam site
https://urlscan.io/result/ceeddf26-5a7f-4aee-a4d3-fd9e55f05367/
https://urlscan.io/result/f3e41614-8ebe-489b-bd9f-5a540c880904/
address: 0xe33086e461749C687c2DDC3ec4EB24EA591c0dc7 (eth)
address: 1BiyLYjfDNQSP81uvr5gzNW77P2viGWi8m (btc)

fly-promo.online
Trust trading scam site
https://urlscan.io/result/466bbb2a-8a52-4f5a-98c3-5958296d3a7c/
https://urlscan.io/result/95a65448-bdd6-403d-ba7c-ffda626f9dae/
https://urlscan.io/result/1d908efc-5eb0-4130-980c-b812d2f5eeef/
address: 0x3414801E9D6Bdf352d4d21a30cBB9a178d28381F (eth)
address: 1Hj2r8SnVim48qG3E4QwZ6td8PMcUiXnGU (btc)