### PR TITLE
fulcrum.plus

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,10 @@
     "torque.loans"
   ],
   "blacklist": [
+    "fulcrum.plus",
+    "eth.fulcrum.plus",
+    "usdc.fulcrum.plus",
+    "dai.usdc.fulcrum.plus",
     "xn--ripp-yva1x.com",
     "ripple.com.bz",
     "chainlinktoken.info",


### PR DESCRIPTION
fulcrum.plus
Fake Fulcrum tool phishing for funds
https://urlscan.io/result/1e33bb52-9d37-4e89-b795-d6144032a4f2/
https://urlscan.io/result/519ee64d-24d4-4274-be1e-3656eb26f0a2/
https://urlscan.io/result/927a5fcd-5dc7-42b2-a4ba-4fe151e5da7a/
https://urlscan.io/result/e09345f8-036e-424d-9243-52431d67bb8f/
https://urlscan.io/result/0a556d57-07e4-4c0b-b5e9-29053cdce5d9/
address: 0x830B99a1DF212abE46C2634F4a0D26685b2B83cF (eth)
address: 0xa5b424581C8B8037aB34cf0F3537911a8e7ACA41 (eth)