### PR TITLE
ethpromo.news + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,12 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "ethpromo.news",
+    "proethevent.com",
+    "bezosxbt.com",
+    "erc-20.online",
+    "ethevent.us",
+    "ethgift.com",
     "teslagives.com",
     "spacex.bz",
     "rewards-program-erc-20-token.com",


### PR DESCRIPTION
ethpromo.news
Trust trading scam site
https://urlscan.io/result/6da33aff-8d93-44e3-9bea-cb1284bf9809/
address: 0x67965a9Af69DD4fa9d6a60ff55d5bAC6e453E0A8 (eth)

erc-20.online
Trust trading scam site
https://urlscan.io/result/a492d904-92f4-4234-a47b-35376ad42c95/
address: 0x444381cf371c588df43a8d2265c2a883bd6445ba (eth)

ethevent.us
Trust trading scam site
https://urlscan.io/result/17e2af5f-baec-4166-9874-4f14761e7934/
address: 0x961834dfED8a283260A29315A460c86517ffAA8A (eth)

ethgift.com
Trust trading scam site
https://urlscan.io/result/f0f7b7d2-bcc0-4e95-9f96-38e8f6503682/
address: 0xc51d701B7E392d32a11f7b86b3fC144Fb12aBC55 (eth)



---

proeth-event-april.com
Trust trading scam site
https://urlscan.io/result/1d1b413d-2623-4d4e-9bff-13012e0b3699/
address: 0x9d9e3b1F8762d383B907428FE2982FE62a7A8022 (eth)