### PR TITLE
btc5000.epizy.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,13 @@
     "actua.ad"
   ],
   "blacklist": [
+    "btc5000.epizy.com",
+    "promobinance.net",
+    "30f3000f-5f1f-4dee-af2d-0b7a6159f4c0.htmlpasta.com",
+    "3365cad5-455b-4ed0-a944-2b9bd0191501.htmlpasta.com",
+    "0978f655-465b-4434-99fb-f8357c7bca4b.htmlpasta.com",
+    "airdrop2.com",
+    "get-crypto.tech",
     "dietologicheskoepit.space",
     "binance5000.epizy.com",
     "btcfast.net",


### PR DESCRIPTION
btc5000.epizy.com
Trust trading scam site
https://urlscan.io/result/6ecc2de5-5186-4875-af60-0910edb206ca/
https://urlscan.io/result/7e0315c3-9d26-478f-b0b6-8cbb418a6835/
https://urlscan.io/result/03ead328-29e7-4e4f-ba22-8dda30120f11/
address: 0x537C2bfbA6B1880a6B11D4B4E83d4489f163d520 (eth)
address: 1E8J5U1vBSiTK8KsKbTHbouLqzqkgnnL3g (btc)

promobinance.net 
Trust trading scam site
https://urlscan.io/result/a53af9a5-9b8c-49f0-a8b5-fcbabbebcbac
address: 19tBJTK4YowE87rxCLS626NdoR3B28mEKx (btc)

30f3000f-5f1f-4dee-af2d-0b7a6159f4c0.htmlpasta.com
Trust trading scam site - redirect via bit.ly/binancegive+
https://urlscan.io/result/0dc32a1d-7378-4b7c-b146-6d514f57beb6/

3365cad5-455b-4ed0-a944-2b9bd0191501.htmlpasta.com
Trust trading scam site
https://urlscan.io/result/2429f8a1-f14e-4352-821c-a2f3b4436875/
address: 0xD83d2B3C816F3923867F4C4a5fdE46224E919236 (eth)

0978f655-465b-4434-99fb-f8357c7bca4b.htmlpasta.com
Trust trading scam site
https://urlscan.io/result/07081ed4-cd00-4e3a-86b7-8d9ed85145c0/
address: 12cXaMMhtWA2Y9kbEF7f9m2pBip72DbzPr (btc)

airdrop2.com
Trust trading scam site
https://urlscan.io/result/1fd8cf96-0917-4ef6-aed8-b4843f56dfbd/
address: 1F3jofkLZR8NLzdaN8Ycuf6qLLaz81LhUm (btc)