### PR TITLE
myetherwallet-getextratoken.000webhostapp.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -514,6 +514,9 @@
     "aditus.io"
   ],
   "blacklist": [
+    "myetherwallet-getextratoken.000webhostapp.com",
+    "triezor.io",
+    "ldexmarket.ru.com",
     "margineth.online",
     "bloom.reward-programs.erc20-tokens.com",
     "erc20-tokens.com",


### PR DESCRIPTION
myetherwallet-getextratoken.000webhostapp.com
Fake MyEtherWallet phishing for secrets with POST //next.get-extra.ml/myether/claim.php - redirected via bitly.com/34EeImF+
https://urlscan.io/result/b4509d3d-7ea4-489f-ac6b-394063bd24d3

ldexmarket.ru.com
Fake Idex market phishing for secrets with POST /log.php
https://urlscan.io/result/56abc374-ec92-4ccd-bb9e-671900cf93af/
https://urlscan.io/result/33dbed65-598d-43f1-b3b5-21e33f5e062b