### PR TITLE
blogstellar.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,14 @@
     "torque.loans"
   ],
   "blacklist": [
+    "xn--rippl-8ra.com",
+    "blogstellar.org",
+    "claimstellar.com",
+    "xn--accountvewer-stellar-pbd.com",
+    "xn--troscan-mkb.org",
+    "xn--tellar-2ib.org",
+    "xn--stelar-5db.com",
+    "getxlm.org",
     "xn--stelar-6db.org",
     "accountviewer.xn--stelar-6db.org",
     "getripple.org",


### PR DESCRIPTION
blogstellar.org
Fake Stellar site linking users to accountviewer.xn--stelar-6db.org
https://urlscan.io/result/f05b28ca-6707-40f0-85da-e9584720c3c9/

xn--accountvewer-stellar-pbd.com
Fake Stellar site phishing for secrets
https://urlscan.io/result/c5e45ba5-69a1-4fc9-8dd0-9eff4b8bbbcd/