### PR TITLE
muetherwallet.co

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -655,6 +655,7 @@
     "divinity.ai"
   ],
   "blacklist": [
+    "muetherwallet.co",
     "btcshower.com",
     "lk.forsage.io.giveaway-token-member.com",
     "giveaway-token-member.com",


### PR DESCRIPTION
muetherwallet.co
Fake MyEtherWallet phishing for keys with POST /sending.php
https://urlscan.io/result/5346adf8-f0f4-4729-b29e-984554dedaa4/
https://urlscan.io/result/1da8d460-45c6-4571-98ad-ae65574858c3/