### PR TITLE
Remove legitimate project site from blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -3128,7 +3128,6 @@
     "coindesk.me.16640.aqq.ru",
     "electrumdownload.com",
     "ldexmarket.com",
-    "ldex.exchange",
     "bittrex-m.com",
     "rnuathervvalfet.com",
     "spacex.promo",


### PR DESCRIPTION
Our project domain https://ldex.exchange/ which we acquired only a couple of weeks ago was blacklisted by MetaMask.
We are a legitimate project. LDEX stands for `Lisk Decentralized Exchange`. I used to work at LiskHQ (Lightcurve).

Our team is here: https://leasehold.io/team/
Also note that I'm a long term open source project author and maintainer (in case you want to verify my credentials): https://socketcluster.io/