### PR TITLE
faobit.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,6 +651,9 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "faobit.com",
+    "teslapromo.org",
+    "xlmget.org",
     "metmamask.com",
     "metamask.info",
     "metamosk.info",


### PR DESCRIPTION
faobit.com
Fake exchange phishing for deposits
https://urlscan.io/result/6d9d5864-60bd-4b1d-ae80-387d8926f66b/
address: qrwpnrpq7s670s3mlurs0z4szhqwd0nq2szp2mtnn6 (bch)
address: MGVm9Hc58piyRmhyFjCgaHMiazWAcM5swF (ltc)
address: 0xd67e205A5b7A5d82B86afBC59f67f74a878D1E68 (eth)
address: 3ACfrcziWsekdTWv9ayAGLrMU2PdMsCJxo (btc)