### PR TITLE
piutrade.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,9 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "piutrade.com",
+    "mytiethervveallet.com",
+    "gmsstatistics.com",
     "yolbit.com",
     "rewards-holders-erc20-tokens.com",
     "taas.fund.rewards-holders-erc20-tokens.com",


### PR DESCRIPTION
piutrade.com
Fake Binance charity page
https://urlscan.io/result/556343df-4c36-4248-b803-5ccd5ae21ec8/
address: 1Nx9EDgy6f1eQ3Q54g5QfetXYvr4NceuJg (btc)

mytiethervveallet.com
Fake MyEtherWallet phishing for keys with POST //gmsstatistics.com/sending.php?message=xxx
https://urlscan.io/result/822ca524-9467-4667-b962-351ad9e0a6b8/