### PR TITLE
calibra-ico.info

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -475,6 +475,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "calibra-ico.info",
     "binancefree2018.droppages.com",
     "binance.newrelease.site",
     "5000coinbase.com",


### PR DESCRIPTION
calibra-ico.info
Fake Calibra crowdsale site
https://urlscan.io/result/4ffa56b0-22df-4ed1-a98a-f73c7dc4616a/
https://urlscan.io/result/f9d43bf0-63d9-4d10-96c8-4f188224cea5/
address: 0x00067010f3Ae17aa53e2B4d5142DDA35380cf72D (eth)
address: 1D6MaXsxxT7DQYDrVv8VKyEZ2KL64jTP3Y (btc)