### PR TITLE
dexairdrop-binance.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -686,6 +686,13 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "ripplebonus.net",
+    "dexairdrop-binance.com",
+    "btccham.info",
+    "geminixfund.info",
+    "geminidrop.fund",
+    "ripplegift.ceo",
+    "ada-give.info",
     "yearm.finance",
     "stellar.org.ng",
     "sushiback.com",


### PR DESCRIPTION
dexairdrop-binance.com
Trust trading scam site
https://urlscan.io/result/d794f4f8-dc1a-47c8-945c-bc1c5758c156/
https://urlscan.io/result/be847078-79e7-4d06-bcc3-771bee6327a2/

btccham.info
Trust trading scam site
https://urlscan.io/result/2ba27131-4998-4e85-a037-c799c7be4c3c/
address: 1Cham1hgP6wD4SqyzP1cYhPYLDQoAvMY2W (btc)

geminixfund.info
Trust trading scam site
https://urlscan.io/result/28ea8eae-90ac-482e-bc32-3d376a46d10b/
https://urlscan.io/result/1fcbe560-8bc3-4b53-b7a3-169b8c50e4f6/
https://urlscan.io/result/3ffb474a-5dfe-47f1-a8de-09ecdec28d66/
address: 0x3274d4D6B15EE6C953777BD967A368072D276E41 (eth)
address: 1EeZV9PhumJ5c7wGGCrE4T7KzW1jhyyFzZ (btc)

geminidrop.fund
Trust trading scam site
https://urlscan.io/result/cf37e48d-6a51-4715-8fd8-80f82e85b553/
https://urlscan.io/result/ce30c7c6-a3ac-44eb-a218-82506cbb0399/
https://urlscan.io/result/2f25637d-b65e-4f53-bd5c-726dc9605834/
address: 0xdaf0204d6A701Bce78De63D4FDc9F76695A01b1E (eth)
address: 34MP7oV2kPgbf2MTrJQfR6HyniqRteF4Kp (btc)

ripplegift.ceo
Trust trading scam site (xrp tag: 7777777)
https://urlscan.io/result/2037cd1d-f182-417e-9209-f2d73389c7e0/
address: rsJZK4463qyxkvPKEcu92zbWdYacPJ7fSk (xrp)

ada-give.info
Trust trading scam site
https://urlscan.io/result/21daf1ba-059f-4dc7-90ce-5b9a7b961075/
address: DdzFFzCqrhtD26CcpSKybxSLz2LHjmD1BaEuPgEmPfNeT3X6DwbzXvEG8yjJcMeau5Xb8Z3T67FcNe2A5XrGPBrn8Vjrp5pR89Gnq7tD (ada)