### PR TITLE
cryptoforhealth.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -661,6 +661,7 @@
     "torque.loans"
   ],
   "blacklist": [
+    "cryptoforhealth.com",
     "xn--binnce-kta.com",
     "xn--blnnce-dd8b.com",
     "node.uniswapv1v2.app",


### PR DESCRIPTION
cryptoforhealth.com
Trust trading scam site
https://urlscan.io/result/74d0fc4f-6ee1-4e4a-986b-3f75adf609af/
address: bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh (btc)