### PR TITLE
max-maicoin-claimbonusbtc.000webhostapp.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -655,6 +655,10 @@
     "divinity.ai"
   ],
   "blacklist": [
+    "max-maicoin-claimbonusbtc.000webhostapp.com",
+    "lokbit.com",
+    "vaubit.com",
+    "bitcoinpaperwallet.com",
     "profitmusk.com",
     "elonsave.com",
     "tony-btc.info",


### PR DESCRIPTION
max-maicoin-claimbonusbtc.000webhostapp.com
Fake MAX exchange phishing for logins with POST /app.php
https://urlscan.io/result/cb0d27aa-2d64-484d-be22-7da0158345b6

vaubit.com
Fake exchange phishing for deposits
https://urlscan.io/result/370c2024-1e2b-4206-a608-969b7cf0da5b/

bitcoinpaperwallet.com
Malicious paper wallet site - https://twitter.com/MyCrypto/status/1261830475003252736
https://urlscan.io/result/d236a8de-047b-424f-b6f9-1232fd7fe52d/