### PR TITLE
crypto-reward.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,10 @@
     "aditus.io"
   ],
   "blacklist": [
+    "crypto-reward.com",
+    "intrenational.bjtftrex.com",
+    "bjtftrex.com",
+    "2xbonus.live",
     "coinbaseteam.com",
     "idex-market.info",
     "geteth.site",


### PR DESCRIPTION
crypto-reward.com
Trust trading scam site
https://urlscan.io/result/b5d2a6de-457e-4f1b-9daf-7e5157703318/
address: 1EquZuJKARvHai9bvJbqN1ZburkAUiCdKw (btc)

2xbonus.live
Trust trading scam site
https://urlscan.io/result/a89e0c21-74c1-45e9-955e-1cf54172d418
address: 0x1071C1e161A70Afe8f4D60635df7bDA3EDcc75Fc (eth)
address: 0xb3741871090D91A0087CFf96082a37433f84F873 (eth)