### PR TITLE
ethaget.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -502,6 +502,9 @@
     "aditus.io"
   ],
   "blacklist": [
+    "ethaget.com",
+    "coinxkeep.com",
+    "cravetrade.com",
     "investmentworld.site",
     "bondinvest.site",
     "lidex.market",


### PR DESCRIPTION
ethaget.com
Fake MyEtherWallet phishing for secrets with POST /savekey.php
https://urlscan.io/result/67dc7eb8-72fc-4314-bfd7-869f92ada5a9/

coinxkeep.com
Fake exchange
https://urlscan.io/result/e5f6da4a-68b6-4401-aac1-4d112ef6f67f/
address: 3KKEdyXwWL4XqXJ6ffQEBfTVWCs2cgwHMd (btc)
address: 1JZGCSb7iiGMfH2xYwKQqbA7dvomYwrGrq (btc)
address: 0x5FAe64a5306672c79E4654873960b20611eA548A (eth)
address: 0x2EA0D2F367eEEbd4cC9980ecDE8D228C726f5A2F (eth)
address: qrqfgg5c2zwyaleguh33gxrj2q0e266uzu2af4e62r (bch)

Closes https://github.com/MetaMask/eth-phishing-detect/issues/3394
Closes https://github.com/MetaMask/eth-phishing-detect/issues/3388