### PR TITLE
mcafeebtc.net + buterineth.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "mcafeebtc.net",
+    "buterineth.net",
     "fastprofitableoptiontrade.com",
     "ethereum4th.com",
     "conn-view-wallet.info",


### PR DESCRIPTION
mcafeebtc.net
Trust trading scam site - redirected via bit.ly/319CYuH+
https://urlscan.io/result/33cc7d9a-241b-490e-90b3-2e0e05221c72/
address: 1MNuqDXUZYN6dqheCHWFxjQyGgRb7thavU (btc)

buterineth.net
Trust trading scam site - redirected via bit.ly/2MsMl4f+
https://urlscan.io/result/66ec153c-bb58-44f5-a050-4b724bb93ed9
address: 0xf9e2f408676d1D7a08378ee879AfF6c0556086D3 (eth)