### PR TITLE
Add missing comma in `config.json`

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,7 +651,7 @@
   ],
   "blacklist": [
     "sso-github.com",
-    "glthubs.info"
+    "glthubs.info",
     "githb.co",
     "git-secure-service.in",
     "wallet.terzcr.com",


### PR DESCRIPTION
This missing comma was resulting in failed phishing updates, as the blacklist was no longer valid JSON.