### PR TITLE
coinbasegive.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -527,6 +527,16 @@
     "aditus.io"
   ],
   "blacklist": [
+    "coinbasegive.net",
+    "btcfree.pro",
+    "coinbasegive.net",
+    "stellardrop.com",
+    "mercatox2xbonus.com",
+    "bitcoindoubler.tech",
+    "upgradesai2dai.com",
+    "xn--bstchnge-neb8176e.net",
+    "xn--bestchge-dqb3626e.net",
+    "xn--bstchane-10a01d.net",
     "stellar.us.com",
     "coinbase12.info",
     "cash-coinbase.com",

--- a/src/config.json
+++ b/src/config.json
@@ -527,7 +527,6 @@
     "aditus.io"
   ],
   "blacklist": [
-    "coinbasegive.net",
     "btcfree.pro",
     "coinbasegive.net",
     "stellardrop.com",


### PR DESCRIPTION
coinbasegive.net
Trust trading scam site
https://urlscan.io/result/8a3d16f8-0815-41a3-a557-50f08c99fa01/
https://urlscan.io/result/fedaa416-cc97-46ac-b77f-1c8f399b24cb/
https://urlscan.io/result/a4f1f674-1b8c-4498-951e-36bfdc3c02d5/
https://urlscan.io/result/ea0d31d0-da30-4190-b2cd-7febff3080dc/
address: 1FDGyP8K4kCEJBVuYEpVsgR1xohSVxDNoG (btc)
address: 1MCn83372bd4p6wDDZX2i6P532uA45qCLm (btc)
address: 139ZK1uHm8mT5N2PR3k9pF5oNix773kEzp (btc)
address: 1LcZDvjWwYaRJJEeBhcpu3KL1ZeCXQbpaG (btc)

stellardrop.com
Trust trading scam site
https://urlscan.io/result/b5edecbd-7f91-48c9-b725-ae24a1f6e771/
address: GCVANRQKI3IURULGVE4HSVZNFTR3LQOE4QPQORLIOJUUUODPQKYYY3ZI (XLM)

mercatox2xbonus.com
Trust trading scam site
https://urlscan.io/result/efa447c5-ba0f-4a37-969c-4ede2737336d
address: 0x14C0Bc72b6023e3d8f8F2D37FAd785bcC32D543f (eth)

bitcoindoubler.tech
Trust trading scam site
https://urlscan.io/result/6c9e1206-f01c-43a1-9f4c-2423684f5164/
https://urlscan.io/result/eca7d5fb-e3fa-42b9-a392-01b5cc5c357b
address: 3QdomtH1J671ty2LebzhivBwHP9PY9FciA (btc)

---

elonmuskgo.com
Trust trading scam site
https://urlscan.io/result/6dcf3628-1c50-48eb-9a5f-8b8a0e7abd5f/
https://urlscan.io/result/bd9f1af3-05bc-460d-b409-781a90cf68d5/
https://urlscan.io/result/82f33022-c57a-46d7-ba5a-469831697e3c/
address: 0x72736a91F746b8E0c446B32948BB7cd8C2F8c54A  (eth)
address: 1PRU7koiVABKZK9Q1G2FEphRf6XsTD2bTK  (btc)