### PR TITLE
freebakkt.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -485,6 +485,13 @@
     "aditus.io"
   ],
   "blacklist": [
+    "fakebakkt.com",
+    "libratokensale.com",
+    "getbabb-claims.exclusive-extra-bonuses.com",
+    "exclusive-extra-bonuses.com",
+    "claims-token-erc20.exclusive-extra-bonuses.com",
+    "xrpcompetition.live",
+    "bithumb.live",
     "spacexfree.com",
     "cryptogood.000webhostapp.com",
     "delltrade.com",


### PR DESCRIPTION
freebakkt.com
Trust trading scam site
https://urlscan.io/result/9efbd3f4-0e0c-4fc3-8762-13175d293966/
https://urlscan.io/result/62ede793-61e1-4a5d-a724-a14101c12f56
address: 0x925B2B9371fdf0E21597FAFC3D379Cf3d2160277 (eth)
address: 19zrZUdAF3zR2cPZnwhH4MbvozfKSjDSRQ (btc)

libratokensale.com
Fake Libra token sale
https://archive.st/archive/2019/9/libratokensale.com/apjn/libratokensale.com/index.html
https://urlscan.io/result/23b9a09a-f236-46ee-9454-fbf970b2d992/

getbabb-claims.exclusive-extra-bonuses.com
Fake Babb giveaway directing users to a fake MyEtherWallet (claims-token-erc20.exclusive-extra-bonuses.com)
https://urlscan.io/result/f2a7e63e-6103-487c-8609-33cfe30bdd33

claims-token-erc20.exclusive-extra-bonuses.com
Fake MyEtherWallet phishing for keys with POST /myetherwallet.php/
https://urlscan.io/result/4644d1ec-d457-40fa-989a-fa63c46235f8/

xrpcompetition.live
Trust trading scam site
https://urlscan.io/result/186f18e5-82ce-46c5-b040-63eb4e8d7ad2/
https://urlscan.io/result/de0c0a6f-486b-45d5-9aaf-1410e2376b01/
address: rw9kHpRE52nza51KnG1ndDqw9Lo1mcQM6r (xrp)

bithumb.live
Trust trading scam site
https://urlscan.io/result/8f55db87-12f2-4943-947a-9ab77e0abe45/
address: 0xe2e4B53A1324F5a7368724eA73e532c626517f19 (eth)

Closes https://github.com/MetaMask/eth-phishing-detect/issues/3352
Closes https://github.com/MetaMask/eth-phishing-detect/issues/3351
Closes https://github.com/MetaMask/eth-phishing-detect/issues/3350
Closes https://github.com/MetaMask/eth-phishing-detect/issues/3348
Closes https://github.com/MetaMask/eth-phishing-detect/issues/3347