### PR TITLE
btcandeth.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -483,6 +483,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "btcandeth.com",
+    "dropkraken.com",
+    "binance-get.org",
+    "project2019.services",
+    "bloclkchain.net",
     "coinbase-prize.com",
     "idex.net.ru",
     "gram-chain.com",


### PR DESCRIPTION
btcandeth.com
Trust trading scam site
https://urlscan.io/result/a39bf028-9df4-4493-a4fb-0d81ca49013f/
https://urlscan.io/result/7f91e36e-ef6f-47a1-8e3b-ce38a624b9f7/
https://urlscan.io/result/f529b9c5-cbc0-4379-b0fa-4b76244dbb9c/
address: 1Gmk4V6HA9tKWzVoBaHKyAxHqVv493EnRt  (btc)
address: 0x0CE2EaF01543132b88e5e8156fCAd978994A9Cf6  (eth)

dropkraken.com
Trust trading scam site
https://urlscan.io/result/cead9d30-f985-49fd-a97a-0d06fa6e3495/
https://urlscan.io/result/25aac21d-f8a1-42e5-806f-16994c2b644c/
address: 1MwYGftVPT5zKAg7mfXQmGFjMZHHxBqmYH (btc)

binance-get.org
Trust trading scam site
https://urlscan.io/result/5eded439-e32d-4928-9fb5-c95490356593/

bloclkchain.net 
Fake Blockchain phishing for logins with POST /blockchain/info/subd/wallet/sessions
https://urlscan.io/result/c67fa4e3-850d-46a2-b773-96cd8963d1aa/
https://urlscan.io/result/647a1ad1-5633-4687-9185-4fe09cfeaba6