### PR TITLE
linkcoinairdrop.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,9 @@
     "torque.loans"
   ],
   "blacklist": [
+    "linkcoinairdrop.com",
+    "batairdrop.com",
+    "team-blockchain.info",
     "avubit.com",
     "fulcrum.plus",
     "eth.fulcrum.plus",


### PR DESCRIPTION
linkcoinairdrop.com
Fake Chainlink airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/2764cf72-17a2-4e4a-a4f5-0e96d9a73773/
https://urlscan.io/result/4f1e33a4-6d26-4ef8-97b9-69cb865b7818/
https://urlscan.io/result/ad6d3331-0a6a-4b6c-b325-ec3c2f829c52/