### PR TITLE
Removing Mintable.app from blacklist as its domain is back online and there is no security risk

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -695,7 +695,6 @@
     "btctesla.org",
     "muskgive.top",
     "space-elon.site",
-    "mintable.app",
     "cutve.finance",
     "appuniswop.org",
     "appuniswop.site",


### PR DESCRIPTION
Removing mintable.app domain as it's domain is back online and there is no risk to users or security access from any malicious actor.