### PR TITLE
binancefree2018.droppages.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -475,6 +475,13 @@
     "actua.ad"
   ],
   "blacklist": [
+    "binancefree2018.droppages.com",
+    "binance.newrelease.site",
+    "5000coinbase.com",
+    "coinbasebtc.atspace.cc",
+    "coinbasebonus.net",
+    "coinbasegift.epizy.com",
+    "transaction-verification.tech",
     "coinbase-team.com",
     "btc-generator.club",
     "idekx.market",


### PR DESCRIPTION
binancefree2018.droppages.com 
Trust trading scam site
https://urlscan.io/result/7cf2f8bc-1c96-4dd5-a54e-5984b92c3b7a/
address: 0x40949225c4a1745a9946F6AAf763241c082cb9ac (eth)

binance.newrelease.site
Trust trading scam site
address: 3ENbaDnoy6GF25ttwwwncwvvuAX1ifsmCp (btc)

5000coinbase.com
Trust trading scam site
https://urlscan.io/result/b9f5b6ce-c7c7-48be-9b0e-56d8ad33cf43/
address: 12u54UVjvwVmzxNBBjTHtC6dgsVeZdr6RR (btc)

coinbasebtc.atspace.cc 
Trust trading scam site
https://urlscan.io/result/7e86f2fb-3ef6-4c37-a2af-0efc7ce4fb81/
address: 1Adc3NV2kFGRAaC5QeXN9veYxpLB4ZQn8t (btc)

coinbasebonus.net 
Trust trading scam site
https://urlscan.io/result/eaebd023-f7cd-4811-8b4c-afb1b4e1c57f/
address: 15vTQrRKX4bVztcjg8i7xmPuS6pmj9DPFd (btc)

coinbasegift.epizy.com
Trust trading scam site
https://urlscan.io/result/9b6654ea-c8f1-48ad-96aa-4d5af41b1fe5/
address: 1CK9kT35qZHGAb7kuqZeKfKQc3j6Ezt8JZ (btc)

transaction-verification.tech
Trust trading scam site
https://urlscan.io/result/ac66f0ab-ad8c-4c95-a314-ee448014ffbe
https://urlscan.io/result/a7d7a018-9ac3-4ed8-b5b2-cb26a0b219b4
address: 0xAD853d8a602C44E9b126fB6E0a4228Ea91C486F6 (eth)
address: 0xBBC0825f36f3e3DEC3b6499F02f609BeA542e74f (eth)

----

now5000.com
Trust trading scam site
https://urlscan.io/result/412ec661-4a0f-4fac-b664-0696002f5b20/
address: 1Q5XatyemWqDo7aytzExFho9YvayaNQhwp (btc)