### PR TITLE
Phishing site pretending to be Origin Protocol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -10205,6 +10205,7 @@
     "origirprotocol.com",
     "originprotocol.tokenpublicsales.com",
     "originprotocol.typeform.com",
+    "dshop.originprotocol.cordpidgeon.com",
     "trx.foundation",
     "tokensale.adhive.net",
     "adhive.net",


### PR DESCRIPTION
This scam is being widely promoted on Facebook using [fake pages](https://www.facebook.com/Origin-Protocol-Team-106702981143889/) pretending to be Origin Protocol.

https://dshop.originprotocol.cordpidgeon.com/