### PR TITLE
Whitelist - add nabis.com to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -591,7 +591,8 @@
     "etherspin.co",
     "actua.ad",
     "aditus.io",
-    "cass.ad"
+    "cass.ad",
+    "nabis.com"
   ],
   "blacklist": [
     "xrp2020.net",


### PR DESCRIPTION
Added nabis.com to config.json whitelist, our domain was currently being flagged due to levenshtein string comparison.

fix #3661 