### PR TITLE
batairdrop.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -662,6 +662,11 @@
     "torque.loans"
   ],
   "blacklist": [
+    "batairdrop.net",
+    "makerdaoweb.org",
+    "vitalik.top",
+    "ether-promo-participate-now.com",
+    "ether-promo.com",
     "bafbit.com",
     "frezor.us",
     "gemini-btc.news",


### PR DESCRIPTION
batairdrop.net
Fake airdrop phishing for keys with POST /sign.php
https://urlscan.io/result/e970a573-4b1c-40a8-a3b2-1fd9a2f856ea/
https://urlscan.io/result/bd39bcd8-73c2-4e41-8b20-a32a7feb7af5/
https://urlscan.io/result/dc62834e-d510-4688-a742-b487ac0fa22d/

makerdaoweb.org
Trust trading scam site (Fake MakerDao competition)
https://urlscan.io/result/e71a4538-81b7-4824-bc43-89fbadada0ef/
https://urlscan.io/result/1e5dcde6-b7e2-4f62-882b-2ed0e1973a34/
address: 0x256D46b673825a5EeDfF1bf8E0a967a5f99Ea1cc (eth)

ether-promo-participate-now.com
Trust trading scam site
https://urlscan.io/result/a07dd17c-b5ca-41ca-ac28-d8e4af9999ff/
address: 0xc8562528E89f27062FB910C64aB6263C5e2AafbB (eth)

vitalik.top
Trust trading scam site
https://urlscan.io/result/b45675df-d1a5-4cd4-be3d-7796ab757edb/
address: 0xCE08FA33203CaA2E3a4E641B90E92F6F95234099 (eth)