### PR TITLE
blockchainsevent.claim-free-btc.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -529,6 +529,14 @@
     "aditus.io"
   ],
   "blacklist": [
+    "trezors.io",
+    "blockchainsevent.claim-free-btc.com",
+    "airdrop-stx-blockchain.info",
+    "coinbase-promo.info",
+    "login.lblockhcoin.com",
+    "lblockhcoin.com",
+    "login-bllockchain.com",
+    "brestchange.ru",
     "site-blockchain.jdevcloud.com",
     "myehterwalltet.info",
     "lastchance.tech",


### PR DESCRIPTION
blockchainsevent.claim-free-btc.com
Fake BlockchainInfo phishing for mnemonics with POST /appblockchain.php
https://urlscan.io/result/b204cdc8-8618-466c-8f4b-6d4a80bd2c1b/
https://urlscan.io/result/fb65ad09-0c89-4cef-8187-d504b0672c8e/

airdrop-stx-blockchain.info
Fake BlockchainInfo phishing for logins with POST /register
https://urlscan.io/result/0dadacb8-c966-4ca9-b629-662fa443f8ad/
https://urlscan.io/result/3e7d4bca-8783-4fbe-98e3-0de6fc5b54d1/

login-bllockchain.com
Fake BlockchainInfo phishing for logins with POST //comroot.herokuapp.com/wallet/sessions (api key: 1770d5d9-bcea-4d28-ad21-6cbd5be018a8)
https://urlscan.io/result/7e9626c0-17d5-4e21-8454-b1c6b656aa61/