### PR TITLE
claimbtc.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -502,6 +502,8 @@
     "aditus.io"
   ],
   "blacklist": [
+    "claimbtc.org",
+    "elonspace.online",
     "xrpinsights.live",
     "ethaget.com",
     "coinxkeep.com",


### PR DESCRIPTION
claimbtc.org
Trust trading scam site
https://urlscan.io/result/e1771b61-c459-4230-a706-782e78162463/
address: 1J8NeCnr2WpNsjSFCGWmkWaSMt7TgnvdZr (btc)

elonspace.online
Trust trading scam site
https://urlscan.io/result/36b536db-b3c5-44b8-9abf-1b5eb9d5e17e/
https://urlscan.io/result/7a31e897-9be9-4a0d-90d5-0103bc2afb94/
https://urlscan.io/result/dd9efb85-ba5f-47b2-ad75-924c8afa0a6e/
address: 0xB52F5eA6DD9FC119f8195858f785C00c3B5e17Ba  (eth)
address: 1Hf37TQ8agT4y9g3d7fwjnv95hTp7wEYfW (btc)