### PR TITLE
calibra-token.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "calibra-token.com",
+    "calibraico.com",
+    "calibra-ico.com",
     "bakkt-btc-event.netlify.com",
     "buylibracoins.com",
     "mcafee-official.net",


### PR DESCRIPTION
calibra-token.com
Fake Libra crowdsale site
https://urlscan.io/result/f8c62904-9b8d-4d5d-b35a-7cf589c0dd2f
https://urlscan.io/result/294dfa5b-1876-4a2c-9a96-51930246c06f/
address: 0xdd68910e9fc5b71d4f0f5eceb4ec57742bcc3cd5 (eth)
address: 1PSHt9agWavn4mf44d8rH6HPfaVpkdV75A (btc)
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/3183