### PR TITLE
info-dex.com + biboxgive.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -484,6 +484,8 @@
     "actua.ad"
   ],
   "blacklist": [
+    "info-dex.com",
+    "biboxgive.com",
     "toreovonline.uk",
     "blockcchain.ru",
     "ethereumclassic.bonus-programs.com",


### PR DESCRIPTION
info-dex.com
Trust trading scam site
https://urlscan.io/result/bed0cff3-43b4-4dcb-8c72-c47d02790fe5/
https://urlscan.io/result/bd8a7581-b50d-4ada-ad32-2a1b93c25557/
https://urlscan.io/result/8f07e75d-2fb8-4331-a6fa-1ade639c9a3b/
https://urlscan.io/result/1b8d6f08-6819-48a4-be7e-19e746feb055/
address: 0x6AeF32C32c765df5eaBF10C56959297e62EcD68e (eth)
address: 15tRrNcqaeUJDTU4ZchrDEKzZquHqxdhx7 (btc)

biboxgive.com
Trust trading scam site
https://urlscan.io/result/a4b417cb-3602-483a-adff-f60b12a74471/
https://urlscan.io/result/7d6b23b2-3457-4fcc-96e7-a1897906ae53/
address: 0x27C57C58559D6e3752375981c499C05279FB68D2 (eth)