### PR TITLE
investmentworld.site + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -502,6 +502,10 @@
     "aditus.io"
   ],
   "blacklist": [
+    "investmentworld.site",
+    "bondinvest.site",
+    "lidex.market",
+    "binancebnbgive.com",
     "eth-charity.tech",
     "tonpresale.com",
     "ethget.org",


### PR DESCRIPTION
investmentworld.site
Ponzi scheme - fake team. Redirect from bondinvest.site
https://urlscan.io/result/5ebd067f-d0e2-46cb-ac18-a4e9e16cfdd1/
https://urlscan.io/result/f4a94703-90ec-4d7b-86c3-f99c5ece7f3e/
https://urlscan.io/result/d3001405-5c2a-402c-a5a2-787fd630eec5/
https://urlscan.io/result/b997f98c-2d39-47fc-82d5-40db9433f00b/
address: 1NnCo286LQGQMAsqPzmWkrGzV5nNWusHGi (btc)
address: qp40j4gcxsf40sutcgk2z0u57hgm6vycssy05th5q3 (bch)
address: 0xf34b357fE1538a67b88cD39b90C45AD36496Dc39 (eth)

lidex.market
Fake Idex market phishing for secrets with POST /log.php
https://urlscan.io/result/bed1c20f-2ccf-47e1-8b56-008e254344bc/
https://urlscan.io/result/08bfd78f-55bb-486d-add3-fd8ea04be294/
https://urlscan.io/result/d70eff3c-959d-4050-8dc2-ee278fb7c8bd/

binancebnbgive.com
Trust trading scam site
https://urlscan.io/result/dec6c959-9a90-412e-9f89-c6e636dcce07/
https://urlscan.io/result/2ae44c67-a5f6-4626-b63f-f177878db926/
address: bnb18htn90crd0cjyzauagcx05grcg3wx70yphvqep (bnb)