### PR TITLE
myetherwallet-giveaway.000webhostapp.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,9 @@
     "aditus.io"
   ],
   "blacklist": [
+    "myetherwallet-giveaway.000webhostapp.com",
+    "extra-bonuses.ga", 
+    "official-ethers.com",
     "login.bllockhaiin.com",
     "bllockhaiin.com",
     "idexmarket.art",


### PR DESCRIPTION
myetherwallet-giveaway.000webhostapp.com
Fake MyEtherWallet phishing for secrets, posting to next.extra-bonuses.ga/myether/claim.php
https://urlscan.io/result/072572e1-6c68-46de-97b2-5fc3fb5abebb/
https://urlscan.io/result/e9a56c35-63a3-4687-8518-9201e99e7e77/
https://urlscan.io/result/381825d3-ad62-4eeb-b6b4-16278bf323df/
https://urlscan.io/result/2553bdad-a3e3-491d-b5f6-f92274d110a9/

official-ethers.com
Trust trading scam site
https://urlscan.io/result/6c8ba0ff-1a7a-4adf-bede-364268f1e803
address: 0x2f0509efAd8555012Ac770866FEce8d35E73A492 (eth)