### PR TITLE
eloneth.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -654,7 +654,6 @@
     "fscrypto.co"
   ],
   "blacklist": [
-    "eloneth.org",
     "elonmusk.financial",
     "ethereum-promo.site",
     "spacexcash.com",

--- a/src/config.json
+++ b/src/config.json
@@ -654,6 +654,9 @@
     "fscrypto.co"
   ],
   "blacklist": [
+    "eloneth.org",
+    "elonmusk.financial",
+    "ethereum-promo.site",
     "spacexcash.com",
     "bestchange.run",
     "applegive.club",


### PR DESCRIPTION
eloneth.org
Trust trading scam site
https://urlscan.io/result/59aa4da0-f370-46dc-bce4-80736b6bf280/
address: 13V1WGBRJS8SpNB9eE32KASULVmPZzHAA9 (btc)

elonmusk.financial
Trust trading scam site
https://urlscan.io/result/6c6fbc81-c865-46a7-8088-bf9fdc3396f3/
https://urlscan.io/result/a45ef9d4-cc59-4200-94c7-07015446fafb/
https://urlscan.io/result/e5cf0c26-b6ab-4aff-9567-20223e93d241/
address: 17BxoQqsDngpzAPk1kNAWvrvK8NYRYNzNu (btc)
address: 0x83eE561B2aBD000FF00d6ca22f38b29d4a760d4D (eth)

ethereum-promo.site
Trust trading scam site
https://urlscan.io/result/6b02eb83-08f9-4b42-8702-f0b8a51e17e1/
address: 0x389045fa0DE32B991FC6138ACc12D20f44B0020c (eth)