### PR TITLE
giveawaysushi.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -686,6 +686,10 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "giveawaysushi.com",
+    "login.blockhaln.com",
+    "blockhaln.com",
+    "wallets-tlx-blockchain.com",
     "paradefi.network",
     "get30bnb.live",
     "pdfescape.su",


### PR DESCRIPTION
giveawaysushi.com
Trust trading scam site - promoted by twitter id 1900436629
https://urlscan.io/result/a2684c04-153f-40d0-8537-4035060674d0/
https://urlscan.io/result/9fdd7a12-e5f6-47b7-9fbb-f639961923da/
address: 0x0b79daa40ec15bad56961689e9f3346f49d20602 (eth)

login.blockhaln.com
Fake Blockchain site phishing for logins - https://twitter.com/sniko_/status/1319319946246184963
https://urlscan.io/result/f856debe-1927-4d03-a5f9-b8885d703241/
https://urlscan.io/result/07247c58-a432-4bbc-8294-c7680c70408f/