### PR TITLE
Adding hex.win - extremely damaging and ongoing

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -10125,6 +10125,7 @@
     "etoroglobal.com",
     "bcrypto.club",
     "airdrop-bitnational.com",
-    "wasabibitcoinwallet.org"
+    "wasabibitcoinwallet.org",
+    "hex.win"
   ]
 }


### PR DESCRIPTION
https://www.theblockcrypto.com/post/49989/the-hex-token-sale-may-be-an-unregistered-securities-offering-but-its-no-ponzi

> It's like saying "Heroin is not a schedule I controlled substance.  There aren't actually any drugs, they're just molecules in the universe."

You can debate:
- Scam? 
- Ponzi? 
- Pyramid scheme?

*(definitely not "certificate of deposit")*

Check the source code: https://etherscan.io/address/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39#code

# `FLUSH_ADDR` ?

<img width="634" alt="Screenshot 2019-12-19 at 13 17 00" src="https://user-images.githubusercontent.com/59055236/71176624-26201e80-2262-11ea-8b7e-cca2d48a0f24.png">

_(do your own research where the "released value" is going - **congratulations** - you've just released yourself from ETH coin)_

Some further discussion:
https://www.reddit.com/r/ethfinance/comments/e1zhyj/warning_beware_of_richard_hearts_hex_project/

# ~Use your own brain.~ Actually I'm realising life is complicated and not everyone has time to run deep analysis of everything.

Using throw away account as I want to protect users, as well as my own family - definitely don't want to engage with these type of guys:

<img width="981" alt="Screenshot 2019-12-19 at 13 23 25" src="https://user-images.githubusercontent.com/59055236/71176930-c8d89d00-2262-11ea-831f-bbae473ca1c1.png">

If you are a journalist looking for a comment - comment in this thread and I'll try to check again in some time...