### PR TITLE
musktesla.press + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,9 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "musktesla.press",
+    "tesladrops.info",
+    "spacexgifts.info",
     "xrpclaim.net",
     "muskfunds.info",
     "proeth-april-campaign.com",


### PR DESCRIPTION
musktesla.press
Trust trading scam site
https://urlscan.io/result/05adeb93-9bd3-456a-a457-cc3bc95937ab/
https://urlscan.io/result/f8793fed-b1f5-4595-aa6f-f03e4b6f4983/
https://urlscan.io/result/95389092-4e5d-44cf-be61-ff0a79347978/
address: 0x2c25484678beFfa8CE2bec715f830dbcF40Cfb35 (eth)
address: 1ExSxJfAYqdT6GrUd6TQsWTNpWg4myQrSD (btc)

spacexgifts.info
Trust trading scam site
https://urlscan.io/result/21686768-185d-4725-827b-3fbb2fffc121/
https://urlscan.io/result/20afdb80-8347-4598-b385-560596b0f775/
https://urlscan.io/result/b786b16d-c441-4a7a-9fa7-26613a7ffa74/
address: 1KVCuE5DFeWf3eRppzkUCDAWT7VCX1pYBF (btc)
address: 0xA3f209350617A096D24D447B9DDe788d1437AE87 (eth)