### PR TITLE
unigiveaway.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -685,6 +685,8 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "unigiveaway.org",
+    "uniswapdex.com",
     "metamask.site",
     "trustwallet.in",
     "etherscan.member.event.monesrg.com",


### PR DESCRIPTION
unigiveaway.org
Trust trading scam site (promoted by twitter id: 3245494379)
https://urlscan.io/result/1bcead28-2b16-422c-b333-86c372bf7bca/
https://urlscan.io/result/64499f11-79e5-483e-bdf4-72a759baa06b/
address: 0xef67efc45ab3a26fcff76c7884603d212c39b75a (eth)

uniswapdex.com
Fake uniswap phishing for secrets with GET //uniswapdex.com:8889/api/tokenholding?accountAddress={address}}&key={key}&key_time={timestamp}
https://urlscan.io/result/51ccc2c1-576b-41b4-b047-7d6f0d32e3a7/

metamask.site
Fake MetaMask site phishing for secrets with POST /ajax/apps/formSubmitAjax.php
https://urlscan.io/result/ae6818da-b166-4a9a-be77-cb9b82b55557/

trustwallet.in
Fake TrustWallet site phishing for secrets with POST /ajax/apps/formSubmitAjax.php
https://urlscan.io/result/64f28d61-f131-4e68-9ada-be1f7978b4d6/