### PR TITLE
airdrop-mcafee.tech + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -482,6 +482,9 @@
     "actua.ad"
   ],
   "blacklist": [
+    "airdrop-mcafee.tech",
+    "crypto-promo.store",
+    "ethereumprize.pro",
     "plus-ethers.com",
     "kucoin.live",
     "b-nance.com",


### PR DESCRIPTION
airdrop-mcafee.tech
Trust trading scam site
https://urlscan.io/result/414e4930-0c6f-4213-b592-42f7c6853e01/
https://urlscan.io/result/7d3a69aa-2bfb-4cd1-8810-72f2e7a01dd4/
https://urlscan.io/result/645d3f76-7e42-4f7f-8119-771b8ec90539/
address: 1GY94WXLS4B5bsGvtarvFaL2gV8KzLaWtn (btc)
address: 0x8C3BD49eF2d468E80879eAa230538aeF08A44175 (eth)

crypto-promo.store
Trust trading scam site
https://urlscan.io/result/3ef28d13-5c50-410b-8c96-4e5ab53ae304/
https://urlscan.io/result/365b6713-b050-4555-86b7-a1281d9946ca/
address: 19AZTLM5C9ptH82y42UNw7D4fHfPBHyWC3 (btc)
address: 0xD2418A41A708676C450117cA1592Ebf435F01ee7 (eth)

ethereumprize.pro
Trust trading scam site
https://urlscan.io/result/aea2e9ed-59ac-4120-8cda-867c5d99d3fa/
address: 0x1E6A9ba05C5b538fB200056Db77d70c63f3D0193   (eth)