### PR TITLE
ripple.com.bz

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "xn--ripp-yva1x.com",
+    "ripple.com.bz",
     "chainlinktoken.info",
     "node-binancedex.online",
     "hexnode.online",


### PR DESCRIPTION
ripple.com.bz
Fake Ripple site phishing for secrets with POST /post.php
https://urlscan.io/result/59a908c9-81b6-4b7c-ab0c-4f960301d2a7/
https://urlscan.io/result/b5b470e3-37b3-444a-a611-1b5cbaf72e70/
https://urlscan.io/result/65cc3dd3-3de0-4bd2-8a63-24ef1d7d0e4a/