### PR TITLE
btcethgift.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -485,6 +485,10 @@
     "aditus.io"
   ],
   "blacklist": [
+    "btcethgift.com",
+    "blockkchain.ru",
+    "login.bllocklnain.com",
+    "bllocklnain.com",
     "mcf2020.net",
     "tmdl.info",
     "xn--stellr-tta.org",


### PR DESCRIPTION
btcethgift.com
Trust trading scam site
https://urlscan.io/result/cc55b03a-9521-47b9-a384-891d5155829c/
https://urlscan.io/result/852584ee-f9f1-481a-ad6c-b038328883e0/
https://urlscan.io/result/ea44843a-33f2-401f-9223-c57c3582f2dd/
address: 0xC8428F2f654BCa80aD74d009a48c5C56fc85ab9f  (eth)
address: 1CkiDfpP794LGjRjeNq5tArzddw42ucvZi  (btc)

blockkchain.ru
Fake blockchain phishing for logins with POST /sp/root/blockchain//wallet/sessions (token 9383f19b-79a3-44ae-95a4-2b5269ab14a)
https://urlscan.io/result/8df9146e-1027-4fbb-b924-a1dc0dff5f20/
https://urlscan.io/result/6331e34c-3424-439e-8677-3311470aa8e6/