### PR TITLE
b-promo.online + elon2020.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -643,6 +643,8 @@
     "nabis.com"
   ],
   "blacklist": [
+    "b-promo.online",
+    "elon2020.online",
     "musk-airdrop.online",
     "xn--bstchang-b1a14b.com",
     "bestchanrge.net",


### PR DESCRIPTION
b-promo.online
Trust trading scam site
https://urlscan.io/result/18dda15d-5fba-4f67-a19b-c738df648697/
https://urlscan.io/result/640c2289-22bb-487d-a0f5-d779956fe245/
https://urlscan.io/result/699bdd11-d25d-43eb-9b8b-3bb216924aee/
address: 1C44Fs8wNstrp9fLKKV89uSDoQWBbChfWL (btc)
address: 0xCF70C00655Ec4356005983420B7AdC866316713b (eth)

elon2020.online
Trust trading scam site
https://urlscan.io/result/1d437cf5-828e-48ec-b898-ae4c80c23b94/
https://urlscan.io/result/fee924de-5b1a-4449-8b32-8702e1b9d493/
https://urlscan.io/result/c4ac09e9-8ca5-4b9d-ab62-cf5e1367777f/
address: 1NkoL43EkSHqMHy4BK8ZR3RQSwzTyq8EHj (btc)
address: 0x1AB45960fc7C38b5087d2B930A2321b01c2f3CEB (eth)