### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -11773,5 +11773,6 @@
     "fulcrum.run",
     "curve.fm",
     "curve.frl"
+    "emiswap.com"
   ]
 }


### PR DESCRIPTION
Hello guys. Please input emiswap.com to the whitelist. It's official and not a phishing website page. The Metamask made a mistake and enter our website domain name to the blacklist (.