### PR TITLE
linkairdrop.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -484,8 +484,6 @@
   ],
   "blacklist": [
     "linkairdrop.com",
-    "tokengiveaway.in",
-    "xn--myetherwallt-leb.com",
     "vipmagija.com",
     "kungmedia.com",
     "btcandeth.com",

--- a/src/config.json
+++ b/src/config.json
@@ -483,6 +483,11 @@
     "actua.ad"
   ],
   "blacklist": [
+    "linkairdrop.com",
+    "tokengiveaway.in",
+    "xn--myetherwallt-leb.com",
+    "vipmagija.com",
+    "kungmedia.com",
     "btcandeth.com",
     "dropkraken.com",
     "binance-get.org",


### PR DESCRIPTION
linkairdrop.com
Fake airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/7df49849-c7c8-4684-bb96-4e547fa2c926
https://urlscan.io/result/e56808dc-9b11-4408-aaa3-f7e44709f007
https://urlscan.io/result/47c0ea4d-672d-46c9-b32a-8d3118325bd6

tokengiveaway.in
Trust trading scam site
https://urlscan.io/result/ea1d3e40-33a4-4de0-a8b6-5ea5972e89e2/
https://urlscan.io/result/eadd458c-0e36-4651-8e04-bfc3909062d1/
https://urlscan.io/result/a1e2c522-7614-4e72-b046-d70189fb2d3d/
https://urlscan.io/result/a741ba69-652f-4d02-bb6b-75e9b2858178/
address: 1HRjt8fJ2kBjj3o2AFbjycYuweNwBQCwg2 (btc)
address: 17dbq21i6L2MMDB4zhS2QaAa4DVzwWdmNc (btc)
address: 1CpGNjoG15u2sKFznSkx91iVXWCrB7mws5 (btc)
address: 0xeFDd858ed5c9Df1b977784C3041140EEA533B48C (eth)