### PR TITLE
xn--treor-wib.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -515,6 +515,10 @@
     "aditus.io"
   ],
   "blacklist": [
+    "xn--treor-wib.com",
+    "trerzor.io",
+    "btcgift.pro",
+    "claim-stellar.info",
     "coinbase5k.com",
     "receipt.invoice.reward-ethereum.cf",
     "reward-ethereum.cf",


### PR DESCRIPTION
xn--treor-wib.com
Fake Trezor site phishing for secrets with POST /ifu/upload.php
https://urlscan.io/result/dd40feb0-297e-4a28-9526-b05a57da5884/
https://urlscan.io/result/737711e9-544d-4d73-9848-0c5a10e557b1/
https://urlscan.io/result/e5b8e998-7ec4-477a-b7c0-50b4ce802ec6/

btcgift.pro
Trust trading scam site
https://urlscan.io/result/ddd63d49-7d07-4ca1-9f9e-b87cdd371b91/
address: 1BWh5qJfCs7S69ZRXwgEEFRDL4sdeh4EP2 (btc)

claim-stellar.info
Fake giveaway hosting malware - https://www.virustotal.com/gui/url-analysis/u-7f441dff58d0a9d2a6a8a5d79ac80cff2fb8fd1016c8fe93402015cee4d9b05c-1575334482/detection & https://app.any.run/tasks/06d8e351-a0f9-48c6-a208-329c24ae1972
https://urlscan.io/result/84a6fcf7-a345-40b4-b556-88c5a098c38a/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/3478