### PR TITLE
Unblock Privatex.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -9402,7 +9402,6 @@
     "myetherwalletver.com",
     "privatix.top",
     "privatix.pro",
-    "privatex.io",
     "stormtoken.cc",
     "raiden.online",
     "stormstoken.com",


### PR DESCRIPTION
It was added in this commit:
https://github.com/409H/EtherAddressLookup/commit/29ee9a9c274debe320b0a91fc57afcd4a59ac70d
Which references a broken urlscan link, but a search of urlscan shows that site as ok:
https://urlscan.io/result/9ecbc06d-c030-49a0-a179-18ed249b34fb/

Reading [their original reasoning](https://github.com/409H/EtherAddressLookup/pull/132), looks like privatix was a regular target of phishing attacks, and privatex.io was at one time used to phish their users, but looking at it now, it appears to now to not be impersonating privatix at all, but to have its own somewhat distinct branding for a crypto wallet, so I think we can safely unblock for now, we can always re-block if phishing returns.

Fixes #3405.