### PR TITLE
buterin.s3.eu-west-2.amazonaws.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -686,6 +686,7 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "buterin.s3.eu-west-2.amazonaws.com",
     "giveawaysushi.com",
     "login.blockhaln.com",
     "blockhaln.com",


### PR DESCRIPTION
buterin.s3.eu-west-2.amazonaws.com
Trust trading scam site
https://urlscan.io/result/a833c6ec-0449-4a35-9700-edfc4f27bc8c/
https://urlscan.io/result/c8cfc2a9-e39d-46e0-893c-b9802f15f02c/
https://urlscan.io/result/c0434dbd-2f47-4e9d-9784-438c792d6d1d/
https://urlscan.io/result/f333a208-1c87-4e4a-97a0-2472a1835985/
address: 0xdb72d3cbe827afa4b223cd928e4f9bed7418444e (eth)