### PR TITLE
elonxcoin.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -643,6 +643,10 @@
     "nabis.com"
   ],
   "blacklist": [
+    "bitcoinelectrum.co",
+    "morefreebitcoin.com",
+    "elonxcoin.info",
+    "binance.com158768471.info",
     "4xrp.org",
     "cnipmixer.com",
     "bliocklchain.com",


### PR DESCRIPTION
elonxcoin.info
Trust trading scam site
https://urlscan.io/result/129aa4f3-b548-41fb-9678-82fa94c3a439/
https://urlscan.io/result/dc41963c-1a34-4b09-b97b-7e0c5df62533/
https://urlscan.io/result/10325414-858c-46f2-a383-270afb28d66d/
address: 18VFBkWz785fmaLzee8upzAuHjVwE4Hceq (btc)
address: 0xF269ebEDcC1F430C4E487BD6218c33E86616F99c (eth)

binance1555556060.zendesk.com
Fake Binance helpdesk
https://urlscan.io/result/03aa519e-69d1-4bd9-82e1-39ed597bf739/