### PR TITLE
stellar.org.sb

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -680,6 +680,7 @@
     "torque.loans"
   ],
   "blacklist": [
+    "stellar.org.sb",
     "excodus.cf",
     "exodus.cf",
     "electrumy.org",


### PR DESCRIPTION
stellar.org.sb
Fake Stellar site phishing for keys with POST /post.php
https://urlscan.io/result/d58565bf-e90a-421b-bc2c-b81430140e32/
https://urlscan.io/result/7198e7e5-d0c6-4e58-a263-4c676eb78a50/
https://urlscan.io/result/c59e1067-4e3d-4556-96e0-761d0776406e/