### PR TITLE
btc-drop.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "btc-drop.net",
+    "coinbasepromo.net",
+    "mgctoken.biz",
+    "mgctoken.org",
     "binance5000.info",
     "bigpromo.net",
     "5000btc.org",


### PR DESCRIPTION
btc-drop.net
Trust trading scam site
https://urlscan.io/result/f7ad1d37-0e0d-48b1-9903-6a8b3e240bf6/
https://urlscan.io/result/4711ca4c-04e3-4040-b2a2-48c0de3aebf7/
address: 1ANV91xkSF1QGos5SGxuxxED6ZVx4L8bra (btc)

coinbasepromo.net 
Trust trading scam site
https://urlscan.io/result/ff7b6f90-14f3-4b0f-9a89-59d68d3fdeaf/
address: 1FZWiRH5zSwsaFY5gUFXVGML6NHsADngRp (btc)

mgctoken.biz 
Promoting malware apk to steal secrets - https://twitter.com/sniko_/status/1140759034292838400 https://www.virustotal.com/gui/url/042a8ed70bb19c5e5b82aae9674abd73d5a549107745ea1dbd1481b48c3a4c50/detection
https://urlscan.io/result/18030da1-f503-4e0b-ade7-462963399ff9/
https://urlscan.io/result/392a805c-e470-4e0e-b6e9-a59c99ddc139/
https://urlscan.io/result/9fb85a7a-eacd-45a0-8e36-291df1246537/