### PR TITLE
elonlive.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,11 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "elonlive.org",
+    "promocoinbase.xyz",
+    "myelthermwallet.com",
+    "asset-erc-20-token.com",
+    "daostack.asset-erc-20-token.com",
     "neblidex.xyz",
     "leakedbitcoin.excelerate.co.nz",
     "nixetrade.com",


### PR DESCRIPTION
elonlive.org
Trust trading scam site
https://urlscan.io/result/922ea8cb-5297-4a7f-9132-e75f1361255f/
https://urlscan.io/result/920d0a11-4cb6-4e7d-b753-645800eeae20
https://urlscan.io/result/3b9eca6b-734d-40fa-a367-c24d0602b057/
address: 0x8D8adA797b018d60FB2c92a238983FA6aCe56ECE (eth)
address: 0x7a27593BaCf900E67A5b315a907A8FA5396e5c91 (eth)
address: 0xA3f209350617A096D24D447B9DDe788d1437AE87 (eth)

promocoinbase.xyz
Trust trading scam site
https://urlscan.io/result/e73f8a7f-83d9-4e7c-800d-c84fa23a42cb/
address: 15VTvGT7H8DMwTLdyFR5n6hgV6dE1dHB9i (btc)

daostack.asset-erc-20-token.com
Fake MyEtherWallet phishing for keys with POST /error.php
https://urlscan.io/result/d94acdfb-747f-4ccb-b931-e77666340e55/
https://urlscan.io/result/2b1b2fc6-09dc-408f-a056-c17735977243/
https://urlscan.io/result/a8002659-79e9-4ffc-a7d6-b4414086356f/