### PR TITLE
etherdelta.net.ru

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -483,6 +483,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "etherdelta.net.ru",
     "win-coinbase.com",
     "tokengiveaway.in",
     "finalgiveaway.com",


### PR DESCRIPTION
etherdelta.net.ru
Fake EtherDelta phishing for secrets with POST /api.php
https://urlscan.io/result/8c258000-4e4a-4593-9484-f54860a681e9/
https://urlscan.io/result/a89dc222-42c3-4543-b10d-1ae27582955f/