### PR TITLE
promo-binance.netlify.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "5000btc.gift",
+    "promo-binance.netlify.com",
+    "btc.wz.sk",
+    "myellthevwaallet.com",
     "mcafeebtc.net",
     "buterineth.net",
     "fastprofitableoptiontrade.com",


### PR DESCRIPTION
promo-binance.netlify.com
Trust trading scam site
https://urlscan.io/result/5f98b1a8-1383-4d5a-835a-3b318e416e85/
address: 3NGgWDD5xrr1Af2FnyCYHhzg5WQmVZEaqG (btc)

btc.wz.sk
Trust trading scam site
https://urlscan.io/result/baf68ce3-855a-4186-85ea-eeafe1994560/
address: 16WJFGc5z5j3VYj2EpSExkxdcGrj28BNCh (btc)

myellthevwaallet.com
Fake MyEtherWallet stealing secrets with POST My/sending.php
https://urlscan.io/result/7f3c9bc0-7e27-42b8-bf45-5fc3dccb9f2e/