### PR TITLE
ia801505.us.archive.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,7 @@
     "torque.loans"
   ],
   "blacklist": [
+    "ia801505.us.archive.org",
     "ps-btc.info",
     "xn--blockchin-c2d.com",
     "xn--blockchn-1od4993e.com",


### PR DESCRIPTION
ia801505.us.archive.org
Trust trading scam site
https://urlscan.io/result/f302a2b7-6984-4601-81cb-992b10ab88dd/
address: 0x0111a93692b5CCFF5C4b006d88d82664f76DFd21 (eth)