### PR TITLE
now5000.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "now5000.com",
+    "crypto-drop.org",
+    "crypto-promo.net",
+    "cryptoextravaganza.online",
     "donalt.livetrades.vip",
     "biitmrt.com",
     "coinbasepromo.epizy.com",


### PR DESCRIPTION
now5000.com
Trust trading scam site
https://urlscan.io/result/69aabe8e-4ccb-48b5-9cc6-7780a28df987/
address: 1Q5XatyemWqDo7aytzExFho9YvayaNQhwp (btc)

crypto-drop.org
Trust trading scam site
https://urlscan.io/result/2a8b1897-b4a0-42b6-b8d3-25ede46b6590/
address: 1JRprezHFY97JEJo55t8wRnuNkAcVkB4uY (btc)

crypto-promo.net
Trust trading scam site
https://urlscan.io/result/ad363f88-56b6-4c2d-ab8f-99ee96a68314/
address: 1212Egq4bLw3FLQx5EWcu7fmJoJkvh3RrB (btc)

cryptoextravaganza.online
Trust trading scam site
https://urlscan.io/result/cb0bd8d2-9d86-48a1-b6aa-477a06a4ce14/
https://urlscan.io/result/4e957859-e4b9-4be9-8b50-ca8f70a3445d/
address: 12E6S5wUtzofn1mivoNYS3Wm5Z8Ld4FwK1 (btc)
address: 0xd9356A97016Bfe90eD4B793289fEB812C58aC127 (eth)