### PR TITLE
unigiveaway.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,7 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "unigiveaway.com",
     "accountviewer.stellar.org.za",
     "stellar.org.za",
     "uni-drop.org",


### PR DESCRIPTION
unigiveaway.com
Trust trading scam site
https://urlscan.io/result/69bd0555-b2c5-49b1-8934-8dc2077b46c7/
https://urlscan.io/result/808de97c-89e7-4508-b366-48bdc45bcc77/
address: 0x1a24d08e3e8682c2cd38159ec8006fa5b20c9f1e (eth)