### PR TITLE
xrp2020.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -594,6 +594,11 @@
     "cass.ad"
   ],
   "blacklist": [
+    "xrp2020.net",
+    "grimebit.com",
+    "craigsecret.com",
+    "ethereumpro.eu",
+    "earn2xethnow.com",
     "teslanews.life",
     "webledger.pro",
     "elongiftpromo.com",


### PR DESCRIPTION
xrp2020.net
Trust trading scam site
https://urlscan.io/result/b2eeeaeb-09f0-4c8e-bba5-d84b1879b333/
https://urlscan.io/result/13a19d21-a03b-4c7e-952c-1f1c1d160ab1/
address: rw65sa4wHeGVUxaEVWWc6CUKP92qP46vnr (xrp)

craigsecret.com
Trust trading scam site
https://urlscan.io/result/6b4ee67f-d7e8-48fb-8f92-8e663cb5fe50/
https://urlscan.io/result/30445369-bd34-4e58-9d3e-3694ab77bdd0/
address: 12PJfztAraWThT1eoWapiXZ273MXRatuCM (btc)

ethereumpro.eu
Trust trading scam site
https://urlscan.io/result/8fe671b3-8dbe-4544-8768-379217bbeafb/
https://urlscan.io/result/eab22ea4-246d-4d52-908f-245e7616db45/
address: 0x610eAcBC066F8Bb1F7853316e214B6bB328b4E8b (eth)

earn2xethnow.com
Trust trading scam site
https://urlscan.io/result/4fae0e2a-4b1a-4191-96eb-e5c8f65c6f48/
address: 0x70ED9fF5f8A02A9B271cE5af8ac62A1B85e51685 (eth)

grimebit.com
Fake exchange phishing for deposits
https://urlscan.io/result/48d4ca01-09f6-459e-b82c-3d7a913a3035/
address: 3GJwHyimGMnKjitTdULHmuTCNtS7fHMfgF (btc)
address: 0xD719B4f91E57D13f61F4B2FE0a10eC0dE64cE02C (eth)
address: qpdmavpxpz2pwd9cxma3669ndyyrpdqw8ucveudydh (bch)
address: MRydA7PNyGhvBinouorK5RvehjpwptAnse (ltc)