### PR TITLE
elonxcrypto.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -532,6 +532,10 @@
     "aditus.io"
   ],
   "blacklist": [
+    "elonxcrypto.com",
+    "xn--myetherwet-bhb64ea.com",
+    "myetherwallet.colu.com",
+    "blokchiain.com",
     "vitaliketh.com",
     "hoxbit.com",
     "free-ethereum.io",


### PR DESCRIPTION
elonxcrypto.com
Trust trading scam site
https://urlscan.io/result/161e6ac8-5002-442e-9529-6b67bebd7b2b/
address: 1FPPtjS2tYyyPyGxjBRwxzfPxwNuPkwqBA (btc)

myetherwallet.colu.com
Fake MyEtherWallet
https://urlscan.io/result/4894cead-c213-4c38-9fc8-34a22e41523c/