### PR TITLE
coinxback.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -514,6 +514,8 @@
     "aditus.io"
   ],
   "blacklist": [
+    "coinxback.com",
+    "cryptocloudx.com",    
     "saitodai.app",
     "cryptoback.org",
     "trezor.bz",
@@ -593,7 +595,6 @@
     "beentrade.org",
     "coinspin.net",
     "bitlare.com",
-    "cryptocloudx.com",
     "uni-pouch.com",
     "elon-get.com",
     "lite.foundation",


### PR DESCRIPTION
coinxback.com
Pushing a malware browser extension to users to steal cookies (id: bhihlepfeofebhiafmidfeipambijdgl) - see mega thread: https://twitter.com/sniko_/status/1199366050783072257
https://urlscan.io/result/afb61416-5989-49db-aa05-3f677a74dc69/
https://urlscan.io/result/ab71e0cf-41c6-4d71-ac18-63efdb27a53d/