### PR TITLE
donalt.livetrades.vip

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "donalt.livetrades.vip",
     "biitmrt.com",
     "coinbasepromo.epizy.com",
     "win-binance.com",


### PR DESCRIPTION
donalt.livetrades.vip 
Fake DonAlt paid investment group https://twitter.com/CryptoDonAII/status/1155849569902759943 twitter id: 701212188694986752 
https://urlscan.io/result/a49a3295-b450-4274-98cd-f172e0a9d576/
address: 3Lqi9MFvmBVRuc1yNsLdm2eB1t6XkgL96p (btc)