### PR TITLE
Remove neblidex.xyz from blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,7 +651,6 @@
     "fscrypto.co"
   ],
   "blacklist": [
-    "neblidex.xyz",
     "leakedbitcoin.excelerate.co.nz",
     "nixetrade.com",
     "bitcoin.cryptogenerator.live",


### PR DESCRIPTION
Due to a false positive on a sandbox test, NebliDex.xyz domain was added to the MetaMask blacklist without consultation with the development team or survey by users actually using the software.

The blacklist was  based on the the software connecting to a Bitcoin Cash electrum server at IP Address: 136.243.250.139 which is recognized as an arbitrary Trickbot IP address by the antivirus.

While I understand the need to stop malicious software online, due diligence is necessary when flagging websites as malicious as that can be slanderous to their brands. It should be common knowledge by now that antiviruses often report false positives for crypto software so it is best to get user feedback before making decisions or verifying the source yourself. 