### PR TITLE
muskto.fun + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -678,6 +678,10 @@
     "torque.loans"
   ],
   "blacklist": [
+    "muskto.fun",
+    "musktop.pw",
+    "muskevent.org",
+    "huobl.ru",
     "uniswap.site",
     "metamask.eu",
     "app.xn--unswap-4va.com",


### PR DESCRIPTION
muskto.fun
Trust trading scam site
https://urlscan.io/result/646e0ec8-e1a6-41a6-a47c-ba983289cd96/
https://urlscan.io/result/0049ff71-cdaa-43e3-8649-ace5e445237a/
https://urlscan.io/result/2965bf1d-71c3-4cd0-920f-c4918afe4dde/
address: 19UdLwZKxboQCvB2AAddVF7hkXwwPRNfbP (btc)
address: 0x9F37c0F7F9d5E8aA3351aFb3D98D0Ae131FB3635 (eth)

musktop.pw
Trust trading scam site
https://urlscan.io/result/dfa02602-775d-4efb-b17e-8373cdd1fe5c/