### PR TITLE
doubleinv.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -483,6 +483,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "doubleinv.com",
     "medium-crypto.xyz",
     "idtex.market",
     "hitbtc.su",


### PR DESCRIPTION
doubleinv.com
Trust trading scam site
https://urlscan.io/result/5a9a44a8-497d-4c6b-9866-0a865ab2a4f1/
https://urlscan.io/result/638e0d5a-4714-4e51-9a50-d67b6999249a/
https://urlscan.io/result/b922dcab-1311-4f57-adb3-69dd9a83b039/
https://urlscan.io/result/6814fec4-6803-400e-9a9f-a719cdcddf1f/
https://urlscan.io/result/2b149bfe-3d6f-405d-ada6-45d47c43dad4/
https://urlscan.io/result/6288beb5-63ee-485a-a729-0ae080a73f67/
address: 0x379e2308268554DC930c235Ca6b6258920898cCe (eth)
address: 1MNQ4yRmGmUMpzyXk1MmSumCgaHRQAbxuY (btc)
address: qr0kaq02jz96t23kyz3h5dmxk9d53p8wg5jqcfgez7 (bch)
address: GBERM2TINERFTDQDVFSHZLGNWYT5KXTC32IUPGGLFANPDQLD2DOVT3A3 (xlm)