### PR TITLE
atlantis-wallet.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -484,6 +484,7 @@
     "actua.ad"
   ],
   "blacklist": [
+    "atlantis-wallet.com",
     "go-testnet.com",
     "info-dex.com",
     "biboxgive.com",


### PR DESCRIPTION
atlantis-wallet.com
Fake Ethereum wallet phishing for secrets with POST /atlantis_node.php
https://urlscan.io/result/f5073558-82df-4096-a33b-86c656a63cf0/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/3317