### PR TITLE
ledgerslive.web.app + ledgerlivewallet.000webhostapp.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -655,6 +655,8 @@
     "divinity.ai"
   ],
   "blacklist": [
+    "ledgerslive.web.app",
+    "ledgerlivewallet.000webhostapp.com",
     "bitcoinmix.org",
     "teamspacex.info",
     "tslamusk.me",


### PR DESCRIPTION
ledgerslive.web.app
Fake Ledger site phishing for secrets with POST //ledgerlivewallet.000webhostapp.com/connect.php
https://urlscan.io/result/40c7d268-cc10-444a-a99a-3c5db4028e03/
https://urlscan.io/result/a0e7925a-4cad-4654-b3b1-327ca4960be0/

ledgerlivewallet.000webhostapp.com
Fake Ledger site acting as a c2 for phished secrets from //ledgerlive.web.app
https://urlscan.io/result/e219e2e5-66c2-428f-8817-5267355fd109/