### PR TITLE
go-testnet.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -484,6 +484,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "go-testnet.com",
     "info-dex.com",
     "biboxgive.com",
     "toreovonline.uk",


### PR DESCRIPTION
go-testnet.com
Trust trading scam site
https://urlscan.io/result/be461149-9bc2-4192-a76d-a5ec6c8eb3b0/
https://urlscan.io/result/67788eb0-e942-46c0-a109-a645bae8c4f6/
https://urlscan.io/result/aa70a84f-66d2-4f4d-ae71-018179fef91e/
https://urlscan.io/result/da09d416-b3c9-4b6d-b365-661850a1e413/
address: 16dy79qVp6vvAw9sxXHrdG7RcjBCsHxnqH (btc)
address: 0x6AeF32C32c765df5eaBF10C56959297e62EcD68e (eth)