### PR TITLE
renairdrop.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,10 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "renairdrop.com",
+    "uniswapnode.com",
+    "app.uniswapnode.com",
+    "drop-eth.org",
     "jdax.market",
     "supportbnb.com",
     "bin-crypto.com",


### PR DESCRIPTION
renairdrop.com
Fake airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/59f48c88-2b30-4bd3-b018-26041384c72a/
https://urlscan.io/result/88a27a42-bee2-4d61-a815-7087103efd71/
https://urlscan.io/result/f545dfa8-0d14-47df-bbcb-12d1847c29f6/

uniswapnode.com
Fake Uniswap phishing for secrets with POST //vooom-6652.restdb.io/rest/unis (x-apikey: 5ef928e3a529a1752c476ac1)
https://urlscan.io/result/89496698-9140-42e9-abf2-801caab78df7/

drop-eth.org
Trust trading scam site
https://urlscan.io/result/92aff596-308b-4546-a7fb-88e7cdcfef5d/
address: 0x0297772598B604CcE74BAfEA2B863205541934Aa (eth)