### PR TITLE
Whitelist cactus.app domain

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14,6 +14,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "cactus.app",
     "lucius.fr",
     "mj-crypto.com",
     "crypto.casa",


### PR DESCRIPTION
https://cactus.app is a consumer application that helps people discover and focus on what makes them happiest in life. It does not practice any phishing.