### PR TITLE
dave-btc.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -655,6 +655,12 @@
     "divinity.ai"
   ],
   "blacklist": [
+    "dave-btc.info",
+    "stevebtc.org",
+    "cham-btc.info",
+    "pantera.ltd",
+    "xiaomibtc.com",
+    "found-bin.com",
     "walletgenerator.net",
     "max-maicoin-claimbonusbtc.000webhostapp.com",
     "lokbit.com",


### PR DESCRIPTION
dave-btc.info
Trust trading scam site
https://urlscan.io/result/a50297e1-b775-4387-8b6d-fe5cd52048b2/

stevebtc.org
Trust trading scam site
https://urlscan.io/result/996edc75-1f13-4159-a4b9-37508a370d90/
address: 1AVsvFnmkRiFFfg3xTfnvcWSNoZHPcEd22 (btc)

cham-btc.info
Trust trading scam site
https://urlscan.io/result/3a2c4658-da74-448e-a4d8-119def292812/
address: 1Cham3QTQ2McKD24ozEHsAgbCinfAszzQc (btc)

pantera.ltd
Trust trading scam site
https://urlscan.io/result/020b12f7-1724-458f-9b29-1474eaa305f0/
address: 3Fd1vmjBUDnxsFoNARjgP2SRkpMNg7Uar3 (btc)

xiaomibtc.com
Trust trading scam site
https://urlscan.io/result/9f8421c2-2f02-4804-9447-fb9834873afe/
address: 37KPhFEL1uZqoJBpYq22ZGahaBc23ActpF (btc)

found-bin.com
Trust trading scam site
https://urlscan.io/result/30e45861-9aa0-47af-817e-90f028372037/
https://urlscan.io/result/a5cea3a5-1dde-446d-a8cd-f16c8f2010cb/
https://urlscan.io/result/d147bb37-22ef-45dd-8bfb-9424644c57cf/
address: 0x6456B53971924d797a1a05E36dAf0D3125f16A32 (eth)
address: 12NP16tkcXw5881UD8H1D3qVq8kmHHXMeb (btc)