### PR TITLE
cryptogenerator.live

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,9 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "bitcoin.cryptogenerator.live",
+    "cryptogenerator.live",
+    "ethereum.cryptogenerator.live",
     "musktesla.press",
     "tesladrops.info",
     "spacexgifts.info",


### PR DESCRIPTION
bitcoin.cryptogenerator.live
Trust trading scam site
https://urlscan.io/result/adf9393d-db91-4645-bc00-2a2c8fb1d240/
https://urlscan.io/result/c464c616-793f-4b0a-8736-965768852359/
address: 343CitDfusT5HLiKxPJJWkUNV26F2bbyrY (btc)

ethereum.cryptogenerator.live
Trust trading scam site
https://urlscan.io/result/63c3bb1c-fc41-43f1-82d0-9f0fd33efe5b/
address: 0x7fa93Cd2c95a3F93C8A20D3f2d1825f9F14c81C2 (eth)