### PR TITLE
news-bnb.org + neofoundation.blogspot.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "news-bnb.org",
+    "neofoundation.blogspot.com",
     "eventbinance.com",
     "xn--blockcain-lmb.com",
     "hiverzone.com",


### PR DESCRIPTION
news-bnb.org
Trust trading scam site
https://urlscan.io/result/c59ebb7f-c67b-4d30-85b5-e309c3c9b61b/
https://urlscan.io/result/e8949597-c193-41a0-826b-6f619031e220/
https://urlscan.io/result/348315a3-fd71-466c-bf56-c48c2bdc69a3
address: 0x97ef8A1EFCb356A76318bf0603890e18ae73d2DC (eth)
address: 17qWPbf7SY4AYzaRUAkCZTCQHAxbh52wu1 (btc)

neofoundation.blogspot.com
Trust trading scam site
https://urlscan.io/result/db467f16-e198-44f1-af5c-6a9f413e8c3a/
address: APrEuwGuqbZF57K8CMto1GEbbV1FgKHY6s (neo)