### PR TITLE
event-eth.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,9 @@
     "torque.loans"
   ],
   "blacklist": [
+    "event-eth.info",
+    "fundsretrieve.com",
+    "bat-airdrop.com",
     "cryptotabhack.com",
     "freebitgenerator.com",
     "tron-project.com",


### PR DESCRIPTION
event-eth.info
Trust trading scam site
https://urlscan.io/result/ab3fced1-6a9d-46fb-8554-a9b54adbb3af/
address: 0x015a8f02b4e55b3c93678e5b44f7205ff9e8ece2 (eth)

fundsretrieve.com
Fake fund recovery service
https://urlscan.io/result/0c2ef7c9-4aa6-4132-a573-5d350f41b052/

bat-airdrop.com
Fake BAT airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/96db2eb7-1e91-44a4-a5f0-f53e4ef31716/
https://urlscan.io/result/e89396f9-2d1e-40da-ae22-b7ea9dc6c690/
https://urlscan.io/result/d9c1a42e-4cfd-4917-b88b-5ace53516a46/