### PR TITLE
coinbase-drop.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -475,6 +475,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "coinbase-drop.com",
+    "teamofbinance.com",
     "neoaugust.blogspot.com",
     "binance.jerseyexchange.site",
     "jerseyexchange.site",


### PR DESCRIPTION
coinbase-drop.com
Trust trading scam site
https://urlscan.io/result/b16fef0c-bfd1-4d2c-963d-ffa9a039cf5f/
address: bc1q580e7qhrzt7gpfmmcm0etdedacnjdt22eh4s93 (btc)

teamofbinance.com
Trust trading scam site
https://urlscan.io/result/461b7fce-6b92-45a9-bce7-7b765fd81c6c/
https://urlscan.io/result/f8ca0673-dce0-4c11-b9a2-7b5739c0df90/
address: 1M2KACJTaautJ6BM3a563LraYNmD6LjcdU (btc)