### PR TITLE
giveaway-transfer.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -475,6 +475,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "locaibitcoins.net",
+    "giveaway-transfer.com",
+    "decentralized-exchange.info",
+    "mcafeenow.net",
     "www-ldax.market",
     "dveryirazdvyzhniesystemy.com",
     "binance.dexmx.site",


### PR DESCRIPTION
giveaway-transfer.com
Trust trading scam site
https://urlscan.io/result/26a309a4-64d5-41ce-ba65-ff27005c4bd3/
https://urlscan.io/result/df5ef11f-2d6c-42b5-8c36-87f204d21c48/
https://urlscan.io/result/bd91f241-28ef-43e3-a07e-7185eb1446e8/
address: 1J1ubTbSfExkCL2EmXPDV7pWDFXk8kJCtz (btc)
address: 0x3c7C92bBcD9dE6D93c04c2F3544C837dA567D805 (eth)

decentralized-exchange.info 
Trust trading scam site
https://urlscan.io/result/c4817b4d-0933-40a3-b72c-ee9a9da77363/
https://urlscan.io/result/90bae372-8b1b-465b-b14d-1b9f01043c69/
https://urlscan.io/result/2993459a-770c-467d-9b00-a1abfab3b2c6/
https://urlscan.io/result/0b5052ba-7a83-414d-8b4e-740456842efd/
address: 1CX3DJTKHx52L1AbV58oo98XZAKi7XF3Dg (btc)
address: 0x20696795BF2e4de3145A795209232d817baA7a21 (eth)

mcafeenow.net
Trust trading scam site - redirect via bit.ly/2To2NVd+ & bit.ly/2KBU4dY+
https://urlscan.io/result/f96517b6-3a18-4443-b55e-e0e2e0f8b691/
https://urlscan.io/result/30cf8302-1a25-4804-8e5a-df2fed5c0c3c/
https://urlscan.io/result/37092280-da4e-408e-9835-c0b081ede98d/
address: 1NjcfMQpGdZTT4RunourC3hc1mkHohcXri (btc)
address: 0x69C24164B73693656747759181FDBe24Ac9607C3 (eth)