### PR TITLE
eventbinance.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "eventbinance.com",
     "xn--blockcain-lmb.com",
     "hiverzone.com",
     "elonmuskcrypto.webcindario.com",


### PR DESCRIPTION
eventbinance.com
Trust trading scam site
https://urlscan.io/result/9dc413aa-95db-40cf-9dc6-890f94579f81
address: 0x812EE157C915Dd8f2FDCAaee453C5B0Aee1F27Ac (eth)