### PR TITLE
diubit.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,11 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "diubit.com",
+    "teslamining.ltd",
+    "riubit.com",
+    "but-send.top",
+    "eth-news.com",
     "swerve-finance.com",
     "czbinance.co",
     "crypto2xpool.com",


### PR DESCRIPTION
diubit.com
Fake exchange phishing for deposits
https://urlscan.io/result/303ebb1e-a6cf-4b0b-bcb8-23e8f21cd3a8/

riubit.com
Fake echange phishing for deposits
https://urlscan.io/result/942ce6ff-ebaa-49b2-a727-3fb094d3ea4c/

teslamining.ltd
Fake webminer
https://urlscan.io/result/739003f0-46ce-4975-8938-168633a782d5/

but-send.top
Trust trading scam site
https://urlscan.io/result/52d617dd-5577-4302-b801-328fbe99937a/
address: 0xC6a4f03F745f4203B2DB7C520b327a27bF070172 (eth)

eth-news.com
Trust trading scam site
https://urlscan.io/result/d8fd6e15-575d-46b8-9869-0daab8b1eb21/
https://urlscan.io/result/516f2605-29f0-4859-bcce-38fdb051ddc9/
address: 0x6Ae7b0F39EbaC0E0abBC0eD0d741939942a65701 (eth)