### PR TITLE
#3560 Add ALIS to whitelist.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -540,7 +540,8 @@
     "orionprotocol.io",
     "etherspin.co",
     "actua.ad",
-    "aditus.io"
+    "aditus.io",
+    "alis.to"
   ],
   "blacklist": [
     "makerdao.ltd",


### PR DESCRIPTION
Dear Metamask Team,
To our surprise, our platform's domain: https://alis.to has been blocked for being similar to https://oasis.app. Taking a brief look at the other reported issues, it seems this has been a trend for the past day.

We are a well-known service in Japan, have worked together with companies like Microsoft, been covered by multiple major media outlets and were speakers at Devcon 5.

https://prtimes.jp/main/html/rd/p/000000005.000027792.html
https://devcon.org/speakers
https://cointelegraph.com/news/blockchain-powers-shift-to-decentralization-in-media

Needless to say, we are in no way similar to oasis.app and would, therefore, like to ask you kindly to whitelist us as soon as possible.
For more information about us, please visit:

https://alismedia.jp