### PR TITLE
glybit.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,9 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "glybit.com",
+    "aprilcontest.tumblr.com",
+    "bezos.xyz",
     "xn--trstwallet-odb.com",
     "10xbitcoin.net.deepprofitstreams.com",
     "elonlive.org",


### PR DESCRIPTION
glybit.com
Fake exchange phishing for deposits
https://urlscan.io/result/4b0d249b-ced0-4437-926c-32af3a60595f/
https://urlscan.io/result/d5d666de-b26b-4908-bfb8-6f2f3294a30f
address: qqmdmv4axg2cdx36kt5p28th865nwuuf0qtw3x0tfx (bch)
address: qprse9a228d0rf6kj4x3ddvptefsnq6vzszl3efp7x (bch)
address: MSdGBicFfHVV8mcBPK4GJaUime7D8pDgLi (ltc)
address: MFc6qc4Z9QQXEfkzW32YmSJX8dK87MWmLi (ltc)
address: 0x0f85F56B4b89D66e18656337f0E7c98499348302 (eth)
address: MFc6qc4Z9QQXEfkzW32YmSJX8dK87MWmLi (eth)
address: 3A5HgbSke8jciFfkNwsCpopMdpLjhFSPra (btc)
address: 3J3LoiVYipMNwS3SAe97xVBaQYGWPPcRTZ (btc)

aprilcontest.tumblr.com
Trust trading scam site
https://urlscan.io/result/80413c7b-93c9-4a7b-812c-279d3de851c1/
address: rKpfL1GYXzJ6vCiPbyib1jrZRxgpYrXDHd (xrp)

bezos.xyz
Trust trading scam site
https://urlscan.io/result/19d77411-9140-4cf6-834e-fc838dce1e30
address: 0x1Ad0d0c821453De875F026A5f438E30d4A3dAc3e (eth)