### PR TITLE
add fairwin.me to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -501,6 +501,7 @@
     "aditus.io"
   ],
   "blacklist": [
+    "fairwin.me",
     "medium-crypto.tech",
     "bakktgift.info",
     "chainlink.webcindario.com",


### PR DESCRIPTION
scam reported:
https://twitter.com/quantstamp/status/1177648648299040769?s=21
https://concourseq.io/Q/FairWin.me
https://mobile.twitter.com/cleanunicorn/status/1177544181679558656

Ethgasstation, and etherscan are reporting this as well.