### PR TITLE
dropelon.co + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,9 @@
     "torque.loans"
   ],
   "blacklist": [
+    "dropelon.co",
+    "btc-event.org",
+    "btcmixer.tech",
     "muskevent.net",
     "muskxdrop.info",
     "musk-give.online",


### PR DESCRIPTION
dropelon.co
Trust trading scam site
https://urlscan.io/result/7b4466bc-001d-4b92-afb0-2a86f17afdd4/
https://urlscan.io/result/0a46a475-a76a-4ccd-bdab-25d320722cad/
https://urlscan.io/result/8db7af0a-58f7-441a-9149-776c6d2ae78d/
address: 0xE10c32eCac0bD4767e21bB05b16Ae7Ed1b7D457B (eth)
address: 14rKdzbFzAzAhCWYpX3RGrt8HYr9NL5RqS (btc)