### PR TITLE
freebakkt.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -485,7 +485,7 @@
     "aditus.io"
   ],
   "blacklist": [
-    "fakebakkt.com",
+    "freebakkt.com",
     "libratokensale.com",
     "getbabb-claims.exclusive-extra-bonuses.com",
     "exclusive-extra-bonuses.com",


### PR DESCRIPTION
freebakkt.com
Trust trading scam site
https://urlscan.io/result/9efbd3f4-0e0c-4fc3-8762-13175d293966/
https://urlscan.io/result/62ede793-61e1-4a5d-a724-a14101c12f56
address: 0x925B2B9371fdf0E21597FAFC3D379Cf3d2160277 (eth)
address: 19zrZUdAF3zR2cPZnwhH4MbvozfKSjDSRQ (btc)