### PR TITLE
ethberlin.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -482,6 +482,12 @@
     "actua.ad"
   ],
   "blacklist": [
+    "ethberlin.org",
+    "coinbasegive.com",
+    "muskelon.ga",
+    "rippleairdrop.club",
+    "myetherwallet.signtransaction.co",
+    "signtransaction.co",
     "zendesk-news.com",
     "litecoinairdrop.club",
     "bllockchain.ga",


### PR DESCRIPTION
ethberlin.org
Trust trading scam site
https://urlscan.io/result/63283fd0-b338-46c0-b57b-e27d55d3fedd/
address: 0x201D2A68bfB83D4DED413A29bB3B7c5002d32772 (eth)

coinbasegive.com
Trust trading scam site
https://urlscan.io/result/831b756f-1cac-404c-9793-63485dc79cc1/
address: 14LV7cwwuizL3xVm6CxBomFvCa55QKZ8WS (btc)

muskelon.ga
Trust trading scam site
https://urlscan.io/result/8049a1f8-1b56-4b60-bf33-caa634114454/
address: 13yyX9C3yaKTCdRp2rEsJNjk1AtVcYxrEd (btc)

rippleairdrop.club
Trust trading scam site
https://urlscan.io/result/990e52c9-e7a4-41a8-b745-c00024af6d17/
address: rHmwdL4URAxBpDovZRycoFZRKyZsMg6WP6 (xrp)