### PR TITLE
leakedbitcoin.excelerate.co.nz + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,8 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "leakedbitcoin.excelerate.co.nz",
+    "nixetrade.com",
     "bitcoin.cryptogenerator.live",
     "cryptogenerator.live",
     "ethereum.cryptogenerator.live",


### PR DESCRIPTION
leakedbitcoin.excelerate.co.nz
Phishing for private keys with POST /check.php
https://urlscan.io/result/9df5df45-58e5-4e3f-93b8-96f2a25b60ee

nixetrade.com
Fake exchange phishing for deposits
https://urlscan.io/result/1a2b20bb-4bb3-4fc2-b8ac-d00561aeec1a/
address: 3DfCchNUv3o1GzgEZf4PaHdi2L8FvAtxrp (btc)
address: 0x30Dd4b66f6023e5896C066F82dc7628740a5aEE3 (eth)
address: 0x8111BaE586883Ff07fB7b2C0702c3E95bF03316C (eth)
address: 0xC4B3549C236Da61E6739f705775021a2FFeE857C (eth)
address: 0x56F905cE852AcbF644C79F732671f62c0fc2E519 (eth)
address: 0x1F627EED155c3D55E32Ec15bFB82b2a5040ABc96 (etc)
address: MWayrCG85ESKMap4KrC189UMMtLrpAygbC (ltc)
address: qz7k75tn4zpf0en84v9t7av392w5y3yruyz7prq2k7 (bch)