### PR TITLE
xrpclaim.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,7 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "xrpclaim.net",
     "muskfunds.info",
     "proeth-april-campaign.com",
     "ethnow.site",


### PR DESCRIPTION
xrpclaim.net
Trust trading scam site - phishing for secrets with POST //api.telegram.org/bot1127033295:AAHdluHxmk7PZkCgzeg8dRy4vs_3v9DZsuE/sendMessage
https://urlscan.io/result/fd93a99e-9a6a-4dab-a356-44a8106a54e1/
https://urlscan.io/result/b99b5014-0b3c-4cd5-a50b-6ec26a6e9dcb/