### PR TITLE
muskspacex.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,10 @@
     "torque.loans"
   ],
   "blacklist": [
+    "muskspacex.org",
+    "pool.balancer.dev",
+    "balancer.dev",
+    "bitcoinsearchengines.store",
     "avaxweb.typeform.com",
     "elonx.co",
     "notall.eshost.com.ar",


### PR DESCRIPTION
muskspacex.org
Trust trading scam site
https://urlscan.io/result/e41e552f-3152-4a32-8984-8dcf7e550a4f/
https://urlscan.io/result/a266a2fb-267b-4d9f-bdaf-1eea3bdb966e/
https://urlscan.io/result/6a75cc1a-e696-4e59-9c42-0798573e45bc/
address: 1BcUR3gUdP8ofhqNaRtWFtChE4fifxK46C (btc)
address: 0xa71073cbc47c62257a0749503bdbd4d9b5595294 (eth)

pool.balancer.dev
Fake Balancer site phishing for private keys with a fake MetaMask popup
https://urlscan.io/result/35281fc3-f9fc-4299-922d-c754d9644816/
https://urlscan.io/result/06ee426f-7ae6-424a-887d-2d58bc0454ca/