### PR TITLE
telegramcrypto.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -650,6 +650,7 @@
     "nabis.com"
   ],
   "blacklist": [
+    "telegramcrypto.net",
     "blokchalne.info",
     "etherum.giveaway-coinbase.com",
     "bitcoin.giveaway-coinbase.com",


### PR DESCRIPTION
telegramcrypto.net
Fake Telegram crowdsale site (promoted by twitter id 1227617073171517442/@sale_gram)
https://urlscan.io/result/b9ccd791-100c-427d-bb31-2a7276039010g
address: 3BpkePo1ZTuFA8nzEDV6D6a9pkkc9mX8UY (btc)
address: 0x6485e2e2a62b8b1c9c88476ec8bb2a03a2b70e3c (eth)
address: 0x672215a018b8151C355591A4A15B8be240539bcc (usdt)
address: rn33WP8CF27n2za3DCfesuAP6FHDkmwyBq (xrp)