### PR TITLE
bafbit.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -661,6 +661,12 @@
     "torque.loans"
   ],
   "blacklist": [
+    "bafbit.com",
+    "frezor.us",
+    "gemini-btc.news",
+    "avaxsales.net",
+    "cryptominer.tel",
+    "bitcryptomania.com",
     "fundusdt.com",
     "v4-antpool.com",
     "airdrop2020.com",


### PR DESCRIPTION
bafbit.com
Fake exchange phishing for deposits
https://urlscan.io/result/5a745560-f9e0-45c9-84e0-4c7513f3222e/

frezor.us
Fake Trezor site phishing for secrets with POST /ssnd_3.php
https://urlscan.io/result/cc6e1035-40cb-4836-8f9a-e0fcd4d9c5f3/
https://urlscan.io/result/3217ddde-325d-4167-b96e-89b71bde8711/
https://urlscan.io/result/a175ca97-6ad9-40ba-a8eb-d8e6ae125f28/

gemini-btc.news
Trust trading scam site
https://urlscan.io/result/ddd64f16-b07b-44aa-a6c0-3f66db58981f/
address: 1Pm4QQcoXWpX8S4hyEai5obzJZMHH6Zw8m (btc)

cryptominer.tel
Fake web miner
https://urlscan.io/result/d537bce2-6ab8-4eb5-8d6d-0116c611b630/
https://urlscan.io/result/9f422136-45d8-45f6-826a-9901b0aa0ea7/
https://urlscan.io/result/e59e067e-6d05-426f-be2a-e4a98205f548/
https://urlscan.io/result/2813e425-6175-4119-a2f7-761c943c8465/
address: 0xd5a9f47af9b7cd29697da45b295744171f5d78b2 (eth)
address: MP8aaUraktPi2LnWxwsKuhZkDaBTPZFJMf (ltc)

bitcryptomania.com
Fake investment platform scamming for deposits
https://urlscan.io/result/52a10101-598f-4a2f-8934-edefa79c4eb3/