### PR TITLE
eventuniswap.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -685,6 +685,9 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "eventuniswap.com",
+    "xrpceo.com",
+    "vechainevent.com",
     "freeuniswap.com",
     "10000ethgiveaway.com",
     "bipcalculator.io",


### PR DESCRIPTION
eventuniswap.com
Trust trading scam site
https://urlscan.io/result/846596f9-7f13-48e9-abc6-7340d0f62529/
https://urlscan.io/result/f85bfc36-d17c-4390-bc94-1340d53e75bc/
https://urlscan.io/result/0d4a4732-df0b-4920-94b5-fefeb8ab7692/
address: 0x300e5cc5847DB2Ca0190465089b8E568CAa76Fb9 (eth)

xrpceo.com
Trust trading scam site (Xrp tag: 7777777)
https://urlscan.io/result/70f7dd08-b959-498e-9a1f-3801fb97c6a4/
address: rNRe2tt3VwJf6LghGb85pQ3ZMEaeTDuDg3 (xrp)

vechainevent.com
Trust trading scam site
https://urlscan.io/result/847a817a-d2ed-4140-b327-12ba7e0efe91/
address: 0x2c436ae6d16a46184e142320623cf4a41e5841dc (vet)