### PR TITLE
ethereum-mixer.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -475,6 +475,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "ethereum-mixer.org",
+    "feathercoin.top",
+    "myethdex.com",
+    "ethcombo.com",
     "locaibitcoins.net",
     "giveaway-transfer.com",
     "decentralized-exchange.info",


### PR DESCRIPTION
ethereum-mixer.org
Fake Mixer
https://urlscan.io/result/5fb9ecfb-8eef-41c4-b641-ffbd08ef3b6a/
https://urlscan.io/result/da6e1b1d-53d1-4098-89d4-b9f8112471ba/
address: 0xD49ff3BBB2b2B82538BAF25Fd5551186BC4994D2 (eth)

feathercoin.top 
Fake exchanger
https://urlscan.io/result/d5994e74-a3d5-450a-bb9b-1f4031129717/
https://urlscan.io/result/b59595e5-c2d9-403d-b0cc-067a49e1342c/
address: 1M8pbSE9EToe6afQsPLZYuGxYuGTHwAwBh (btc)

myethdex.com
Fake DEX phishing for secrets with POST /reward/private.php
https://urlscan.io/result/643d25ef-5d9f-41c3-8e6a-fef4218f10b6/
https://urlscan.io/result/4920f90b-63a5-48fa-91f8-750d7b6d0ec6/

ethcombo.com 
Fake ETH slots
https://urlscan.io/result/f29ae565-a570-4656-ab9e-50e58a122591/
https://urlscan.io/result/28bd7d64-1506-4c8a-9397-811ba5492257