### PR TITLE
official-mcafee.me + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,9 @@
     "aditus.io"
   ],
   "blacklist": [
+    "official-mcafee.me",
+    "elonbonus.com",
+    "idex-market.space",
     "sai2dai.com",
     "wallet.trezcr.com",
     "trezcr.com",


### PR DESCRIPTION
official-mcafee.me
Trust trading scam site
https://urlscan.io/result/a4f3b67d-2526-4574-a9d5-e9c3ef47cbcf/
https://urlscan.io/result/b5a00605-dd98-4149-a1e5-be8bc4d4d459/
https://urlscan.io/result/16a9ff85-e354-4e28-805c-3e50fdbf4ac4/
address: 1D6K4JzMtscFLFevtLeFsbsnoZDFMFHzCR (btc)
address: 0x1BA10320062103Ef36716bb888E739d41b17efF2 (eth)

elonbonus.com
Trust trading scam site
https://urlscan.io/result/5159d829-1a40-486c-a846-a07337ed0850/
https://urlscan.io/result/72a74906-51fe-4141-b683-4902368ae079/
https://urlscan.io/result/18b3c887-b2d0-4a8e-966d-f81626e84028/
address: 0xCF70C00655Ec4356005983420B7AdC866316713b (eth)
address: 1C44Fs8wNstrp9fLKKV89uSDoQWBbChfWL (btc)

idex-market.space
Fake Idex phishing for secrets with POST /log.php
https://urlscan.io/result/b56f1908-1573-456e-bc46-e4f76049257a/
https://urlscan.io/result/bd75209b-f721-4999-acd3-f7b73a1d932c/