### PR TITLE
dexapis.xyz + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,11 @@
     "torque.loans"
   ],
   "blacklist": [
+    "dexapis.xyz",
+    "the-blockchain.com",
+    "arbitragecrypto.org",
+    "theapi.pro",
+    "elonevent.site",
     "trustapp.ltd",
     "myrthervvellanti.com",
     "guadra.com",


### PR DESCRIPTION
dexapis.xyz
Fake Binance phishing for secrets with POST /api/validate/
https://urlscan.io/result/ccd30a34-4c1d-4d7d-b5a2-0e4edd941b8a/
https://urlscan.io/result/353c444b-29bb-45e8-af57-da2cdcc4f344/
https://urlscan.io/result/2061ef9d-fe66-42fe-ad63-42ef41046d38/

the-blockchain.com
Fake news site directing users to a Fake Stellar site xn--stelar-6db.org
https://urlscan.io/result/e63cd0b1-3155-4ba9-bfb6-ee3fd3a6dc5d/

arbitragecrypto.org
Fake exchange phishing for deposits
https://urlscan.io/result/d76260a8-395c-4362-9ab0-dffa7d5fbbd1/
address: 1GvguQFtP8qtjZYKhV7e5ynHfp4K9P2oaY (btc)

elonevent.site
Trust trading scam site
https://urlscan.io/result/5d090367-d786-446e-b9b2-ff87113c57c9/
https://urlscan.io/result/02ced759-a625-48d1-b637-a51632894ca7/
https://urlscan.io/result/1906115d-1cd0-44d1-b09f-f2f95c4d7237/
address: 1TESLAm6THJvbj7UyQzVuGBhYKcZn5u3o (btc)
address: 0xf6945f3297Aa17EC806Ed1323679a2457b5f003D (eth)