### PR TITLE
promotion-crypto.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "promotion-crypto.com",
+    "coinbasegift.net",
+    "ethereum4th.org",
     "drop-crypto.com",
     "coinbasetop.com",
     "coinbase.promo",


### PR DESCRIPTION
promotion-crypto.com
Trust trading scam site
https://urlscan.io/result/85a2900f-ebad-46f5-b934-b44a06625c41/
address: 1LDhw8MefBidkbqPW9RsUePigt47deSrGH (btc)

coinbasegift.net
Trust trading scam site
https://urlscan.io/result/14f32204-63a4-4e56-b0c3-9be03a29f873/
address: 1HMC6jvM7WSEAM5pQpWotYErJs5k2qAHxN (btc)

ethereum4th.org 
Trust trading scam site
https://urlscan.io/result/356576c3-182c-443b-b5fd-40b2778c535c/
address: 0xF3Df0Ed1B1E25fce934eC9216d9Fac59659d5678 (eth)