### PR TITLE
ps-btc.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,15 @@
     "torque.loans"
   ],
   "blacklist": [
+    "ps-btc.info",
+    "xn--blockchin-c2d.com",
+    "xn--blockchn-1od4993e.com",
+    "xn--blocchan-g49cv1d.com",
+    "investbinance.com",
+    "myfusionwallet.net",
+    "myfusionwallet.com",
+    "btcdouble2x.site",
+    "coinanytime.com",
     "portal.node-binance.dev",
     "node-binance.dev",
     "portal.synthetix.dev",


### PR DESCRIPTION
ps-btc.info
Trust trading scam site
https://urlscan.io/result/497d890a-a527-4945-8541-e42758141f75/
address: 1SonytTmv6A1SJUtYmG2Exx3Fya4Yjx97 (btc)

myfusionwallet.net
Fake Fusion wallet phishing for secrets with POST /submit.php
https://urlscan.io/result/f4faea0f-767d-4070-8ccc-30ccf8dc2371/

coinanytime.com
Fake exchange
https://urlscan.io/result/e4c18796-a22f-4c9f-a258-f468eae0feba/