### PR TITLE
sushi-gifts.blogspot.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,9 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "sushi-gifts.blogspot.com",
+    "vbeth.com",
+    "uniairdrop.com",
     "futures-binance.co",
     "uni-giveaway.blogspot.com",
     "genscripteth.go.yo.fr",


### PR DESCRIPTION
sushi-gifts.blogspot.com
Trust trading scam site
https://urlscan.io/result/cc97b7e7-cbe9-4686-af08-02a72894c032/
https://urlscan.io/result/f836aba7-fba9-49ef-bb2f-eece7ace51ec/
address: 0x936013fc672f8dE42c4C02Af0c0EB18a23eBfeC0 (eth)

vbeth.com
Trust trading scam site
https://urlscan.io/result/0d8be235-bcf7-4520-88e4-0411dd2b62ed/
address: 0xCE005DA1073375BF4780aae45fAeD1aA7c94712c (eth)

uniairdrop.com
Fake airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/e0920404-04f3-479a-b7f1-72d38c7e4059/
https://urlscan.io/result/bd63c6df-5fd6-4616-8909-544631e793d9/
https://urlscan.io/result/391fc084-b0c0-4037-9e74-c98005439e74/