### PR TITLE
accountviewer.stellar.org.za + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,9 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "accountviewer.stellar.org.za",
+    "stellar.org.za",
+    "uni-drop.org",
     "un2app.com",
     "fund-vechain.com",
     "chico-eth.com",


### PR DESCRIPTION
accountviewer.stellar.org.za
Fake Stellar site phishing for secrets
https://urlscan.io/result/80cd8a60-1b76-483d-9f01-23fb222388c8/
https://urlscan.io/result/73c228f8-4e07-4952-8364-0654ae228d7b/

uni-drop.org
Trust trading scam site
https://urlscan.io/result/286f6ec5-ecc9-4734-989e-139833300820/
https://urlscan.io/result/ecd35c5f-82f0-4bae-ad71-fad67f15c0df/
address: 0x18F39eAd861d9EDD999900a1Ea8f4193a481E78f (eth)