### PR TITLE
notall.eshost.com.ar + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "notall.eshost.com.ar",
+    "notallwallet.ml",
     "bavbit.com",
     "tesla-bonus.com",
     "trez0r.com",


### PR DESCRIPTION
notall.eshost.com.ar
Fake recovery tool phishing for secrets with GET /index2.php?wallet=<private_key>
https://urlscan.io/result/98a33a61-8388-4737-9fb4-1d6c892ef21d/
https://urlscan.io/result/d550e277-62bd-46ed-8206-6b1e2b51effa/

notallwallet.ml
Fake recovery tool phishing for secrets with GET //notall.eshost.com.ar/index2.php?wallet=<private_key>
https://urlscan.io/result/d550e277-62bd-46ed-8206-6b1e2b51effa/
https://urlscan.io/result/fb65b7ef-ac69-4c37-89ea-d1f78df4cc9b/