### PR TITLE
bitcoinminerpro.yj.fr + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -643,6 +643,16 @@
     "nabis.com"
   ],
   "blacklist": [
+    "bitcoinminerpro.yj.fr",
+    "mercadobitcoin.tech",
+    "elonnews.online",
+    "thebitcoin-code.net",
+    "bitcoinelectrum.ws",
+    "bitcoin-electrum.org",
+    "bitcoinrising.net",
+    "www.login.coinbase.com-src.cgi-bin.colnbase.site",
+    "colnbase.site",
+    "bitcoingives.info",
     "xn--treor-7hb.com",
     "wallets-trezor.io",
     "muskbitcoin.info",


### PR DESCRIPTION
bitcoinminerpro.yj.fr
Fake bitcoin miner phishing for secrets with POST /start.php
https://urlscan.io/result/b69c0438-d86a-4869-9c97-922679be2af2/
https://urlscan.io/result/3d4bb233-dc35-4989-b272-9f5cea77cbf0/

elonnews.online
Trust trading scam site
https://urlscan.io/result/9d4ab14b-be69-40fe-9e6d-f40038631963/
address: 1Fv2mhwqNzHPM3fN29E64nY4Z29eQVcUF6 (btc)

bitcoingives.info
Trust trading scam site
https://urlscan.io/result/290e0698-5744-4eb4-8c47-ebe1985cf927/
https://urlscan.io/result/f8668c7a-0bd4-4bb7-aa47-9e7cedbd829c/
https://urlscan.io/result/4dec19f3-4906-4921-a4c2-17b643884855/
https://urlscan.io/result/8402c074-d281-4f4e-b51f-2e37e1045da7/
address: 16aZUGY4c4Nhdvx6vHNF7SajzAqYcXgxez (btc)
address: 0x7f0dD36F14f21a10f560caa3d7567f483613BaaF (eth)
address: rGU8WTvKbbF23LsajTf4xt9saAmh48UAuj (xrp)