### PR TITLE
cryptoxluck.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -657,6 +657,7 @@
     "torque.loans"
   ],
   "blacklist": [
+    "cryptoxluck.com",
     "kucoin-info.live",
     "elon.gifts",
     "simpleswap.org",


### PR DESCRIPTION
cryptoxluck.com
Fake gambling site phishing for deposits - bad actor asks withdraw to 1DwcR2SJyb8Lqd5oXUeDxE34K8YQcZcMky
https://urlscan.io/result/9295ff58-fd5b-417d-aee7-c09dfa710bda/
address: 3C9bCoMdbshB22tAv7aVhc8bm9ZTM7QBVh (btc)
address: 3AD76aUsAgGYb69Kx5XLhkwrFjBPWJn9Ny (btc)
address: 0xEE4A42bCB8EFb34E4b8F620Fe148E5f07aA4E401 (eth)
address: MAtmt8TZEya4r2a1pdXqC81n3BwNsXhSBt (ltc)
address: qr42kzy403xcvcqw34n03325ke3pfdscwsq072n79n (bch)