### PR TITLE
etherum.giveaway-coinbase.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -650,6 +650,12 @@
     "nabis.com"
   ],
   "blacklist": [
+    "blokchalne.info",
+    "etherum.giveaway-coinbase.com",
+    "bitcoin.giveaway-coinbase.com",
+    "giveaway-coinbase.com",
+    "jaxxupdatesupport.com",
+    "trustcoin.exchange",
     "doubleway.rf.gd",
     "xtibit.com",
     "crypto-crown.ltd",


### PR DESCRIPTION
etherum.giveaway-coinbase.com
Trust trading scam site
https://urlscan.io/result/598ab325-e72e-4d01-9967-459e0fa8013d/
https://urlscan.io/result/2df0186b-c47e-4178-aca6-3824886d3755/
address: 0xdd9a314AcA28A44eC99dBB6962a47b33c6112406 (eth)

bitcoin.giveaway-coinbase.com
Trust trading scam site
https://urlscan.io/result/296e0746-192f-4ec9-a4e0-e69256697b81/
address: 19MWChcPLkh6kQhWbKxfU9AgJgbWmEEb7E (btc)

trustcoin.exchange
Fake exchange phishing for deposits
https://urlscan.io/result/e6974874-9071-4729-98c9-163fcfc3868f/