### PR TITLE
Whitelist Request for Ducatus Group Sites

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14,11 +14,14 @@
     "etherscan.io",
     "originprotocol.com",
     "makerdao.com",
-    "makerfoundation.com", 
+    "makerfoundation.com",
     "fulcrum.trade",
     "uniswap.org"
   ],
   "whitelist": [
+    "ducatus.com",
+    "staydmob.com",
+    "ducatuscoins.com",
     "flarum.org",
     "qiswap.com",
     "decrypto.finance",
@@ -936,7 +939,7 @@
     "altexchenge.com",
     "mycosmospay.com",
     "exoddus.net",
-    "uniswap.net", 
+    "uniswap.net",
     "uniswap.eu",
     "muskto.fun",
     "musktop.pw",
@@ -11757,7 +11760,7 @@
     "airdrop-bitnational.com",
     "wasabibitcoinwallet.org",
     "idex-claim.su",
-    "fulcrum.click", 
+    "fulcrum.click",
     "fulcrum.run"
   ]
 }


### PR DESCRIPTION
Adding ducatus.com and group sites-staydmob.com & ducatuscoins.com to whitelist. Currently ducatus.com is wrongly flagged as phishing site by metamask extension as **the name ducatus is similar to auctus.org**