### PR TITLE
omisegoairdrop.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,18 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "omisegoairdrop.info",
+    "siubit.com",
+    "linkcoinbonus.com",
+    "link-token.com",
+    "goairdrop.fun",
+    "goairdrop.pro",
+    "eth-link.site",
+    "airdrop-linkchain.site",
+    "airdropwallet.pro",
+    "airdropwallet.site",
+    "airdrop-linkchain.pro",
+    "tokenlink.info",
     "trezor.com.se",
     "restore-ledger.org",
     "wallet.restore-ledger.org",


### PR DESCRIPTION
omisegoairdrop.info
Fake OmiseGo airdrop phishing for secrets with POST /sign.php (promoted by twitter id 1227974606448885760)
https://urlscan.io/result/f51f912e-8576-4bf4-9874-c72f13e0d704/
https://urlscan.io/result/f8131a7e-ef3d-4dbd-aa3d-49a285816c79/
https://urlscan.io/result/95440e80-79b9-4858-a0ee-bdbc637fc83a/