### PR TITLE
binancebtc.epizy.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "binancebtc.epizy.com",
+    "upbit.sale",
+    "binance-updates.com",
     "btc5000.epizy.com",
     "promobinance.net",
     "30f3000f-5f1f-4dee-af2d-0b7a6159f4c0.htmlpasta.com",


### PR DESCRIPTION
binancebtc.epizy.com
Trust trading scam site
https://urlscan.io/result/a6c37b02-4858-44f9-8800-b76ca25f1352/
address: 1CK9kT35qZHGAb7kuqZeKfKQc3j6Ezt8JZ (btc)

upbit.sale
Trust trading scam site
https://urlscan.io/result/57b3cd36-0a9f-477d-9ec6-fec8a85eab06/
address: 0x22ffb8cf9871cb143575effea5524a19d0bd72f6 (eth)

binance-updates.com
Trust trading scam site
https://urlscan.io/result/450f6094-6081-46b2-8428-3fe21e7672c3/
https://urlscan.io/result/e3b96986-ff56-4951-96bd-14719c9987c2
https://urlscan.io/result/35ae3edb-a62d-499b-959f-2ee747b71b9d/
address: 18ZLv7gCDmzXVgCfQhDoT3DfmuiT3vhVCx (btc)
address: 0x2189B1EEA27F1D19Bc2c61D991068ec947d8Ec7b (eth)

---

promobinance.net
Trust trading scam site
https://urlscan.io/result/cfa359d4-b151-4c89-b0fb-c90cadf05f75
address: 19tBJTK4YowE87rxCLS626NdoR3B28mEKx (btc)