### PR TITLE
Block compoundnode.dev

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,7 @@
     "torque.loans"
   ],
   "blacklist": [
+    "compoundnode.dev",
     "lumiwalletapp.com",
     "dashwalletapp.com",
     "metamask.ltd",


### PR DESCRIPTION
It featured a fake MetaMask popup embedded within the page, and it asks for your private key.