### PR TITLE
Unblock droppages

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8377,7 +8377,6 @@
     "tokensale-adhive.com",
     "ataritoken.ltd",
     "transfer-address-confirmation.droppages.com",
-    "droppages.com",
     "dfinlty.org",
     "poloniex.work",
     "tokensale-havven.in",


### PR DESCRIPTION
This is a CDN, and while it has been used to host many scams, it does not seem to be itself a scam and hosts other sites.

Based on https://github.com/MetaMask/metamask-extension/issues/7100