### PR TITLE
add Cryptrix.ru to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -502,6 +502,7 @@
     "aditus.io"
   ],
   "blacklist": [
+    "Cryptrix.ru",
     "mygram.pro",
     "gramsale.org",
     "mc2020get.com",


### PR DESCRIPTION
Cryptrix.ru reported as scam

support reference:
26110
26200
26213
26058