### PR TITLE
coinbasepromo.epizy.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "biitmrt.com",
     "coinbasepromo.epizy.com",
     "win-binance.com",
     "crypto-extravaganza.store",

--- a/src/config.json
+++ b/src/config.json
@@ -473,6 +473,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "coinbasepromo.epizy.com",
+    "win-binance.com",
+    "crypto-extravaganza.store",
+    "drop-binance.com",
     "gift-binance.com",
     "huobipartners.com",
     "mn-r.store",


### PR DESCRIPTION
coinbasepromo.epizy.com
Trust trading scam site
https://urlscan.io/result/a72d71ac-e743-4e7d-8b1e-2e280351bb16/
address: 1E8J5U1vBSiTK8KsKbTHbouLqzqkgnnL3g (btc)

win-binance.com
Trust trading scam site
https://urlscan.io/result/d8a0b3f7-b3ae-4e49-b322-dee2c4c073a6/
address: 16wd9B1LiXmTNf9hxQyb3Q9fbVHzP3NvSV (btc)

crypto-extravaganza.store
Trust trading scam site
https://urlscan.io/result/4b0c9642-3acb-452f-883f-66558067a29c/
https://urlscan.io/result/1eaafcd8-c6ec-464d-b5f8-d99f06c1ff82/
https://urlscan.io/result/37689062-b92d-459e-963c-b48a59dd4a26/
address: 12E6S5wUtzofn1mivoNYS3Wm5Z8Ld4FwK1 (btc)
address: 0xd9356A97016Bfe90eD4B793289fEB812C58aC127 (eth)

drop-binance.com
Trust trading scam site
https://urlscan.io/result/cbf0c6c7-53ac-48b0-93c1-b6b94f5b600f
address: 1NuZ4rxsQPU4izgtkScs793Uxx2c6ADRQo (btc)