### PR TITLE
Add divinity.ai to the whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -651,7 +651,8 @@
     "aditus.io",
     "cass.ad",
     "nabis.com",
-    "fscrypto.co"
+    "fscrypto.co",
+    "divinity.ai",
   ],
   "blacklist": [
     "metamaks.io",

--- a/src/config.json
+++ b/src/config.json
@@ -652,7 +652,7 @@
     "cass.ad",
     "nabis.com",
     "fscrypto.co",
-    "divinity.ai",
+    "divinity.ai"
   ],
   "blacklist": [
     "metamaks.io",


### PR DESCRIPTION
It's a non related crypto project and probably caught by the similarity to dfinity (?)