### PR TITLE
binance.oktaplatform.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,9 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "binance.oktaplatform.com",
+    "trustswap-rewards-programs-claims-tokens.com",
+    "freebitcoinmining.website",
     "omgnetwork.info",
     "atomicweb.network",
     "wallet.atomicweb.network",


### PR DESCRIPTION
binance.oktaplatform.com
Fake Binance site phishing for logins with POST /login/cert
https://urlscan.io/result/9df7db07-21e8-4a93-8f94-a3003272bc17/

trustswap-rewards-programs-claims-tokens.com
Fake MyEtherWallet phishing for secrets with POST /myetherwallet.php/
https://urlscan.io/result/892749c5-33e0-48f7-857c-48d2058958ff/
https://urlscan.io/result/d44b3f8e-2deb-4827-a7d5-b6b0a10546a8/

freebitcoinmining.website
Fake cloudminer
https://urlscan.io/result/80614852-d427-48a5-8235-f290b1c38b01/
address: 19aGJV9X9kETEWZ7kXqXBgm8BJ7xWot1yz (btc)