### PR TITLE
stellar.org.ng

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -686,6 +686,7 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "stellar.org.ng",
     "sushiback.com",
     "ripple.supply",
     "zillet.org",


### PR DESCRIPTION
stellar.org.ng
Fake Stellar site phishing for keys with POST /post.php
https://urlscan.io/result/126d07ad-fa9b-48ec-8b4d-883bc7299b81/
https://urlscan.io/result/3628f89d-19d3-4970-8b48-387e61a8907a/