### PR TITLE
coinbase-team.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -474,6 +474,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "coinbase-team.com",
+    "btc-generator.club",
+    "idekx.market",
+    "vip.kelireqa.xyz",
     "muskelon547776.webcindario.com",
     "muskelon.net",
     "airdrop-crypto.com",


### PR DESCRIPTION
coinbase-team.com
Trust trading scam site
https://urlscan.io/result/d7ec89b0-5f51-4411-a1a6-45423730a36f/
address: 1FGZE75bUCHkoEcaoQLRzBuPYB9NA8XRCQ (btc)

btc-generator.club 
Trust trading scam site - fake btc generator
https://urlscan.io/result/39daea27-3057-40d1-9458-b50697aa475f/
address: 3AqmwvMXNfA7NhCLGup34JHKa7LWNhakqk (btc)