### PR TITLE
muskgiving.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -643,6 +643,15 @@
     "nabis.com"
   ],
   "blacklist": [
+    "muskgiving.com",
+    "coinbase.com.nervo.co.za",
+    "bitcoin-electrum.me",
+    "bitcoinelon.com",
+    "bitcoinpayout.net",
+    "bitcoinforme.net",
+    "com-bitcoins.com",
+    "elon-musk.online",
+    "binance-giveeth.online",
     "bitcoinelectrum.co",
     "morefreebitcoin.com",
     "elonxcoin.info",


### PR DESCRIPTION
muskgiving.com
Trust trading scam site
https://urlscan.io/result/fc816b13-0469-4e73-baad-d4349d139c10/
https://urlscan.io/result/adca16a8-401a-4960-802f-7aca51ac25ff/
https://urlscan.io/result/0c514028-f2cb-4244-a93b-116560995d67/
address: 0x75ef5d2f364a605aaf4358f0336532414b97b1b0 (eth)
address: 16RM2Jo1gktgppJ9mwZtZrjW36zsYFTVrY (btc)

coinbase.com.nervo.co.za
Fake Coinbase phishing for logins with POST /signin_step_two.php
https://urlscan.io/result/5ad666bc-ed3e-4276-bc13-6b5dd6eb68fb/loading

bitcoinelon.com
Trust trading scam site
https://urlscan.io/result/311798d2-96f1-45e3-b48c-5b7876e2e007/
address: 36NxXedkXecvw9VbyGTUd4Fm9tMgpVHv3u (btc)

bitcoinpayout.net
Fake investment platform
https://urlscan.io/result/84f48905-e61e-4d98-aabb-75e4d316642c/
https://urlscan.io/result/1e67bce8-afed-4642-85cb-3c0903502972/

elon-musk.online
Trust trading scam site
https://urlscan.io/result/6736c033-2113-4e56-bce3-b6b53670f80d/
https://urlscan.io/result/cd0567ae-6f31-4b0f-a405-851222334441/
https://urlscan.io/result/73722939-3d63-4eb2-89d6-e939766087d1
address: 0x57E47cEEb9b5bB9750eb54F7e0469F710a5FaFc8 (eth)
address: 1BLHcwDTeS9TXnt3CfpvCWV4y5LhLEmcVE (btc)