### PR TITLE
sebiltv.com.tr

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -7071,6 +7071,7 @@
     "xn--mytherwalt-smbh17c.com",
     "bitcointalk.to",
     "bitcointolk.org",
+    "sebiltv.com.tr",
     "ethbonus.net",
     "etherspromo.org",
     "ethergiving.org",


### PR DESCRIPTION
Fake bitcointalk.org login page with the intent to phish account credentials.
Reference: https://bitcointalk.org/index.php?topic=5173531.0

https://urlscan.io/result/1bc0afda-1e6e-4e1e-a61c-36a32ed07d9d