### PR TITLE
btc-coinbase.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -482,6 +482,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "btc-coinbase.com",
+    "gwayaugust.blogspot.com",
+    "intenrational.bfttrex.com",
+    "litecoingiveaway.info",
+    "bfttrex.com",
     "ethberlin.org",
     "coinbasegive.com",
     "muskelon.ga",


### PR DESCRIPTION
btc-coinbase.com
Trust trading scam site
https://urlscan.io/result/d1307801-c701-4c6f-803a-5dd46603f00c/
address: 1D8t6aVhADka9aDfDnxBwzCRCywMb3YBhz (btc)

gwayaugust.blogspot.com
Trust trading scam site
https://urlscan.io/result/be487cc9-c90d-4385-93b6-44549f9d1341/
address: rhTCdpaZQSKbHNYY85xPLMEWQbyxYr4SFY (xrp)

litecoingiveaway.info
Trust trading scam site
https://urlscan.io/result/2c85c071-2b94-401d-8997-d0a41c6ed9cc/
address: LiP7zzggZpbL3yUqJ5UmNYXcj7NyaP13b6  (ltc)