### PR TITLE
muskfree.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -643,6 +643,13 @@
     "nabis.com"
   ],
   "blacklist": [
+    "muskfree.net",
+    "tesladrop.space",
+    "btcfminer.online",
+    "ledgerhalving.com",
+    "btcethtesla.info",
+    "muskevent.pro",
+    "muskbtc.net",
     "gram-march.com",
     "rivbit.com",
     "btczeal.com",


### PR DESCRIPTION
muskfree.net
Trust trading scam site
https://urlscan.io/result/203359d7-4941-4e1e-a0b4-e1ba715dece6/
address: 1BnYDL7hDQGm1ki9TjdFCbQg9V1CTVbLxw (btc)

tesladrop.space
Trust trading scam site
https://urlscan.io/result/b619a714-1cb9-4fd6-935b-4e0ba20cd556/
https://urlscan.io/result/a06afe85-9482-4cbe-9268-88c42d9d0aa9/
https://urlscan.io/result/00dca346-1047-4e5b-a45e-e8183eef160b/
address: 12YBo1asZ9evpwGLXQeLMxxmU2RgBL9vpq (btc)
address: 0x6fAa99b46f56DDFc03d68463551d3C4FfF33e9a9 (eth)

btcfminer.online
Trust trading scam site - fake miner
https://urlscan.io/result/de0102b0-3d2c-4d7c-bc32-0495e295ea57/
address: 19j3CFxycDHTZkShZ37hToKyfmvvBSzPm6 (btc)

ledgerhalving.com
Fake Ledger site phishing for secrets with POST /action.php
https://urlscan.io/result/7fbfbc0e-5a8b-4556-9762-936e2fefc86a/

btcethtesla.info
Trust trading scam site
https://urlscan.io/result/cc326bd2-8d72-482b-b0c7-8a704166993f/
address: 3BaokMZbkyC2EtCAWQVA1KkZg8aQZvmFLo (btc)
address: 0xB8258BbBce4D987bf98c5dF92775ffC3Def94702 (eth)

muskevent.pro
Trust trading scam site
https://urlscan.io/result/f75f8b6f-c3eb-4cd7-9742-bfe9da0d162d/
address: 15YM8cx1aiFGuHfi4YYbiHqidswc6uM5TD (btc)

muskbtc.net
Trust trading scam site
https://urlscan.io/result/52097d1f-e223-446d-beb4-59eae03603bb/
address: 1EbijjL7sFfQVio8c4bWLUrti3Hxi9Nujc (btc)