### PR TITLE
bitcoinblack.cash + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "0101.systems",
+    "bitcoinblack.cash",
     "xn--rippl-8ra.com",
     "blogstellar.org",
     "claimstellar.com",


### PR DESCRIPTION
bitcoinblack.cash
Fake giveaway phishing for emails
https://urlscan.io/result/6d7f3913-cde7-4b2d-add7-48fc9f305e3d/

0101.systems
Fake Electrum wallet phishing for secrets with POST /api.php
https://urlscan.io/result/fa69de32-1ceb-4a92-9be0-ecd919ca5931/
https://urlscan.io/result/eb6c94d1-cc1a-46d3-ba7c-ed719200d525/