### PR TITLE
elonmuskevent.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -671,6 +671,13 @@
     "torque.loans"
   ],
   "blacklist": [
+    "elonmuskevent.com",
+    "elonmusk.network",
+    "bitcoincomputos.com",
+    "dshop.originprotocol.cordpidgeon.com",
+    "bitfurytrade.com",
+    "bitfuryweb.com",
+    "bitfuryinvest.co",
     "xn--unswap-q9a.com",
     "bestchamge.ru",
     "chamathcapital.com",


### PR DESCRIPTION
elonmuskevent.com
Trust trading scam site
https://urlscan.io/result/62772d6e-9a95-4730-9bc3-1d6addc9bbfc/
address: 1Musk12cgb4MBVtzECDrhb9dYTYsb8gPCz (btc)

xn--unswap-q9a.com
Fake Uniswap phishing for secrets with POST /googleanalytics.php
https://urlscan.io/result/0a123bd5-6eb0-4e87-b5ff-381427ed9ea5/

bitcoincomputos.com
Fake Bitcoin exchange
https://urlscan.io/result/f98417f8-7115-43a7-ad02-232c9d844332/
https://urlscan.io/result/de98a371-eab9-4b47-a45d-0f5c03d63293/
address: 19SFqd4iCByXqSqDmEVApA25eGoYknwApT (btc)
address: 19zyeofprSQc7DMZ93AHS9ZJsEuxcKUXhr (btc)

dshop.originprotocol.cordpidgeon.com
Fake Origin dshop phishing for logins
https://urlscan.io/result/fa0837f9-c326-4e24-9e9f-1b6f328ff928/

bitfurytrade.com
Fake Investment platform
https://urlscan.io/result/f4019246-5613-468a-9651-23d51ddd0213/

bitfuryweb.com
Fake webmining platform
https://urlscan.io/result/df1e8069-f038-4a7b-8b5f-c4ce71215170/

bitfuryinvest.co
Fake Investment platform
https://urlscan.io/result/be2bcaf5-bf31-49da-a6e2-97a013aa168d/