### PR TITLE
un2app.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,8 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "un2app.com",
+    "fund-vechain.com",
     "chico-eth.com",
     "cryptogenscript.com",
     "officialvbuterin.com",


### PR DESCRIPTION
un2app.com
Fake Uniswap app
https://urlscan.io/result/563c9617-d569-4c0a-b1a0-393bce776862/

fund-vechain.com
Trust trading scam site (xrp destination tag: 100992747)
https://urlscan.io/result/f16f6cb7-1240-4efc-bbd1-98f72c6724d0/
https://urlscan.io/result/e86a6a17-1673-4912-aa70-37d46d7330cd/
https://urlscan.io/result/49c636c1-62f6-41ca-b5ec-c179c41d34f0/
https://urlscan.io/result/161ab021-94ca-4d14-9676-fef0f27b22ad/
https://urlscan.io/result/d97f5db0-1b72-4c20-b5d7-46ba2c0aeaf9/
address: 0x84D785f443dF8F1f4e113fCa0b37b0fB59c8a0E0 (eth)
address: 0xd4637c5588242836C28d4bC2Be560B07a49222C3 (eth)
address: 1MqkvAoQ47NEFbtqfob5oVTwvwym5C7MhM (btc)
address: rFqfCQ6cyJAQem9henkQkAsjuXrL4JEuo (xrp)
address: 0xb42880C7590320531D1492Ef0ed11Bf84fAB5B8C (eth)