### PR TITLE
binance5000.epizy.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "dietologicheskoepit.space",
+    "binance5000.epizy.com",
+    "btcfast.net",
+    "transaction-sends.tech",
     "btc-drop.net",
     "coinbasepromo.net",
     "mgctoken.biz",


### PR DESCRIPTION
binance5000.epizy.com
Trust trading scam site
https://urlscan.io/result/ea1f7fad-6752-4593-a80f-2daa0b481bec/
https://urlscan.io/result/effe279c-67bc-4fc5-82b9-9a010d1beecb/
https://urlscan.io/result/f85c8563-7415-42f7-b9bf-f07cd4fb3aec/
address: 1CK9kT35qZHGAb7kuqZeKfKQc3j6Ezt8JZ (btc)
address: 0x537C2bfbA6B1880a6B11D4B4E83d4489f163d520 (eth)

btcfast.net 
Trust trading scam site
https://urlscan.io/result/d2242d61-5f96-49cc-9d41-b1687f424b1b
address: 16YvTd9otULCCArAQfPCURb58fSwVqzqnE (btc)

btc5000.epizy.com
Trust trading scam site
https://urlscan.io/result/80e75dde-ea38-4a76-9e16-f8144174be97/
https://urlscan.io/result/7f6781e3-b330-41dd-83b8-8a524dd340e7/
https://urlscan.io/result/09a899d0-561c-4dc9-95b3-b16adb65a42a/
address: 0x537C2bfbA6B1880a6B11D4B4E83d4489f163d520 (eth)
address: 1E8J5U1vBSiTK8KsKbTHbouLqzqkgnnL3g (btc)

transaction-sends.tech
Trust trading scam site
https://urlscan.io/result/e5da6e58-b80b-45bd-bfed-6167f767768b
address: 0x7b8583C2d1A5B66eF6CD377B10130B20D09fc04b (eth)