### PR TITLE
gift-binance.com + huobipartners.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "gift-binance.com",
+    "huobipartners.com",
     "mn-r.store",
     "token-1.com",
     "coinbase.token-1.com",


### PR DESCRIPTION
gift-binance.com
Trust trading scam site
https://urlscan.io/result/d9e88f48-01af-4574-8edb-8a39b666ae3e/
https://urlscan.io/result/77c0b945-ea9f-4598-8c58-94aafcc087f1/
https://urlscan.io/result/01640c44-8c76-456d-a88e-e19f564b69f4/
address: 0xF4c996752C0346dA4D290553fD58b3fcB6774ed6 (eth)
address: 16FVNrp2nfsRH9cWRidV6ZVZf4mDPBnJG9 (btc)

huobipartners.com
Trust trading scam site
https://urlscan.io/result/3cd82918-ca23-4616-820f-14d688c49211/
address: 0xe2e4B53A1324F5a7368724eA73e532c626517f19 (eth)