### PR TITLE
spacexfree.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -485,6 +485,11 @@
     "aditus.io"
   ],
   "blacklist": [
+    "spacexfree.com",
+    "cryptogood.000webhostapp.com",
+    "delltrade.com",
+    "yobit.website",
+    "netexcoins.com",
     "highcoin.net",
     "coinbascet.com",
     "chartrade.com",


### PR DESCRIPTION
spacexfree.com
Trust trading scam site
https://urlscan.io/result/1a48ee0e-c6c2-4e7e-9e2b-9cf0143a0050/
https://urlscan.io/result/c3ee68d9-92d8-4a54-8c5f-d3af33e0701c/
https://urlscan.io/result/e0048e93-106f-4cef-b58b-56cbedab365a/
address: 1ESJK4wspFSyGPmH64ZdKBSxZAxUtX4pAr (btc)
address: 0xb7D8c320CB7d1de6F7e62Cf65146Ead4Be48aAEB (eth)

cryptogood.000webhostapp.com
Fake exchange
https://urlscan.io/result/a5495bba-e8a4-4070-ac5f-a67993f7314b/

delltrade.com
Fake exchange (same as highcoin.net)
https://urlscan.io/result/ddb8a2a9-eb3e-458c-97b3-9873ccb8dd77/
address: 193DV6FpP1X5w9KLJmLqUHfUqNZFrw9NTW (btc)
address: 0x150f70875C0229Daa9c46E461498F81aB9a76A81 (eth)
address: qpvzcsnn66mzlxn03e58tra7sfelcaj7lq770mt5yg (bch)

yobit.website
Fake yobit site
https://urlscan.io/result/1646b5d4-a405-4de3-80f9-b36cd3b74f04/
https://urlscan.io/result/a10ae7d0-7b94-40ef-a598-b490c5a04247/
address: 17HD8n2Pm1a17QKuJZxjeLDih51xYHHxqq (btc)
address: 0x18f3c8cc8e628db33c56a22ddb092d1af9fc96b3 (eth)
address: qz576ee91a05b194fe37103d0a42899664267bd90c (bch)

netexcoins.com
Fake exchange (similar to highcoin.net)
https://urlscan.io/result/8c3dc3a9-2b01-4864-b467-92c616c391f3/
address: 353SVFnJhzL7F8ofFuDwq6hruoxVjbKW7M (btc)
address: 0xE75CB1646422dD9dB0b47647ee5545f6be341Fb9 (eth)
address: MDF12vRXhgQ32uAF4NCpBaTiHSQda1bn9w (ltc)