### PR TITLE
tokenairdrops.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -485,6 +485,9 @@
     "aditus.io"
   ],
   "blacklist": [
+    "tokenairdrops.net",
+    "idexmarket.info",
+    "xn--localitcoins-bh4f.net",
     "ddexbit.com",
     "secure-ledger.com",
     "ethereumatlantis.network",


### PR DESCRIPTION
tokenairdrops.net
Trust trading scam site - redirect via bit.ly/2lUWADy+
https://urlscan.io/result/5cb516bb-0b18-43ff-8c07-89278f95d673/
https://urlscan.io/result/a9929b17-783e-4c42-af65-78814b69e4aa/
https://urlscan.io/result/c9f1f0d8-4a52-4c9c-b45c-add37d0b3b57/
https://urlscan.io/result/4e1e8bc5-4cc8-4609-9435-27bb751d65d7/
address: rP4bYxry6Eg9mfBmdsX7CcUMYnB3rnNdqt (xrp)
address: 12aqkn88dsTBrMParX9k9J1ZSjWpurCXxo (btc)

idexmarket.info
Fake idex phishing for secrets with POST /log.php
https://urlscan.io/result/141cc859-ac9e-4bab-901c-0b24a1dbd808/
https://urlscan.io/result/b41878fe-08de-475f-beb7-7fec5920164b/

xn--localitcoins-bh4f.net
Fake LocalBitcoins phishing for logins with POST /accounts/login/admm/rdy.php
https://urlscan.io/result/02bd28ad-4a47-4f54-ba32-983ecb670973/
https://urlscan.io/result/6f987d34-f5dd-48a5-87b9-d64476bf7271