### PR TITLE
givetesla.com + teslax.live

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "givetesla.com",
+    "teslax.live",
     "ainbit.com",
     "spacexbtc.net",
     "makerdao.redeem.bz",


### PR DESCRIPTION
givetesla.com
Trust trading scam site
https://urlscan.io/result/851d24f3-5247-4f5a-9a03-c9036055efdc/
https://urlscan.io/result/f5f40cf9-ea8f-4992-bc25-568162c69528/
https://urlscan.io/result/a875d945-5998-4bcf-8a5d-c748437c1e13/
address: 0xa78Ec860A66A3a676e767e3bFB3ffBeA3E7EFAE8 (eth)
address: 1JzVgiRTq1J3Jf5AFYQaFdkdkXD5pVBnYv (btc)

teslax.live
Trust trading scam site
https://urlscan.io/result/9af6f40b-418c-47d3-8866-93342155145e/
https://urlscan.io/result/efc37b79-3815-4a69-bbf2-4690ba04bf06/
https://urlscan.io/result/4ef46950-2c6e-4808-846c-072222c3e5ae/
address: 0xceB3f016e6b1cbb5b1ec599CdCE90BBBb8bC7664 (eth)
address: 1G8dvVbXq3W7CVvu9BDQYLbDApEnp6pwGL (btc)