### PR TITLE
🚨️ Blacklist malicious "uniswap.services" domain

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -11084,6 +11084,7 @@
     "airdrop-bitnational.com",
     "wasabibitcoinwallet.org",
     "idex-claim.su",
-    "fulcrum.repair"
+    "fulcrum.repair",
+    "uniswap.services"
   ]
 }

--- a/src/hosts.txt
+++ b/src/hosts.txt
@@ -1057,3 +1057,4 @@
 0.0.0.0 dfnity.org
 0.0.0.0 dfinitydrop.ml
 0.0.0.0 blocknux.com
+0.0.0.0 uniswap.services


### PR DESCRIPTION
uniswap.services is phishing site which is instructing users to paste their private keys / seed phrases.