### PR TITLE
zrxairdrop.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -666,7 +666,6 @@
     "teslax.in",
     "app.fulcrum.repair",
     "jaxxx.io",
-    "besrtchange.ru",
     "zilllet.io",
     "moonllet.io",
     "app.moonllet.io",

--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,16 @@
     "torque.loans"
   ],
   "blacklist": [
+    "zrxairdrop.com",
+    "leddger.io",
+    "quickbtcminer.com",
+    "teslax.in",
+    "app.fulcrum.repair",
+    "jaxxx.io",
+    "besrtchange.ru",
+    "zilllet.io",
+    "moonllet.io",
+    "app.moonllet.io",
     "profittesla.com",
     "teslapayout.com",
     "givetesla.com",


### PR DESCRIPTION
zrxairdrop.com
Fake airdrop phishing for private keys with POST /
https://urlscan.io/result/67c6aa8a-d0a0-480e-ae38-dfde776e8609/
https://urlscan.io/result/69f268fe-92b6-4c26-b5db-197f7d77e9b0/
https://urlscan.io/result/f1febf5e-adf4-4811-9df8-cd8f8acc62d3/

quickbtcminer.com
Malware miner
https://urlscan.io/result/b036c770-612f-45df-b6f7-616573e863f5/

teslax.in
Trust trading scam site
https://urlscan.io/result/30b4cf0e-a2d6-49a5-9576-2c87347bab17/
https://urlscan.io/result/5e8ddd8b-8354-4c8e-be40-8400aac3ad7f/

jaxxx.io
Fake Jaxx site phishing for secrets with POST /save.php
https://urlscan.io/result/0a20f034-586e-4279-abd6-fcdff2413802/

zilllet.io
Fake Zillet site phishing for secrets with POST /process.php
https://urlscan.io/result/055c6168-e105-408a-a101-e0423b75a174/
https://urlscan.io/result/02abf30c-e073-4649-ab03-7f15e6e706e4/
https://urlscan.io/result/30d4dcc8-b8b6-41fd-9c36-8bce9e72f4d3/
https://urlscan.io/result/2d16eb7b-e31b-438f-bff2-181a5468a9c7/

moonllet.io
Fake Moonlet site phishing for secrets with POST /recover.php
https://urlscan.io/result/05fd823d-fbdc-431d-9aeb-1a721b54d911/