### PR TITLE
cryptoback.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,12 @@
     "aditus.io"
   ],
   "blacklist": [
+    "cryptoback.org",
+    "trezor.bz",
+    "wallet.trezor.bz",
+    "bedstchange.pp.ru",
+    "xn--bestchnge-51a.net",
+    "xn--betchange-6ld.net",
     "3mdl.pw",
     "trezor-info-wallet.musicfestes.com",
     "muskbonus.info",


### PR DESCRIPTION
cryptoback.org
Fake crypto cashback extension (malware)
https://urlscan.io/result/1d6868f0-783c-4569-a529-e6bd36487a0d/
https://urlscan.io/result/4dacadfc-7a05-446a-851a-27081b1f1d2b/

bedstchange.pp.ru
Fake BestChange site
https://urlscan.io/result/3f85a3c2-de70-41dc-b763-84167591d0f9/