### PR TITLE
fundusdt.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -661,6 +661,11 @@
     "torque.loans"
   ],
   "blacklist": [
+    "fundusdt.com",
+    "v4-antpool.com",
+    "airdrop2020.com",
+    "wozbtcfunds-joinpromotion.com",
+    "btcxevent.com",
     "cryptoforhealth.com",
     "xn--binnce-kta.com",
     "xn--blnnce-dd8b.com",


### PR DESCRIPTION
fundusdt.com
Trust trading scam site
https://urlscan.io/result/c1b28e5a-25f6-4dfb-ad61-066eca5f6960/
address: 0x521627A7b963700B0Bc6B03956e6FDaaA86f1C1e (eth)

v4-antpool.com
Fake antpool site (coinpayments merchant: 8b6232573cfe7a219e76a9da45db5024)
https://urlscan.io/result/6653fdf3-d475-4d6f-ad6a-3db39108c74c/

wozbtcfunds-joinpromotion.com
Trust trading scam site
https://urlscan.io/result/90af6e8d-6fc8-43a8-9e32-11b1caba0f20/
address: 3DgNrMHMyoQHT3MD5sgsEWt6mjCEbCCDh5 (btc)