### PR TITLE
remove ethtreasury.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -6455,8 +6455,6 @@
     "airdrop-ether.com",
     "medium-blog-ethereum.info",
     "ethpromogivegroup.net",
-    "safe.ethtreasury.com",
-    "ethtreasury.com",
     "idexwall.online",
     "muytherwallet.info",
     "myetherywallet.com",


### PR DESCRIPTION
ethtreasury.com
https://urlscan.io/result/e7a75865-f71e-4d02-8c08-18448b7bbd27/
Request submitted via email to contact@cryptoscamdb.org - new ownership

```
Domain Name: ETHTREASURY.COM
Registry Domain ID: 2487176217_DOMAIN_COM-VRSN
Registrar WHOIS Server: whois.namecheap.com
Registrar URL: http://www.namecheap.com
Updated Date: 2020-02-01T12:22:42Z
Creation Date: 2020-02-01T12:22:39Z
Registry Expiry Date: 2021-02-01T12:22:39Z
Registrar: NameCheap, Inc.
Registrar IANA ID: 1068
Registrar Abuse Contact Email: abuse@namecheap.com
Registrar Abuse Contact Phone: +1.6613102107
Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
Name Server: DNS1.REGISTRAR-SERVERS.COM
Name Server: DNS2.REGISTRAR-SERVERS.COM
DNSSEC: unsigned
URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
>>> Last update of whois database: 2020-02-11T22:49:46Z <<<
```