### PR TITLE
tronairdrop.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -660,6 +660,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "tronairdrop.com",
+    "stellar-limited.com",
     "verify.paxfulsupport.online",
     "paxfulsupport.online",
     "im-creator.com",


### PR DESCRIPTION
tronairdrop.com
Fake Tron airdrop prompting malware - https://app.any.run/tasks/8eba6336-a61f-4f80-9f36-3f1103b1d339
https://urlscan.io/result/934d2aa8-39af-41c0-87c6-3884485d0c0e/