### PR TITLE
profittesla.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,7 @@
     "torque.loans"
   ],
   "blacklist": [
+    "profittesla.com",
     "teslapayout.com",
     "givetesla.com",
     "teslax.live",


### PR DESCRIPTION
profittesla.com
Trust trading scam site
https://urlscan.io/result/dcafb71d-aa6a-4ced-96ca-e3ca116418c7/
https://urlscan.io/result/3e865ca9-7b70-456b-8b66-776ba83eb1bd/
https://urlscan.io/result/69ac4194-52f2-47e8-ba02-8158035c5f99/
address: 1B1p1qkv912ifcE9mRZ3jwrighVcM1GALr (btc)
address: 0xd3Cc87f9070e339c099f01Ce4c499BDe2CD90f3D (eth)