### PR TITLE
dropcoinbase.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -482,6 +482,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "blcokchian.lcgljn.com",
+    "lcgljn.com",
+    "dropcoinbase.com",
+    "augustcontest.blogspot.com",
+    "xn--localbitcons-jfbf.net",
     "airdrop-mcafee.tech",
     "crypto-promo.store",
     "ethereumprize.pro",


### PR DESCRIPTION
dropcoinbase.com
Trust trading scam site
https://urlscan.io/result/23f36774-fdd7-4749-b645-5f09a5e5f7da/
address: 1Lkakee2QGSQ92uNBUCUD1LaL4RKQTobLG (btc)

augustcontest.blogspot.com
Trust trading scam site
https://urlscan.io/result/71523d62-69e9-495c-813a-3120d7e40e42/
address: rhTCdpaZQSKbHNYY85xPLMEWQbyxYr4SFY (xrp)

xn--localbitcons-jfbf.net
Fake LocalBitcoins phishing for logins with POST /accounts/login
https://urlscan.io/result/1b8318cf-b080-4335-900e-6c237cd91e75/
https://urlscan.io/result/e764971e-cc57-4997-ae87-26199ed84b92/