### PR TITLE
winnerscrypto.live + uni-fund.info

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -686,6 +686,8 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "winnerscrypto.live",
+    "uni-fund.info",
     "ripplebonus.net",
     "dexairdrop-binance.com",
     "btccham.info",


### PR DESCRIPTION
winnerscrypto.live
Trust trading scam site
https://urlscan.io/result/19abc9dc-2c73-4088-9162-3557bc7552ce/
https://urlscan.io/result/107982fe-31b0-422e-bdc4-b714de194188/
address: 0x886C18194BC6BC30086cB29D41082AA7574048dB (eth)

uni-fund.info
Trust trading scam site
https://urlscan.io/result/3c35301b-c026-4e5d-8834-b509cf052c6f/
address: 0x2d675e9Df1B5F36FDc5480718161cc1f041140Cd (eth)