### PR TITLE
top-binance.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "top-binance.com",
     "news-bnb.org",
     "neofoundation.blogspot.com",
     "eventbinance.com",


### PR DESCRIPTION
top-binance.com
Trust trading scam site
https://urlscan.io/result/1da2437e-6890-4a6d-b82f-0cb693d6e832/
address: 16wd9B1LiXmTNf9hxQyb3Q9fbVHzP3NvSV (btc)
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/3203