### PR TITLE
royal-crypto.cc + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -655,6 +655,11 @@
     "divinity.ai"
   ],
   "blacklist": [
+    "royal-crypto.cc",
+    "muskprofit.com",
+    "etherscanner.ml",
+    "wozdrop.me",
+    "yaubit.com",
     "halfbit.cc",
     "bitcoinbonuswallet.com",
     "bytombit.com",


### PR DESCRIPTION
royal-crypto.cc
Fake exchange phishing for deposits
https://urlscan.io/result/a6b94392-ef61-4d48-8f98-88c05a3a50bb/
address: 1AxvT4BM8ZUDC13N8VaSY1mPXN3Ewt7vZm (btc)
address: 0x8328279BAA90deBe686b29a2948c7fa636cfCD2a (eth)

etherscanner.ml
Trust trading scam site
https://urlscan.io/result/d82f5239-311c-4c89-b2ce-3cf18495acb7
address: 0xd852dd6AC9655fA4833d0eC09A6E3d4a44054870 (eth)

wozdrop.me
Trust trading scam site
https://urlscan.io/result/931301f8-6ba9-42dd-98aa-61a23147fc3c/
address: 1WoznScUTGbqGTqqeLPBgAVPgipx64URX (btc)

yaubit.com
Fake exchange phishing for deposits
https://urlscan.io/result/10d51904-ff53-41c5-bc72-4b2e4a11c17b/