### PR TITLE
dogechain.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -485,6 +485,10 @@
     "aditus.io"
   ],
   "blacklist": [
+    "ltdex.market",
+    "dogechain.org",
+    "exodus.icu",
+    "ton-telegram.net",
     "freebakkt.com",
     "libratokensale.com",
     "getbabb-claims.exclusive-extra-bonuses.com",


### PR DESCRIPTION
dogechain.org
Fake Dogechain wallet (mirrored from dogechains.info/overview/) phishing for details with POST /index.php
https://urlscan.io/result/a14812cc-fe7b-433f-bf50-4fd088d98c9e/

exodus.icu
Fake MyCrypto download - https://app.any.run/tasks/6ddb8bf1-81f1-4cd4-9c86-ff26335d050f
https://urlscan.io/result/96c04d7c-214d-4e9f-9aba-256400280622/

ton-telegram.net
Fake Telegram crowdsale site - linking users to tg://resolve?domain=TonometerBot
https://urlscan.io/result/1da526d1-dc18-4c40-b840-ab5471afd674/