### PR TITLE
quickinv.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -501,6 +501,12 @@
     "aditus.io"
   ],
   "blacklist": [
+    "quickinv.com",
+    "mcafee-prize.online",
+    "bakkt-event-start.netlify.com",
+    "spacexbit.com",
+    "unruffled-shockley-1db491.netlify.com",
+    "t3md.net",
     "earnbros.com",
     "m2020.me",
     "rippleinsights.pro",


### PR DESCRIPTION
quickinv.com
Trust trading scam site - fake bitcoin doubler
https://urlscan.io/result/5c513b93-0c16-4e90-a8b9-8c2dd9d3e1bd/
https://urlscan.io/result/54b65be6-e32b-4b5e-a77e-ce87d72f126e/
https://urlscan.io/result/62c0f651-7a09-4424-99ae-2bdd747bf087/

mcafee-prize.online
Trust trading scam site
https://urlscan.io/result/bee2aa54-bad6-4cfe-89af-ea96a1e44e53/
https://urlscan.io/result/6f4f130f-08b2-442f-8dd3-e164e49e5301/
https://urlscan.io/result/4e91d552-d40c-4824-b117-aa9cca670511/
address: 18WR6TiLrT76qz546UVEEjhR8UoR2wSxzi (btc)
address: 0xD2418A41A708676C450117cA1592Ebf435F01ee7 (eth)

bakkt-event-start.netlify.com
Trust trading scam site
https://urlscan.io/result/40805658-2a2a-4a2e-adcc-c510fe03b608/
https://urlscan.io/result/f076b278-6321-44e3-a9b9-3418d3b72c88/
https://urlscan.io/result/9c1cbfeb-0b7b-48af-b965-b550b8479cac/
address: 0x71D663DE2Df38D61A1871Bb8eF503d18D19964d6 (eth)
address: 1J1dss8NQVuezZ4GTUZNYMxueQhCN6XTGV (btc)

spacexbit.com
Trust trading scam site - linking users to unruffled-shockley-1db491.netlify.com
https://urlscan.io/result/98e91a52-d3df-47dc-bf29-57bc90d72f10/
address: 18Q3MbqJyTJdxtjjACzkbP4qMDgRa4yYc8 (btc)
address: 0xeF79301402010f85b14ce5A931AB14e6DE60bCc0 (eth)

unruffled-shockley-1db491.netlify.com
Trust trading scam site
https://urlscan.io/result/f4848527-5a1a-442e-98ef-abebcd14c68e/
https://urlscan.io/result/f32cdfad-deab-4cc1-9dd4-1cc83935ef92/
address: 18Q3MbqJyTJdxtjjACzkbP4qMDgRa4yYc8 (btc)
address: 0xeF79301402010f85b14ce5A931AB14e6DE60bCc0 (eth)

t3md.net
Trust trading scam site
https://urlscan.io/result/80269e3e-0f02-43ac-bf5d-d7287fa7921a/
https://urlscan.io/result/d7a8b59b-bcde-421d-be90-ef25363c8a08/
address: 1FQML5ZpPRJur5d4B7NdXBiCT6ktVCAodU (btc)
address: 0x6194338943d1fB18C4399f042FE9790e4b80fbAc (eth)