### PR TITLE
cryptoxluck.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -657,6 +657,12 @@
     "torque.loans"
   ],
   "blacklist": [
+    "paxful-verifier.com",
+    "paxful-fra.com",
+    "bitoprowallet.000webhostapp.com",
+    "ftx-com-exchange-cryptocurrency.000webhostapp.com",
+    "pionex-com-exchange-giveaway.000webhostapp.com",
+    "paxfulsecured.com",
     "cryptoxluck.com",
     "kucoin-info.live",
     "elon.gifts",


### PR DESCRIPTION
cryptoxluck.com
Fake gambling site phishing for deposits - bad actor asks withdraw to 1DwcR2SJyb8Lqd5oXUeDxE34K8YQcZcMky
https://urlscan.io/result/9295ff58-fd5b-417d-aee7-c09dfa710bda/
address: 3C9bCoMdbshB22tAv7aVhc8bm9ZTM7QBVh (btc)
address: 3AD76aUsAgGYb69Kx5XLhkwrFjBPWJn9Ny (btc)
address: 0xEE4A42bCB8EFb34E4b8F620Fe148E5f07aA4E401 (eth)
address: MAtmt8TZEya4r2a1pdXqC81n3BwNsXhSBt (ltc)
address: qr42kzy403xcvcqw34n03325ke3pfdscwsq072n79n (bch)

paxful-verifier.com
Fake Paxful phishing for logins with POST /
https://urlscan.io/result/a6c75bf4-2b76-4b5a-9736-b94ca15129c2/

paxful-fra.com
Fake Paxful phishing for logins with POST /verify.php
https://urlscan.io/result/602c78c4-1b9c-4f12-bef0-c25b2976a231/

bitoprowallet.000webhostapp.com
Fake Bitopro phishing for logins with POST /app.php
https://urlscan.io/result/22634333-a124-4b0c-9c4f-5fc0a7bdf6c7/

ftx-com-exchange-cryptocurrency.000webhostapp.com
Fake FTX exchange phishing for logins with POST /app/claim.php
https://urlscan.io/result/21b1d3e4-69a8-4ee8-874d-d4aee7806bde/

pionex-com-exchange-giveaway.000webhostapp.com
Fake Pionex exchange phishing for logins with POST /app/email.php
https://urlscan.io/result/6fbd6c7c-7709-47bf-bf0c-2c3795a8f5e1/

paxfulsecured.com
Fake Paxful phishing for logins with POST /
https://urlscan.io/result/595636ac-ad45-4ae2-9576-6fa89fe000d2/