### PR TITLE
wallet.trrezor.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -515,6 +515,15 @@
     "aditus.io"
   ],
   "blacklist": [
+    "trezgr.io",
+    "wallet.trrezor.com",
+    "trrezor.com",
+    "xn--bestcange-u85d.com",
+    "xn--bstchange-03a.com",
+    "xn--bestchang-83a.com",
+    "xn--besthnge-49a5586e.net",
+    "beldexcoins.com",
+    "mcafeegiveaway.com",    
     "btc-on.com",
     "ripple-gifts.online",
     "coinbasegrant.com",


### PR DESCRIPTION
wallet.trrezor.com
Fake Trezor wallet phishing for secrets
https://urlscan.io/result/ec8a819f-1c99-4c27-b376-bad3f3428370/
https://urlscan.io/result/57e4df99-82a3-477e-85fe-654a2548b5d3/

beldexcoins.com
Fake exchange phishing for deposits (also pointing users to coinxback.com)
https://urlscan.io/result/888d9867-2463-4ed0-92b4-9377c1e67ab8/
address: 3MiMhJh9XYyHL6L9MuWfeTw9ULZtSkQoy3 (btc)
address: 0xEe18e156a020F2b2B2DcdEC3A9476E61fBDE1e48 (eth)

mcafeegiveaway.com
Trust trading scam site
https://urlscan.io/result/7605b1af-1de1-44a6-bbaf-e19b7252db84/
address: 1FrpXF2JBavTqoMNk6K6TmK37H6s8chtJq (btc)