### PR TITLE
Whitelist cass.ad

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -570,7 +570,8 @@
     "orionprotocol.io",
     "etherspin.co",
     "actua.ad",
-    "aditus.io"
+    "aditus.io",
+    "cass.ad"
   ],
   "blacklist": [
     "musk2020.site",


### PR DESCRIPTION
Add Andorran official health security service to whitelist.

It also happened with #2908 and #2909 

Is it a thing with `.ad` (Andorra's domains)?

