### PR TITLE
coinbase-xmas.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -529,6 +529,11 @@
     "aditus.io"
   ],
   "blacklist": [
+    "coinbase-xmas.com",
+    "xmasgive.info",
+    "trezor.world",
+    "xn--trzr-cpa7e.com",
+    "ripplelabs.space",
     "elonchristmas.com",
     "coinbasexmas.com",
     "xmasbtc.com",


### PR DESCRIPTION
coinbase-xmas.com
Trust trading scam site
https://urlscan.io/result/6e118522-804c-4e04-9b3b-148a2d3b760d/
https://urlscan.io/result/5e25b25e-1b9e-4ee4-9328-bc52d99a8f57/
address: 1N4J2oTxhsdtbwqC7Xu8Pmw92CNxoDyuiE (btc)

xn--trzr-cpa7e.com
Fake Trezor site phishing for mnemonics with POST /ifu/upload.php (has a fingerprinting technique to show a different page if it detects a bot such as urlscan)
https://urlscan.io/result/d776a0b1-e211-421d-a250-f3c4ef7d17de/
https://urlscan.io/result/5c8e92ce-2029-498d-8c51-fab840aaf069/
https://urlscan.io/result/2baab1b4-8464-4efd-8439-63ab9ca06265

ripplelabs.space
Trust trading scam site
https://urlscan.io/result/fbd9cd92-2636-4a6e-92da-01d37fbb7270/
address: rHfrzH5rZ2d16V7oKMbh15qY8aB48zF6eE   (xrp)

---

official-ethers.com
Trust trading scam site
https://urlscan.io/result/81e522ca-75ef-46b1-ad52-a8d1a7eb7cd0/
address: 0x45978Fb0Fe38db2E4E54e866F9000D5f8D3aB7e9 (eth)