### PR TITLE
cryptogifts.s3.amazonaws.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -680,6 +680,8 @@
     "torque.loans"
   ],
   "blacklist": [
+    "cryptogifts.s3.amazonaws.com",
+    "xrp-event.com",
     "cryptogifts.s3.us-east-2.amazonaws.com",
     "xrp-funds.com",
     "omisego-giveaway.blogspot.com",


### PR DESCRIPTION
cryptogifts.s3.amazonaws.com
Trust trading scam site
https://urlscan.io/result/a001662a-ea59-42d0-919a-83cac3c0b298/
https://urlscan.io/result/4696acb1-6878-4426-9f7b-1cd6c03d4de5/
address: 0x2135883c8934a4588bAB6efAA785e1C1ae39baEc (eth)

xrp-event.com
Trust trading scam site - tag 7777777
https://urlscan.io/result/8cad2966-1c0c-4e3e-a928-6cf861d4b72a/
address: rH53Fwm247eu5LY4Fs5qZEhLqQDBhH7vK4 (xrp)