### PR TITLE
ethereumboston.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -483,6 +483,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "ethereumboston.com",
     "5000-btc.com",
     "loqin.blcakchian.com",
     "blcakchian.com",


### PR DESCRIPTION
ethereumboston.com
Trust trading scam site
https://urlscan.io/result/08ccd57d-533c-48cc-aaf8-8535e72b38a7/
address: 0xba367D6445c181e4033BB2B49181d5c45868d975 (eth)