### PR TITLE
sushigiveaway.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,8 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "sushigiveaway.com",
+    "omg-airdrop.io",
     "muskbtcx.top",
     "binance-defi.net",
     "binance-smart.com",


### PR DESCRIPTION
sushigiveaway.com
Trust trading scam site
https://urlscan.io/result/7a293d48-04f7-4fae-b977-ffa0826e9c14/
https://urlscan.io/result/6d9cbd7e-c2ec-43c2-91c4-41bec4b32d5c/
address: 0x6350fb4a8bc3cda203cfe00f87ba0f7b3bf61600 (eth)

omg-airdrop.io
Fake airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/7accb8bc-2548-4bf2-99b0-e3886653e73a/
https://urlscan.io/result/17ee16d9-81bf-486c-a7c5-b98897cf22f6/
https://urlscan.io/result/f53236ef-7aaa-433e-afdd-56eb60dd99f8/