### PR TITLE
cryptonil.ltd + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,9 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "cryptonil.ltd",
+    "ledger.com.de",
+    "rewards-coin.000webhostapp.com",
     "renairdrop.com",
     "uniswapnode.com",
     "app.uniswapnode.com",


### PR DESCRIPTION
cryptonil.ltd
Trust trading scam site - fake doubler
https://urlscan.io/result/ef1d3b9f-b57e-4520-b718-33ea6b0259fd/
address: 39Nj3fhsQewWMgcNtQ6cuyuuw78bSPseTy (btc)

ledger.com.de
Fake Ledger site phishing for secrets  - https://twitter.com/Mutex_Lock/status/1303364247070691328
https://urlscan.io/result/782110a1-b075-4871-a99e-06a46d7d5485/

rewards-coin.000webhostapp.com
Fake MyEtherWallet phishing for secrets with POST /error.php?access-my-wallet
https://urlscan.io/result/9f0ee211-c5d2-464d-b50e-54dfc8204c9e/
https://urlscan.io/result/09e18b51-4ff0-438c-a77f-95004ffdd7ef/