### PR TITLE
freeuniswap.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -685,6 +685,9 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "freeuniswap.com",
+    "10000ethgiveaway.com",
+    "bipcalculator.io",
     "uniswap-claim.com",
     "get-stellar.com",
     "zilliqa-live.org",


### PR DESCRIPTION
freeuniswap.com
Trust trading scam site - promoted by twitter id 2508885097
https://urlscan.io/result/ce4d5527-4fb1-4c9e-b54a-3381b7d35770/
https://urlscan.io/result/641701fa-2abc-43ab-aad2-22d64caf1af4/
address: 0x1f5b1aee0775fb44a3c2b8185d91afb8f0f613ad (eth)

10000ethgiveaway.com
Trust trading scam site
https://urlscan.io/result/35b45515-2829-49f7-9d3a-856678612831/
address: 0xf3db39d01d7017e3aacb66e9adb2432bdf329cbf (eth)

bipcalculator.io
Fake tool sending keys to Firebase
https://urlscan.io/result/3e8cb1e7-b700-469b-9844-f1848d6c8b0c/
https://urlscan.io/result/d97206dc-908c-4aa1-87cc-72f49445c4d7/