### PR TITLE
Block paradefi.network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -686,6 +686,7 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "paradefi.network",
     "get30bnb.live",
     "pdfescape.su",
     "uniswap.org.claim-tokens-airdrop.info",


### PR DESCRIPTION
Being promoted by fake MetaMask support telegram channels.