### PR TITLE
Added auctia.io to whitelisted domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -17,6 +17,7 @@
     "makerfoundation.com"
   ],
   "whitelist": [
+    "auctia.io",
     "sgcrypto.info",
     "mr-crypto.net",
     "morcrypto.net",


### PR DESCRIPTION
Auctia.io is World of Warcraft Auction House data collection website with no association with cryptocurrencies whatsoever.