### PR TITLE
cryptofans2019.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -476,6 +476,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "cryptofans2019.com",
+    "coinbase-promotion.com",
+    "coinbase-news.com",
+    "btc-bonus.com",
     "myetherverify.com",
     "forkdelta.id",
     "forkdelta.co.uk",


### PR DESCRIPTION
cryptofans2019.com
Trust trading scam site
https://urlscan.io/result/4e237638-a87d-40e7-bc0f-475060e0d686/
https://urlscan.io/result/37462622-e8fc-4ac5-9443-c178decb4cd1/
https://urlscan.io/result/92ee3da6-4fab-4d6a-a518-02edcc51f5a1/
address: 0xBb8fbca74cF891B8B91D719D6C3f2fFC5345482F (eth)
address: 1NYiYR86bBbbGkMQiboxjhsCUy21FQ2MqX (btc)
address: LfuKcuVfdLn4bPHp2epe9QEA6XJ722L2cu (ltc)

coinbase-promotion.com
Trust trading scam site
https://urlscan.io/result/647ca3d0-97ed-4950-a6fd-69070afaaba1/
address: bc1qmjwhdlz2wvdfrpmrgeydkej5eyv9djjqvsp3lz (btc)

coinbase-news.com
Trust trading scam site
https://urlscan.io/result/f390895e-727a-49b9-b940-2f8970e72cda/
address: 13meEx92158wdczweN8yxZ8jbYKCwr146D (btc)

btc-bonus.com
Trust trading scam site
https://urlscan.io/result/37f1dec8-2007-4d6e-9d3d-375158480e83/
address: bc1q580e7qhrzt7gpfmmcm0etdedacnjdt22eh4s93 (btc)