### PR TITLE
login.bllockhaiin.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,11 @@
     "aditus.io"
   ],
   "blacklist": [
+    "login.bllockhaiin.com",
+    "bllockhaiin.com",
+    "idexmarket.art",
+    "hellogold.in",
+    "steemeth.com",
     "beentrade.org",
     "coinspin.net",
     "bitlare.com",


### PR DESCRIPTION
login.bllockhaiin.com
Fake blockchain phishing for logins
https://urlscan.io/result/85979d87-6311-44c6-adbc-e389f94d5363/

idexmarket.art
Fake idexmarket
https://urlscan.io/result/92c76a82-e3d3-4ea0-bd14-710ef6660f46/

hellogold.in
Fake HelloGold site
https://urlscan.io/result/605e9303-f852-448f-9564-273a7c0eec07/

steemeth.com
Trust trading scam site
https://urlscan.io/result/d957dd4f-a018-432a-bf04-ad8fd0fca228/
address: 0xC85f7D1bb0f462D3AB2a2d83E4D5dd2C5ADfCe46 (eth)