### PR TITLE
2ethereum.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -678,6 +678,17 @@
     "torque.loans"
   ],
   "blacklist": [
+    "2ethereum.org",
+    "spacex-eth.biz",
+    "spacexethereum.net",
+    "xn--niswap-oya.com",
+    "metask.website",
+    "wallet.metask.website",
+    "spacex.click",
+    "tesla-musk.net",
+    "uniswapp.site",
+    "altexchenge.com",
+    "mycosmospay.com",
     "exoddus.net",
     "uniswap.net", 
     "uniswap.eu",


### PR DESCRIPTION
2ethereum.org
Trust trading scam site
https://urlscan.io/result/eb95199f-6e64-489b-a859-1d0f0edf11a7/
address: 0x3ad072778446db654Dee3FF5f80ac1e5AC12dD56 (eth)

spacex-eth.biz
Trust trading scam site
https://urlscan.io/result/c168f891-9fc5-4b96-ace4-b513067087f6/
address: 0xD5E310BD39cd20EC1db047eC1d28dddF9A520d51 (eth)

spacexethereum.net
Trust trading scam site
https://urlscan.io/result/ac7dd2f6-c427-4ca2-b573-42d68fc214e3/
address: 0xD200C6403509589098745490A1fAFA024c987581 (eth)

xn--niswap-oya.com
Fake Uniswap phishing for secrets with POST /googleanalytics.php
https://urlscan.io/result/4f14b269-6460-4b60-9562-29f74557dcdc/

wallet.metask.website
Fake MetaMask site phishing for secrets with POST /token.php
https://urlscan.io/result/7bdb5a5f-c5f9-4ede-a59c-9e4f491b8735/
https://urlscan.io/result/a8d58003-7f78-4612-a8ed-feb1ea7d6f2d/

tesla-musk.net
Trust trading scam site
https://urlscan.io/result/88d2ea2c-346a-4b0e-8328-33f857620049/
https://urlscan.io/result/f743b0a2-a22f-4390-a622-ebb74a2a806f/
https://urlscan.io/result/de444225-2d86-4964-aeb0-ce0532c41cc3/
address: 1C79u5iXhxp2fxcAU5CzJF8duEJRridyXq (btc)
address: 0xBeFE4154A616DAe79f90d496E104892b14292e17 (eth)