### PR TITLE
avubit.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,7 @@
     "torque.loans"
   ],
   "blacklist": [
+    "avubit.com",
     "fulcrum.plus",
     "eth.fulcrum.plus",
     "usdc.fulcrum.plus",


### PR DESCRIPTION
avubit.com
Fake exchange phishing for deposits
https://urlscan.io/result/58ce6e0c-811f-46b0-9bac-8d7b91ebb963/
address: MWhbe8B8YtU8J1MsFavtkGVYqAABTKMds4 (ltc)
address: 0x0C7bdabE793f84A8F8FCBa6A84EDdD7B250B6481 (eth)
address: 3CpCLbYjwXjYonyUXqdJ3pQHn5VyS6ysrn (btc)