### PR TITLE
plus-ethers.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -482,6 +482,18 @@
     "actua.ad"
   ],
   "blacklist": [
+    "plus-ethers.com",
+    "kucoin.live",
+    "b-nance.com",
+    "coinbase.gifts",
+    "www-idaex.market",
+    "btc-drop.com",
+    "promo-coinbase.com",
+    "get-mcafee.me",
+    "mcafeegiveaway.net",
+    "mcafeetoday.com",
+    "john-mcafee-events.com",
+    "get-mcafee.press",
     "cryptofans2019.com",
     "coinbase-promotion.com",
     "coinbase-news.com",


### PR DESCRIPTION
plus-ethers.com
Trust trading scam site
https://urlscan.io/result/20dd7518-1a59-468b-b401-67a7542eeef1
address: 0xE1bc77871849F3690cd9ba32fcc6aFb4aAcbE99B (eth)

kucoin.live
Trust trading scam site
https://urlscan.io/result/9354da73-618a-4078-ac93-dc5507cd27bc
https://urlscan.io/result/d776eb8c-d174-47e5-89fe-efb190f46327/
address: 0xC1841FCa71E31578f28B7787c12e9f1ae18956c6 (eth)

b-nance.com
Trust trading scam site
https://urlscan.io/result/ddeccdaa-d3b4-4908-9b6c-d1ea592833c3/
address: 12rnnsmLnNUXiQgoz2X9874P94WH6uQH4V (btc)

coinbase.gifts
Trust trading scam site
https://urlscan.io/result/5837a532-f24d-487b-b52a-7273d5b1f226/
address: bc1q580e7qhrzt7gpfmmcm0etdedacnjdt22eh4s93 (btc)

btc-drop.com
Trust trading scam site
https://urlscan.io/result/bba0df96-c439-432e-a615-ed03380872a8/
address: bc1q580e7qhrzt7gpfmmcm0etdedacnjdt22eh4s93 (btc)

promo-coinbase.com 
Trust trading scam site
https://urlscan.io/result/86157f51-3a3d-4afb-a06d-0101dc736396/
address: 16xwVY9mChAawi9TrpunpstPeyoGJ2k3kC (btc)

get-mcafee.me
Trust trading scam site
https://urlscan.io/result/5c209227-d6b4-4555-8e60-8bb5c1197d54/
https://urlscan.io/result/92a6acfc-4b03-4b74-b3e6-06cf100850b3/
address: 0xDEE993d994f06BC06144aEAC1E78BBAe3B06136A (eth)
address: bc1qmn2mlj6ca2f4lk4q78a9zvd8ceqkf9p3dke0x9 (btc)

mcafeegiveaway.net
Trust trading scam site
https://urlscan.io/result/8311fbf6-d89c-4d90-9b06-97928af70a41/
address: 17sQ6GcXGsqzGfZ9Y5QsMaf1UUsNSL2VLF (btc)

mcafeetoday.com 
Trust trading scam site
https://urlscan.io/result/cbd70850-10d2-4907-87df-1adab13b894d/
address: 1448UnuXjXwpD2eTUibVrx3CMMBQLQ7UMm (btc)

john-mcafee-events.com
Trust trading scam site
https://urlscan.io/result/86f98e5c-0d4b-498b-82a7-d192b48653bc/
https://urlscan.io/result/26ff3a57-6118-4bce-8e6e-0ee95ef12130/
https://urlscan.io/result/bd761514-2556-4330-877c-84031d3dda79/
address: 0x4b826ba0795b76d5f3596abe28a77e6d3cbc3a15 (eth)
address: 1LFnaimaMB69hDPCuSavJwEkkMVE8NVCX2 (btc)

get-mcafee.press
Trust trading scam site
https://urlscan.io/result/dc9ec340-1489-4468-b91c-e2065ec9343c/
https://urlscan.io/result/f4bd1e09-95ba-4138-be86-d36180cc302c/
https://urlscan.io/result/f1e08f0b-bec3-4f40-bdc5-a24b861cb63e/
address: 0xDEE993d994f06BC06144aEAC1E78BBAe3B06136A (eth)
address: bc1qmn2mlj6ca2f4lk4q78a9zvd8ceqkf9p3dke0x9 (btc)