### PR TITLE
medium-crypto.xyz + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -483,6 +483,10 @@
     "actua.ad"
   ],
   "blacklist": [
+    "medium-crypto.xyz",
+    "idtex.market",
+    "hitbtc.su",
+    "blcckchian.com",
     "ethereumboston.com",
     "5000-btc.com",
     "loqin.blcakchian.com",


### PR DESCRIPTION
medium-crypto.xyz 
Trust trading scam site
https://urlscan.io/result/3a942e79-b953-4e49-9dd8-bfdca9d84cff/
https://urlscan.io/result/e44f4f97-0495-419d-8b3f-21afa83cc406/
address: 1EZFPTfExR96daXncbi9BGRFC7KYaxJSdT (btc)

hitbtc.su
Fake HitBTC phishing for logins with POST /login.php
https://urlscan.io/result/ef13f11f-5eb3-408c-b15f-af8a0313c501/