### PR TITLE
ddexbit.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -485,6 +485,9 @@
     "aditus.io"
   ],
   "blacklist": [
+    "ddexbit.com",
+    "secure-ledger.com",
+    "ethereumatlantis.network",
     "btcethgift.com",
     "blockkchain.ru",
     "login.bllocklnain.com",


### PR DESCRIPTION
ddexbit.com
Fake ddex phishing for deposits
https://urlscan.io/result/3ffef84c-0a12-4f55-b420-d86290344a4d/
https://urlscan.io/result/14a88030-3d32-4b99-ae32-27f9bcc5d90f/
address: 3AYGe1KZsEwmh8uMHGAsQEAHRmJxczPNMy (btc)
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/3329

secure-ledger.com
Fake Ledger site phishing for mnemonics with POST /wallet/save.php
https://urlscan.io/result/908669f2-6d98-4b0e-aaaa-2f68ee6b0aac/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/3328

ethereumatlantis.network
Fake ETC wallet phishing for secrets with POST /etherwallet/log.php
https://urlscan.io/result/3c81cec7-0891-4b05-83ae-4bb50fb18990/
https://urlscan.io/result/b0cd6398-c3ed-4858-9c36-4d786d773fff/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/3322