### PR TITLE
chamathcapital.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -670,6 +670,14 @@
     "torque.loans"
   ],
   "blacklist": [
+    "bestchamge.ru",
+    "chamathcapital.com",
+    "cardano-page.org",
+    "neo-live.org",
+    "elonmusk.capital",
+    "chamath.fund",
+    "vet.capital",
+    "giveeth.com",
     "appuniswap.com",
     "uniswapdex.org",
     "ethereumupdate.info",


### PR DESCRIPTION
appuniswap.live
Fake Uniswap phishing for secrets with POST /googleanalytics.php (redirect from uniswapdex.org)
https://urlscan.io/result/68d1d831-d56e-496f-91e6-27af499257a9/

chamathcapital.com
Trust trading scam site
https://urlscan.io/result/a8aa2a7b-3b71-4d48-bebb-c61ac0cd218a/
https://urlscan.io/result/7b8709bb-76bc-41c2-9437-8eb5381a0019/
address: 3BWDXBQyMAbZKEc8JT5UGdP4Ebi29orqkQ (btc)
address: 3DcTzg5Gyaj7JSAQu7gkqsoMztzUfwgT4u (btc)

cardano-page.org
Trust trading scam site
https://urlscan.io/result/85f2ad53-0d0a-466c-a396-364ed4e504b2/
https://urlscan.io/result/3efc18a0-cbb0-437b-aa6c-506fa9a581bd/
address: DdzFFzCqrhsxVRHtNc8vfrvQBfeRev9gNssNQFrGbKLqT5f5uAE6cJwuUCFx4i754aDZfMiM7CZAwGCLyHEmtPmuVvFxLqWcFrAhLGJV (ada)

neo-live.org
Trust trading scam site
https://urlscan.io/result/cadd5e9a-47be-427b-89f3-5453a4415c08/
https://urlscan.io/result/08a5ea3f-de99-4f16-bc85-da845371e315/
address: AJBM4nbzs8M79k5EioHZrj1QQ9kW2bE97W (neo)

elonmusk.capital
Trust trading scam site
https://urlscan.io/result/4fb1ce97-2af0-48c4-8acd-e7e7371620c2/
address: 18CpTwUqLyUY3K9s6VCNDeQ3noLu3251Ji (btc)

chamath.fund
Trust trading scam site
https://urlscan.io/result/c7a3f510-ab88-4c84-a580-b289c85b9154/
address: 15Lda7FW6ooCgtKJhMDbm9DCrFjN33Gafg (btc)

vet.capital
Trust trading scam site
https://urlscan.io/result/cd029ea7-dc94-4316-be8a-aeaf74ab5a4b/
address: 0x91b99dab2aaa6c87606924e1112c952276cb1b58 (vet)