### PR TITLE
5000crypto.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -475,6 +475,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "5000crypto.com",
+    "exchange.eventsolutions.top",
+    "coinbasegives.com",
+    "coinbasegold.com",
+    "coinbase-5000.com",
     "coinbase-drop.com",
     "teamofbinance.com",
     "neoaugust.blogspot.com",


### PR DESCRIPTION
5000crypto.com
Trust trading scam site
https://urlscan.io/result/41d3f29d-cc0b-4fe1-8223-31a2d9e7e06a/
address: bc1qerc6yxzre8xrcdfjx4zkgprafde30lr89vpd5s (btc)

coinbasegives.com
Trust trading scam site
https://urlscan.io/result/64707fe0-2b5e-443c-8b01-1310e6394106/
address: bc1q580e7qhrzt7gpfmmcm0etdedacnjdt22eh4s93 (btc)

coinbasegold.com
Trust trading scam site
https://urlscan.io/result/b02ff2da-a1ef-4264-9441-dcc4053ac49c/
address: 1NDewuhwPYoGiv8zyG2wCh5aQKeWfStVhK (btc)

coinbase-5000.com
Trust trading scam site
https://urlscan.io/result/e5368d85-f584-4235-b08e-e7afda8dc4ab/
address: bc1qerc6yxzre8xrcdfjx4zkgprafde30lr89vpd5s (btc)