### PR TITLE
Remove oasis from fuzzy list

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14,8 +14,7 @@
     "etherscan.io",
     "originprotocol.com",
     "makerdao.com",
-    "makerfoundation.com",
-    "oasis.app"
+    "makerfoundation.com"
   ],
   "whitelist": [
     "basic.international",


### PR DESCRIPTION
The oasis name is so short that it has been triggering an unreasonable number of false positives. I am removing it for now.

Fixes #3732
Fixes #3728
Fixes #3726
Fixes #3725
Fixes #3724
Fixes #3720
Fixes #3719
Fixes #3718

And many more, we'll have to close many after this is merged. Opening PR to run tests.