### PR TITLE
eth-charity.tech + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -502,6 +502,9 @@
     "aditus.io"
   ],
   "blacklist": [
+    "eth-charity.tech",
+    "tonpresale.com",
+    "ethget.org",
     "ildex.host",
     "blittrex.intrenational.com",
     "lcgin-blockchian.com",


### PR DESCRIPTION
eth-charity.tech
Trust trading scam site
https://urlscan.io/result/346cb306-9f7a-4c81-85c8-3163cff33b29/
address: 0x69ff68516cB36384546786243E1F314D7b9C7E57 (eth)

ethget.org
Trust trading scam site
https://urlscan.io/result/511f8b2b-318d-4c27-a233-501917b172ea/
address: 0xB3805B7A3098F9E8E4C0A4bFa212d2C8d7d072a6 (eth)

tonpresale.com
Fake Telegram crowdsale site
https://urlscan.io/result/4fd6ab3a-b92d-44db-bc97-5ce3a310eb89/
https://urlscan.io/result/27d6f0a7-ca40-4fb1-b6aa-0884baa1b438
address: 1KCoVnnNv6UaqFJ9PogYwhPA2Rn9hPy4R (btc)
address: 0xC25Fed458cd7Ee6948729faD58bEbC640BdbCD18 (eth)


---

claim-btc.com
Trust trading scam site
https://urlscan.io/result/1eb0b829-ae29-4756-8f91-a48759bbd4a1/
address: 1DUEPJfr8ayZnHo8i3MxXVfu51Grpk6NwY (btc)