### PR TITLE
whitelist mracrypto.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -17,6 +17,9 @@
     "makerfoundation.com"
   ],
   "whitelist": [
+    "mracrypto.com",
+    "crypto.ro",
+    "buycrypto.info",
     "basic.international",
     "actua.ca",
     "bultus.nl",


### PR DESCRIPTION
mracrypto.com
https://urlscan.io/result/38b575f5-2228-446f-bbc1-a69f0903d893/

crypto.ro
https://urlscan.io/result/d1557b91-6758-477a-8309-540d299f5666/

buycrypto.info
https://urlscan.io/result/ada16848-bd43-41ea-b633-ba233914076d/