### PR TITLE
ia601405.us.archive.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -662,6 +662,7 @@
     "torque.loans"
   ],
   "blacklist": [
+    "ia601405.us.archive.org",
     "batairdrop.net",
     "makerdaoweb.org",
     "vitalik.top",


### PR DESCRIPTION
ia601405.us.archive.org
Trust trading scam site
https://urlscan.io/result/6b9f60b1-b8d2-4654-b5a0-c4591d32a47f/
https://urlscan.io/result/8825c4bf-a25f-4295-b217-7c037000dfcd/
address: 0x5af80572a85CFA273e3aa18CaB26fcF306B8dfF4 (eth)