### PR TITLE
drop-crypto.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "drop-crypto.com",
     "coinbasetop.com",
     "coinbase.promo",
     "100kbtc.com",


### PR DESCRIPTION
drop-crypto.com
Trust trading scam site
https://urlscan.io/result/2a49250d-25d1-4f33-b2e7-32b9be8a4b0e/
address: 1JRprezHFY97JEJo55t8wRnuNkAcVkB4uY (btc)