### PR TITLE
avaxweb.typeform.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "avaxweb.typeform.com,
+    "elonx.co",
     "notall.eshost.com.ar",
     "notallwallet.ml",
     "bavbit.com",

--- a/src/config.json
+++ b/src/config.json
@@ -660,7 +660,7 @@
     "torque.loans"
   ],
   "blacklist": [
-    "avaxweb.typeform.com,
+    "avaxweb.typeform.com",
     "elonx.co",
     "notall.eshost.com.ar",
     "notallwallet.ml",


### PR DESCRIPTION
avaxweb.typeform.com
Fake Ava crowdsale
https://urlscan.io/result/5063fae7-e3c6-4edc-a76d-3edf10f0af20/
address: bc1qgxsey0klllnhue0cltqgdu0nprasu87uvgg7t3 (btc)
address: 0xc1bE0c106963dDc7F76655006ebc9F4B0855642D (eth)
address: 0xCdE7411dEAd6698E1effa8Ef64FB0063857E7e7f (eth)

elonx.co
Trust trading scam site
https://urlscan.io/result/b71a96cb-8328-4967-aca7-0f19a25782f8/
https://urlscan.io/result/82ca0340-bbb1-4d1a-a192-9e8d761b57e9/
https://urlscan.io/result/06092055-56bc-4132-aa0b-7a36bafd007a/
https://urlscan.io/result/d21629f5-d608-4f18-88d1-aa0d84aa9f4a/
https://urlscan.io/result/2b604246-7848-477c-87e2-c0c7a8ebec97/
address: 1ELoNKrzDHQHrPozNT4QKsbBL1rsvdfm7 (btc)
address: 0x1D153deE0A823e9238b4F2E83758E27Be3f1158e (eth)
address: rLp4FVEPo5evkpoGjJ4yxHUerRoWRc5rH4 (xrp)