### PR TITLE
unidrop.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,9 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "unidrop.org",
+    "polkawallets.site",
+    "tradeintel.biz",
     "sushi-gifts.blogspot.com",
     "vbeth.com",
     "uniairdrop.com",


### PR DESCRIPTION
unidrop.org
Trust trading scam site
https://webcache.googleusercontent.com/search?q=cache:v4W5rLFGhAwJ:https://unidrop.org/+&cd=1&hl=en&ct=clnk&gl=uk
address: 0xB0091BE2ea814275a4590AFbdf7c609C8e27BFee (eth)

polkawallets.site
Fake Polkawallet site phishing for secrets with POST /mnemonic.php
https://urlscan.io/result/05c8d12d-905b-4860-834a-11ac81729825/