### PR TITLE
giveawayairdrop-eth.ga + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -662,6 +662,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "giveawayairdrop-eth.ga",
+    "secretmethodsnow.com",
     "airdropbat.com",
     "muskx.co",
     "daxxcoins.com",


### PR DESCRIPTION
giveawayairdrop-eth.ga
Fake Trust Wallet phishing for secrets with POST /truswallet.php?
https://urlscan.io/result/a5ec025f-6da4-4f3d-8e5d-e1140e974754/
https://urlscan.io/result/d4333d89-23ec-4efb-ad85-4fa975d9d58c/
https://urlscan.io/result/6f0adbc4-4357-4e75-805f-c3dcdf1e7225/

secretmethodsnow.com
Fake investment platform
https://urlscan.io/result/f9e2f1ba-e75f-49c7-b736-db3ece30499f/