### PR TITLE
chainlinktoken.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "aditus.io"
   ],
   "blacklist": [
+    "chainlinktoken.net",
+    "chainlink-info.pro",
     "claim-erc20-token-bonus.ga",
     "bancor-network.ga",
     "crypto-reward.com",


### PR DESCRIPTION
chainlinktoken.net
Fake chainlink airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/50685e39-aff8-4721-a1f3-4d5bd7b2eafb/
https://urlscan.io/result/b6820053-73ed-4980-8ec9-27e1eb8cca09/
https://urlscan.io/result/ae01bd97-0871-4119-b00e-631c3d0cf3d5/
https://urlscan.io/result/9a33ee3f-b584-479f-9501-e9038239752d