### PR TITLE
added blacklist site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -75,6 +75,7 @@
     "ohmycrypto.news",
     "aureus.cl",
     "audius.de",
+    "ethplode.org",
     "sfcrypto.co",
     "alytus.lt",
     "nbcrypto.eu",
@@ -502,6 +503,7 @@
     "aditus.io"
   ],
   "blacklist": [
+    "ethplode.live",
     "mygram.pro",
     "gramsale.org",
     "mc2020get.com",


### PR DESCRIPTION
ethplode.org is original site
ethplode.live is scam site..