### PR TITLE
brave-bounty.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -475,6 +475,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "brave-bounty.com",
     "5000crypto.com",
     "exchange.eventsolutions.top",
     "coinbasegives.com",


### PR DESCRIPTION
brave-bounty.com
Fake Brave website
https://urlscan.io/result/c2882673-1d98-41e4-9303-a43680b46f7b/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/3228