### PR TITLE
Add morcrypto.net to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
   "whitelist": [
     "sgcrypto.info",
     "mr-crypto.net",
+    "morcrypto.net",
     "decrypto.org",
     "mracrypto.com",
     "etinity.net",


### PR DESCRIPTION
Was incorrectly marked for similarity to mycrypto.