### PR TITLE
binance5000.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "binance5000.info",
+    "bigpromo.net",
+    "5000btc.org",
     "calibra-token.com",
     "calibraico.com",
     "calibra-ico.com",


### PR DESCRIPTION
binance5000.info 
Trust trading scam site
https://urlscan.io/result/bf0ba238-6b52-4b8e-83a5-8091b064a413/
address: 19tBJTK4YowE87rxCLS626NdoR3B28mEKx (btc)

bigpromo.net 
Trust trading scam site
https://urlscan.io/result/a0edb13e-0eb2-4d05-8445-bf9cb02f9362/
address: 1ANV91xkSF1QGos5SGxuxxED6ZVx4L8bra (btc)

5000btc.org
Trust trading scam site
https://urlscan.io/result/18f6ca1c-59ea-4dd1-8732-e4aeeb9c2a90/
address: 14CcftBcHmQwPwhgd9e2dVdURqVtP2hQW3 (btc)