### PR TITLE
muskbtcx.top + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,9 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "muskbtcx.top",
+    "binance-defi.net",
+    "binance-smart.com",
     "unidrop.org",
     "polkawallets.site",
     "tradeintel.biz",


### PR DESCRIPTION
muskbtcx.top
Trust trading scam site
https://urlscan.io/result/6dc618f6-7253-4a3d-a04a-613f9219766a/
address: 1FBujpGzjBdR7vjrHFFTcMqzQFbubvPmGQ (btc)

binance-defi.net
Trust trading scam site
https://urlscan.io/result/cd4206a6-a237-40e9-aedb-07de4c8d1200/
https://urlscan.io/result/d28ed30f-6a14-48a0-a3fb-ceed9b83255c/
https://urlscan.io/result/d65c0ad5-edbe-440c-93a0-095e18cfcff6/
https://urlscan.io/result/80b59b87-5c3e-49fc-ad28-0d8299344f65/
address: 1LWWjzf9bT7MxUuenmT4QCmakZUmKDjJ6P (btc)
address: 0xB4fa90E3fc495Ec7C57FC3aA580F07DadEf8e0B3 (eth)

binance-smart.com
Trust trading scam site
https://urlscan.io/result/f2af9aaa-1217-4810-87e2-af84d9930b5a/
https://urlscan.io/result/84ccbf2c-d330-4991-af34-fe28930b9808/
https://urlscan.io/result/dc44e586-603f-4344-ad12-862c6aad036d/
https://urlscan.io/result/fc8a6f36-d283-4a05-8813-52832a084c57/
address: 1M7TNrXpBsZJDHxCiDS2YZE5v88tBE9Zxx (btc)
address: 0x3C83CeCe2025C51D964DDEe6c7ec9812Aef4F1AD (eth)