### PR TITLE
bitinfo.cc

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -7448,6 +7448,7 @@
     "xn--mytherwalt-smbh17c.com",
     "bitcointalk.to",
     "bitcointolk.org",
+    "bitinfo.cc",
     "sebiltv.com.tr",
     "ethbonus.net",
     "etherspromo.org",


### PR DESCRIPTION
Fake version of the original bitcointalk.org forum.

This fake site seems to scrape bitcointalk.org threads and forum posts with the intent to phish account credentials.

Reference: https://bitcointalk.org/index.php?topic=5193542.0

Urlscan: https://urlscan.io/result/40e43335-3cac-410f-9786-54353a49b554/