### PR TITLE
musk-airdrop.online + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -643,6 +643,12 @@
     "nabis.com"
   ],
   "blacklist": [
+    "musk-airdrop.online",
+    "xn--bstchang-b1a14b.com",
+    "bestchanrge.net",
+    "bit-exhcanger.xn--r-9ga.net",
+    "xn--besthage-49a.com",
+    "besrchange.ru",
     "elon-give.online",
     "spacexbonus.info",
     "elonmusk.world",


### PR DESCRIPTION
musk-airdrop.online
Trust trading scam site (posted on medium.com/@folly2010/breaking-news-74f3fa78ef40)
https://urlscan.io/result/0d81ddf6-8114-43f6-b982-36cd29598878/
https://urlscan.io/result/dc26060e-1b9a-453f-a21f-1ea0fcb93b07/
address: 12ty2ez9snjDzS3o28UyeWTeBuoGVXY4jd (btc)
address: 0x1AB45960fc7C38b5087d2B930A2321b01c2f3CEB (eth)