### PR TITLE
Temporarily remove auctus from fuzzylist protection

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -10,7 +10,6 @@
     "localcryptos.com",
     "dfinity.org",
     "hederahashgraph.com",
-    "auctus.org",
     "etherscan.io",
     "originprotocol.com",
     "makerdao.com",


### PR DESCRIPTION
Due to [an outstanding bug](https://github.com/MetaMask/eth-phishing-detect/issues/4192), the auctus fuzzylist is blocking some audius pages.