### PR TITLE
trust-wallet.me + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -650,6 +650,10 @@
     "nabis.com"
   ],
   "blacklist": [
+    "trust-wallet.me",
+    "trustwollet.com",
+    "xn--blnnce-yc8b.com",
+    "coinbase.fund",
     "login.blcohchaln.com",
     "blcohchaln.com",
     "wallet.blockchaln.company",


### PR DESCRIPTION
tifbit.com
Fake exchange phishing for deposits
https://urlscan.io/result/e3f12fb4-0353-40a0-bcde-4e75587389d9/
address: qqc44wx95qgtttu3leywkffucn3msvztrukh59fj3s (bch)
address: MBfs6Hmbm2DbHnSnCFbJhkiXeRos1N4uhX (ltc)
address: 0x6Aab4345110aD9B151BF1aD604c723b29612ea7b (eth)
address: 38rTymJX3wpN8MT3GASUQc4VknuB3wZisD (btc)

trust-wallet.me
Fake trust wallet phishing for secrets with POST /device/init/payload
https://urlscan.io/result/b89f69e7-ea8a-4e59-82a6-c1c1f2e1ff57/

coinbase.fund
Trust trading scam site
https://urlscan.io/result/58e2b47f-b398-42ad-a142-75cd573e1c90/
address: 37AcsKNzsBpHeWfjJ4E3vSePT1RrRcbFyW (btc)