### PR TITLE
reward-crypto.com + spacexbit.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "aditus.io"
   ],
   "blacklist": [
+    "reward-crypto.com",
+    "spacexbit.net",
     "spacexbit.info",
     "terezor.io",
     "wallet.terezor.io",


### PR DESCRIPTION
reward-crypto.com
Trust trading scam site
https://urlscan.io/result/1b9b5ede-2a36-4b19-90a6-45c199614df5/
https://urlscan.io/result/b9560df8-25ff-4e53-9021-424d337d9073/
https://urlscan.io/result/9992ebba-f4a9-496c-a5b8-4fba8bd6eaa1/
https://urlscan.io/result/e7e35f15-a94b-4ec9-ab8b-3465c5c225c4/
address: 15oDUWND6QkDPFQ5bpfMNcHC3ZU3oxmao7 (btc)
address: 1L6jmSN8EnwpcvsW4Bhvjo47gpMnNf2XR8 (btc)
address: 1LPtmuQtht7U1mrLJW5GtniAFnP2mvUo4c (btc)
address: 19q96TZPwt6nkmTeppQpirbPvuFVGmGPsy (btc)

spacexbit.net
Trust trading scam site
https://urlscan.io/result/8596aad8-8773-4b86-b4f2-418e71058e1e/
https://urlscan.io/result/aeb0ed90-188c-4f9b-b255-529edd5fc392/
https://urlscan.io/result/1ef93c86-6a9f-469d-a303-9c7239d7945d/
address: 1Dce8kjMfFzFh48a9njNvqZiqGe7mR39ix (btc)
address: 0x52414069b0AF176210603ef8621d0B0D6b669e6A (eth)