### PR TITLE
bit-coinvestor.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -643,6 +643,8 @@
     "nabis.com"
   ],
   "blacklist": [
+    "bit-coinvestor.com",
+    "bestchrnge.ru",
     "wallet-coinomi-giveaway.000webhostapp.com",
     "trustwallet.biz",
     "ledgerweb.ai",


### PR DESCRIPTION
bit-coinvestor.com
Fake investment platform
https://urlscan.io/result/d7bfd7c0-e48a-4c3a-b326-a14d380282c8/
https://urlscan.io/result/42210814-3cff-44cc-bd41-9eea51b532d2/
address: 1H9D6gQ5ZfGFFv97kFrdU7vWC77vWbfqwT (btc)