### PR TITLE
muskfunds.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,15 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "muskfunds.info",
+    "proeth-april-campaign.com",
+    "ethnow.site",
+    "bestcrhange.ru",
+    "hofbit.com",
+    "elonfund.info",
+    "doubleyourbitcoin.com",
+    "bitcoinairdrop.info",
+    "easybitcoin.fun",
     "sso-github.com",
     "glthubs.info",
     "githb.co",


### PR DESCRIPTION
muskfunds.info
Trust trading scam site
https://urlscan.io/result/76ade816-c9a5-4fd4-9067-2b25144616a0/

ethnow.site
Trust trading scam site
https://urlscan.io/result/56e0a1ab-add2-438b-a10f-3fe80f3614c0/
address: 0x6Ab217AF622F676a403dE3b7fbf75D5348aa480d (eth)

hofbit.com
Fake exchange phishing for deposits
https://urlscan.io/result/b07bd015-a26e-41ae-b264-123bb7797334/
address: qpmah46nqqapxacz5c842kp6ghrywtgkhuxay3dqz0 (bch)
address: MKPBHfpZs4SmHJikkBpZu6K4kQmAHbXvrt (ltc)
address: 0x15f0f424E44FdAf352b1D15166020114381F2C8a (eth)
address: 3Et3JRicX6So3RrseDXpGgApH8xdWRXV8F (btc)