### PR TITLE
myetherwallet-getfreetoken.000webhostapp.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -514,6 +514,11 @@
     "aditus.io"
   ],
   "blacklist": [
+    "myetherwallet-getfreetoken.000webhostapp.com",
+    "get-extra.ml",
+    "myetherwallet.rekllama.com",
+    "vintage-myetherwallet.telegram-airdrop.com",
+    "telegram-airdrop.com",
     "coinxback.com",
     "cryptocloudx.com",    
     "saitodai.app",


### PR DESCRIPTION
myetherwallet-getfreetoken.000webhostapp.com
Fake MyEtherWallet phishing for secrets with POST //next.get-extra.ml/ether/claim.php
https://urlscan.io/result/8ba6faca-e612-4856-bc02-fb9ee63e22e8/

vintage-myetherwallet.telegram-airdrop.com
Fake MyEtherWallet
https://urlscan.io/result/8692c38b-6782-4ccf-8bff-de5aa9e68bfe/

telegram-airdrop.com
Fake Telegram crowdsale site pushing malware downloads
https://urlscan.io/result/bbe642f7-999f-432b-9892-bc0e26a2acaa/