### PR TITLE
unionfinance.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -662,6 +662,13 @@
     "torque.loans"
   ],
   "blacklist": [
+    "unionfinance.org",
+    "exoduss.org",
+    "excodus.io",
+    "exsodus.io",
+    "elcastrum.com",
+    "basbit.com",
+    "digiminer.io",
     "yfii.finance",
     "ia601405.us.archive.org",
     "batairdrop.net",


### PR DESCRIPTION
unionfinance.org
Fake Union Finance site
https://urlscan.io/result/9a22ee8a-a84f-4ea1-a182-7e4180f341e4/
address: 0x90f10470a7E90d9cB74Ceb57cC7AF22a8c4994FF (eth)

excodus.io
Fake Exodus site phishing for secrets with POST /save.php
https://urlscan.io/result/ce2204b2-b6f0-4d79-8fe0-0af371929f8f/

basbit.com
Fake exchange phishing for deposits
https://urlscan.io/result/9f3f9b3e-98cb-4090-b0fb-22dd3d66ac18/

digiminer.io
Fake webminer
https://urlscan.io/result/9cd91230-0635-46d1-a6cd-b4d074f2587a/
address: 1HBnZtT3s89pPbR7uPTyVv4hfZwFH3iAmG (btc)
address: 17CZGv5MHrj6hK7qfPShcfYYXPQ2W1GCx2 (btc)


---

freebtcminer.org
Fake webminer
https://urlscan.io/result/03ff368c-0ba2-4100-8359-a6c3b6a95bb6/
https://urlscan.io/result/78a34b43-565d-4f2d-a460-17daa2da8381/
https://urlscan.io/result/1c69f409-dda0-4d66-a9c8-0af8164bf23c/
https://urlscan.io/result/1d12f61a-477a-48b1-a9fe-ad7b6662a788/
address: 1PY1yWDqGN5KPhnTwSad3XbtDLXqjXN484 (btc)
address: 0x9735bA8D7374649d188AFaDEa5019e12d2587E00 (eth)