### PR TITLE
Add audius.org to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -468,6 +468,7 @@
     "twinity.com",
     "decrypto.net",
     "audius.co",
+    "audius.org",
     "verasity.io",
     "anatomia.me",
     "orionprotocol.io",


### PR DESCRIPTION
Audius is a decentralized audio hosting + streaming protocol; goal of the project is to give everyone the freedom to share and listen to any audio. Looks like our domain audius.org (and previously the domain audius.co which was whitelisted last year) are getting caught up by the rule for auctus.org, which is unrelated to our project.

URL scan: https://urlscan.io/result/15f40f45-ae31-455c-b9d9-094b41da816e

Previously whitelisted domain: https://github.com/MetaMask/eth-phishing-detect/pull/1619

Thanks for your help!