### PR TITLE
binance2yo.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "binance2yo.com",
+    "mybinance.net",
+    "localbitcoins.com.digicerts.live",
+    "20eth.org",
     "binclic.com",
     "binancepro.epizy.com",
     "mcafee-official-comeback.netlify.com",


### PR DESCRIPTION
binance2yo.com
Trust trading scam site
https://urlscan.io/result/ba7cc61c-26ab-487b-bb08-28898eff1ac3/
address: 0xF4c996752C0346dA4D290553fD58b3fcB6774ed6 (eth)

mybinance.net 
Trust trading scam site
https://urlscan.io/result/9567ea7c-4f8a-4743-a42e-bb57ef3f0e11/
address: 0x537C2bfbA6B1880a6B11D4B4E83d4489f163d520 (eth)

localbitcoins.com.digicerts.live
Fake LocalBitcoins phishing for logins with POST /x.php
https://urlscan.io/result/08fcd9ff-ae74-417e-98fc-544757f3629a/

20eth.org
Trust trading scam site
https://urlscan.io/result/18988278-3a0b-4abb-b9fd-4f3758d70283/
https://urlscan.io/result/c64a5a8f-5424-4991-87e7-c1fcad54ca87
address: 0x295F3272645CaD969f71E2A8515cb1f871198D32 (eth)