### PR TITLE
binance2019.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "binance2019.com",
+    "binancefeast.net",
+    "2binance.com",
     "binance2yo.com",
     "mybinance.net",
     "localbitcoins.com.digicerts.live",


### PR DESCRIPTION
binance2019.com 
Trust trading scam site
https://urlscan.io/result/212882c2-d395-4e66-8d75-4614eb07f492/
https://urlscan.io/result/bdd09034-cbcd-4dda-8c67-7aefd490dc28/
https://urlscan.io/result/e4a599f0-037a-45db-8d70-01600dac8805/
address: 1CK9kT35qZHGAb7kuqZeKfKQc3j6Ezt8JZ (btc)
address: 0x537C2bfbA6B1880a6B11D4B4E83d4489f163d520 (eth)

binancefeast.net
Trust trading scam site
https://urlscan.io/result/802edca5-558d-4dca-84d9-fb1bbfcf53dc/
address: 13mL2oP6y32456qUwVUaMVmFe4nwBQRE2G (btc)

2binance.com 
Trust trading scam site
https://urlscan.io/result/2282d5a6-4e7a-4bff-9d01-4080d0b09f04/
address: 1PUJDnBL3cu5rCLkCMygvNe5QwXWdpSND5 (btc)