### PR TITLE
tony-btc.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -657,7 +657,6 @@
   "blacklist": [
     "tony-btc.info",
     "dentacoins.com",
-    "beldexcoins.com",
     "laubit.com",
     "binancechange.com",
     "royal-crypto.cc",

--- a/src/config.json
+++ b/src/config.json
@@ -655,6 +655,11 @@
     "divinity.ai"
   ],
   "blacklist": [
+    "tony-btc.info",
+    "dentacoins.com",
+    "beldexcoins.com",
+    "laubit.com",
+    "binancechange.com",
     "royal-crypto.cc",
     "muskprofit.com",
     "etherscanner.ml",


### PR DESCRIPTION
tony-btc.info
Trust trading scam site
https://urlscan.io/result/bea12d79-b9f7-414d-bc62-1960f231dd32/
https://urlscan.io/result/969e5396-70f9-4ac4-9528-8656a5ea8015/
address: 1Tony5wpzKJQr4yzsohQK9XtxwvBSQBeA (btc)

dentacoins.com
Fake exchange/casino phishing for deposits
https://urlscan.io/result/e4f3c86f-a997-427d-9c81-c1654a79f46d/
address: 3QJgNQsMLoXDU7cUWtHQrz4i9KQxLtUb6e (btc)
address: 0xEe18e156a020F2b2B2DcdEC3A9476E61fBDE1e48 (eth)

laubit.com
Fake exchange phishing for deposits
https://urlscan.io/result/06535c13-fb64-4bd9-a8db-ae6f18c386fc/