### PR TITLE
pdfescape.su + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -686,6 +686,17 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "get30bnb.live",
+    "pdfescape.su",
+    "uniswap.org.claim-tokens-airdrop.info",
+    "claim-tokens-airdrop.info",
+    "aavelend.com",
+    "aave-defi.com",
+    "app.trieaharderewa.com",
+    "bitcoinnow.bid",
+    "sushiswapclasslc.org",
+    "xn--bstchange-03a.net",
+    "bithau.com",
     "elongift.s3.eu-west-2.amazonaws.com",
     "bitnau.com",
     "unigiv.com",


### PR DESCRIPTION
pdfescape.su
Fake Trust wallet site phishing for secrets with POST /claimx.php (redirected from get30bnb.live)
https://urlscan.io/result/90202372-53e1-4a71-8b1c-c1267b08bf11/
https://urlscan.io/result/acd38230-a377-4db7-87b0-7bb02edfd2e9/
https://urlscan.io/result/acd38230-a377-4db7-87b0-7bb02edfd2e9/

uniswap.org.claim-tokens-airdrop.info
Fake MyEtherWallet phishing for secrets with POST /error.php?access-my-wallet
https://urlscan.io/result/01a723d6-1a5b-48ab-8629-7cbae029092e/
https://urlscan.io/result/bc059417-9c92-406f-89d7-4025abd54327/
https://urlscan.io/result/a1491ccf-e533-4d62-8dd2-f384c4fe3835/

aavelend.com
Fake Aave site
https://urlscan.io/result/4e9bde2f-a2ab-4736-9adc-8513fe9aa2b5/

aave-defi.com
Fake Aave site directing users to app.trieaharderewa.com
https://urlscan.io/result/2fda7466-3a27-4eef-96a9-9f76db798b9f/

bitcoinnow.bid
Trust trading scam site - fake btc generator
https://urlscan.io/result/4453a262-140f-4967-afbb-ae52d9b62889/
address: 1M5kNCeceBN2mUtSX7PDZ7tWE46M3ySwvA (btc)

sushiswapclasslc.org
Fake Sushiswap site phishing for secrets with POST /send_phrase_metaMask.php
https://urlscan.io/result/8ec53472-8fa5-4674-9b89-250016f06646/
https://urlscan.io/result/d18f87a7-e7f2-460f-8634-514df1b93d34/

bithau.com
Fake exchange scamming for deposits
https://urlscan.io/result/1efcccd4-f70a-4d6a-9b18-24de8e32f83e/