### PR TITLE
sushiback.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -685,6 +685,10 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "sushiback.com",
+    "ripple.supply",
+    "zillet.org",
+    "chico-ethers.com",
     "login-metamask.com",
     "eventuniswap.com",
     "xrpceo.com",


### PR DESCRIPTION
sushiback.com
Trust trading scam site (promoted by twitter id: 963007081)
https://urlscan.io/result/45010d12-939d-4833-9bdd-822187e2ffae/
https://urlscan.io/result/07611f37-eb8c-41f4-b96f-8df890ccc6b2/
address: 0x7337c3e5d030f14bad8b9bf405394bb7bf75f14a (eth)

login-metamask.com
Fake MetaMask site phishing for secrets with POST /ajax/apps/formSubmitAjax.php
https://urlscan.io/result/0625ef7b-1b6d-4e48-a89b-154c245e4abd/

ripple.supply
Trust trading scam site (Xrp tag: 7777777)
https://urlscan.io/result/b44a8cba-c179-4216-b476-915012258251/
address: r4BdWELq8VYg8esrbWEBXtiL3KodWSG9oD (xrp)

chico-ethers.com
Trust trading scam site
https://urlscan.io/result/df8dc103-385e-462d-a340-83dd3c7d7a0f/
address: 0xAA8f023923e2b2056296d176D78936B4F530F9ED (eth)

zillet.org
Fake Zilliqa wallet phishing for secrets with POST /privateKey.php
https://urlscan.io/result/bc52a8a3-ceb1-4a7e-a9aa-54674457c07e/

---

unigiveaway.net
Trust trading scam site
https://urlscan.io/result/896744ef-2344-4963-a9fa-ae90e3ceb289/
address: 0x9961fd00110a4a968ee9f1daeb8f4a87b61f29ce (eth)