### PR TITLE
gram-chain.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -483,6 +483,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "gram-chain.com",
     "etherdelta.net.ru",
     "win-coinbase.com",
     "tokengiveaway.in",


### PR DESCRIPTION
gram-chain.com
Fake Telegram crowdsale site - usd payments though free-kassa.ru merchant id 158563
https://urlscan.io/result/66b89826-cb38-4ae7-8184-4efa80b575f2/
address: 38cSam9LTWzTRQ5YGBYkSYGJ1thaSc47aa (btc)
address: rsPWJUSb4mheJqPYjBcvB9A15NGnXSBeay (xrp)
address: 0x181b89F4002d2CDE8AfF8D98aE7805EaDf690EA4 (eth)
address: MEdS16jkeNpn1A1RSujUKL2HeDkTrL2riQ (ltc)