### PR TITLE
coinbase-prize.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -483,6 +483,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "coinbase-prize.com",
     "idex.net.ru",
     "gram-chain.com",
     "etherdelta.net.ru",


### PR DESCRIPTION
coinbase-prize.com 
Trust trading scam site
https://urlscan.io/result/848c7a43-d882-4cb0-8b2b-0567c350249e/
address: 19R9MWW88rZwivGWvvz15Ey9G7mpgJYesB (btc)