### PR TITLE
blacklisted phishing domain

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -11041,6 +11041,6 @@
     "airdrop-bitnational.com",
     "wasabibitcoinwallet.org",
     "idex-claim.su",
-    "fulcrum.repair",
+    "fulcrum.repair"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -652,7 +652,9 @@
     "cass.ad",
     "nabis.com",
     "fscrypto.co",
-    "divinity.ai"
+    "divinity.ai",
+    "fulcrum.trade",
+    "torque.loans"
   ],
   "blacklist": [
     "librasale.io",
@@ -11038,6 +11040,7 @@
     "bcrypto.club",
     "airdrop-bitnational.com",
     "wasabibitcoinwallet.org",
-    "idex-claim.su"
+    "idex-claim.su",
+    "fulcrum.repair",
   ]
 }


### PR DESCRIPTION
Fake "repair tool" phishing for Fulcrum user's deposits

blacklisted domain: fulcrum.repair 

Whitelisted Fulcrum and Torque dApps domains: 
fulcrum.trade
torque.loans 