### PR TITLE
Unblock YFII

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -706,7 +706,6 @@
     "elcastrum.com",
     "basbit.com",
     "digiminer.io",
-    "yfii.finance",
     "ia601405.us.archive.org",
     "batairdrop.net",
     "makerdaoweb.org",


### PR DESCRIPTION
Per [our blocking policy](https://github.com/MetaMask/eth-phishing-detect#blocking-policy), we will list sites that reuse or impersonate established brands. [Phish Fort very understandably flagged YFII](https://twitter.com/PhishFort/status/1287566239540404225) for its near identical name to YFI.

Since then, it's become clear that [YFII has its own loyal following](https://decrypt.co/37218/the-inside-story-of-yfii-chinas-celebrated-defi-knockoff) and it _may not_ be engaging in phishing.

I will unblock it for now, and if we see evidence of phishing YFI users we will re-block.

For future forks: I recommend you choose new names that distinguish yourselves, so you are not easily accused of deceiving users of the product you are forking.

Closes #4026