### PR TITLE
cryptogifts.s3.us-east-2.amazonaws.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -680,6 +680,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "cryptogifts.s3.us-east-2.amazonaws.com",
+    "xrp-funds.com",
     "omisego-giveaway.blogspot.com",
     "omg-giveaway.blogspot.com",
     "uniswap-x.com",


### PR DESCRIPTION
cryptogifts.s3.us-east-2.amazonaws.com
Trust trading scam site
https://urlscan.io/result/402d4248-aca7-41e8-b8b7-84920e88a88b/
https://urlscan.io/result/858561ca-8333-4190-a073-2908db2ba842/
https://urlscan.io/result/eb660345-ac56-44aa-bc86-35995f5d424b/
address: 0x2135883c8934a4588bAB6efAA785e1C1ae39baEc (eth)

xrp-funds.com
Trust trading scam site
https://urlscan.io/result/6f77fd16-c2a3-4a03-b588-b911a881e258/
address: rpbEnGX29zTJez3yV17E71s7AVkmCch63o (xrp)