### PR TITLE
razebit.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -590,6 +590,7 @@
     "aditus.io"
   ],
   "blacklist": [
+    "razebit.com",
     "infinivi.io",
     "bytetrade.com",
     "bytetrade.io",


### PR DESCRIPTION
razebit.com
Fake exchange phishing for deposits - https://redd.it/evayv1
https://urlscan.io/result/d0fc37c6-6fd4-48a1-8869-1523e534d638/
address: 35D11agVkS4C8rH57MaShdTSR8QDGoyZb4 (btc)
address: 0x8F4eD737DE54707C452B1A6E55Df3B72Fc41c9f9 (eth)
address: qrzwlpgnj5c06l06znx8xqjffx096fh8pymr80pgvp (bch)
address: MS88cntTyM3XTz7PdYEPp84ZbXf34eGq9B (ltc)