### PR TITLE
rozbit.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -644,6 +644,7 @@
     "nabis.com"
   ],
   "blacklist": [
+    "rozbit.com",
     "myledgernano.com",
     "completssl.com",
     "bitcoinsystem-app.com",


### PR DESCRIPTION
rozbit.com
Fake exchange phishing for deposits
https://urlscan.io/result/6cc5a1a9-a77d-4a4e-a1fd-6d60d6bea637/
address: 3Jm4rKchVHpz6DYgzvFqpR1T48Ra7dAKNR (btc)
address: 0x9E4e6CfD41adDE2Ec74B6A45C7bdd547189850D0 (eth)
address: qznz5ms2stvwwcjay2vyftye56z5qqzl0v603srm2j (bch)
address: MFNYgSPBbjzkxPW99pcwn1WFFwpXfnZyYx (ltc)