### PR TITLE
air-drop-coinbase.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -643,6 +643,9 @@
     "nabis.com"
   ],
   "blacklist": [
+    "air-drop-coinbase.com",
+    "droptesla.com",
+    "elonx-space.com",
     "exodus.onl",
     "ledger.icu",
     "aragongift.live",


### PR DESCRIPTION
air-drop-coinbase.com
Trust trading scam site
https://urlscan.io/result/c5a4afd0-f363-4fd3-8aeb-af38cdd01b83/
address: 1H8Ayqrnz1LYzNT4UvPsjugZdiY5udpqxx (btc)

droptesla.com
Trust trading scam site
https://urlscan.io/result/d6efb86b-f1f6-4b63-8286-d84ad639f06f/
https://urlscan.io/result/6cca1d39-ffe9-40d9-91e2-e58a2bea61b5/
https://urlscan.io/result/ad647fa3-eac0-414d-a6df-24afa2b54452/
https://urlscan.io/result/98661b20-48c7-47b2-b63b-492be6b1a53f/
https://urlscan.io/result/b48e96ed-d4e1-41ff-ab71-76dde51aa06a
address: 0xEd38E12F2A6B19c544D1144eD306B410070B8Ff5 (eth)
address: 0x1f59bc7B5A771B46D40264FacBfF37350fb5de82 (eth)
address: 1Ce3JcutnvKx5GwyYCcTQJzCFZzDjtYJJE (btc)
address: 12batJfsBSHd2wKHit3M3kXKUVr5V8oo4r (btc)

elonx-space.com
Trust trading scam site
https://urlscan.io/result/b3e1d5aa-ac73-476c-8526-3c88000a90e3/
address: 1Et8yV4H9BHqVKgazdvRZZ9xLp6giwUa82 (btc)