### PR TITLE
doubleway.rf.gd + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -647,6 +647,8 @@
     "nabis.com"
   ],
   "blacklist": [
+    "doubleway.rf.gd",
+    "xtibit.com",
     "crypto-crown.ltd",
     "feex.exchange",
     "musktesla.pro",


### PR DESCRIPTION
doubleway.rf.gd
Trust trading scam site
https://urlscan.io/result/cd2e480f-6993-4d7a-9e21-1c23b4556b2c/
address: 12EDsQnwb3BkaUuGxjNVovCBp2DVRdUpAt (btc)

xtibit.com
Fake exchange phishing for deposits
https://urlscan.io/result/8b7b4999-a7e8-4697-b6dd-2ec589235251/
address: 3KqpD7uwKCtCkU1iQiJjP3iCXM3mfoK5vH (btc)
address: 0xd93ed2F2acFD0E7D3dF633533dbC4652Db923d87 (eth)
address: qqgs0xq7nz6sf4042zehsycpd29fzm64ayfu225wu4 (bch)
address: MCZ1VdWt9YWkLuvA3N4HWiQUR9M7FjM3cZ (ltc)