### PR TITLE
muskelon547776.webcindario.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "muskelon547776.webcindario.com",
+    "muskelon.net",
+    "airdrop-crypto.com",
     "promotion-crypto.com",
     "coinbasegift.net",
     "ethereum4th.org",


### PR DESCRIPTION
muskelon547776.webcindario.com
Trust trading scam site
https://urlscan.io/result/586c305b-610b-43d9-b3bf-051e740a8d82/
address: 13gyBExvYbc4tEjqPHmAznXF5QDxFHgrZZ (btc)

airdrop-crypto.com 
Trust trading scam site
https://urlscan.io/result/4a64b30c-75cc-41e5-92d5-0eb193bed3cf/
address: 1LDhw8MefBidkbqPW9RsUePigt47deSrGH (btc)