### PR TITLE
profitmusk.com + elonsave.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -655,6 +655,8 @@
     "divinity.ai"
   ],
   "blacklist": [
+    "profitmusk.com",
+    "elonsave.com",
     "tony-btc.info",
     "dentacoins.com",
     "laubit.com",


### PR DESCRIPTION
profitmusk.com
Trust trading scam site
https://urlscan.io/result/a5b94634-a770-48d0-ad29-d5f3cbead7ec/
https://urlscan.io/result/29b12eeb-e991-4d23-a0f2-ab790957ab2a/
https://urlscan.io/result/f6a0e6f4-ffd6-49c1-bb83-3f1e6062e2e7/
address: 1QGrCGJpghkgeWJ4LKmC2gYH4bFN7241B9 (btc)
address: 0x5F08FFD6dD5388Ebc71043dd9CD3a61eCBccE2A6 (eth)

elonsave.com
Trust trading scam site
https://urlscan.io/result/1165f9e7-5ef9-4dfe-9db5-95a1c514d07d/
https://urlscan.io/result/d793b7de-d2b4-48b5-bb06-6e6366e5265b/
address: 1NSghJuU3aZdGNUCwjPf8B4sg8pUY2LRx (btc)