### PR TITLE
Reported fake uniswap sites

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -679,6 +679,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "appuniswop.site",
+    "unswap.site",
     "btcsystem-web-app.com",
     "hederabit.com",
     "nivbit.com",


### PR DESCRIPTION
Reported appuniswop[.]site along with unswap[.]site, in case 43851 with a linked conversation at Bitcointalk.org