### PR TITLE
spacexgiveaway.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,9 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "spacexgiveaway.com",
+    "ethdrop.org",
+    "prethbonus.com",
     "ethpromo.news",
     "proethevent.com",
     "bezosxbt.com",


### PR DESCRIPTION
spacexgiveaway.com
Trust trading scam site
https://urlscan.io/result/77bcc848-a708-4ed4-9546-2be2a96d4c7f/
address: 1NKpKW6yA7VUjFEo1cRVeRUjQQHBJemx7L (btc)

ethdrop.org
Trust trading scam site
https://urlscan.io/result/4d126723-0d64-46ad-80a6-5933deda40d3/
address: 0xd0c50c8d499967a15fcbbb23e0b9f58b8358f329 (eth)

spacex.bz
Trust trading scam site
https://urlscan.io/result/48376953-cef6-41f2-b8a7-c00104636043/
address: 114ymJUsYogZuv4cbAQLFyRpd6uddEgvL (btc)
address: 0x00e8b95224298D3A9D14f4982b56f53275431f57 (eth)