### PR TITLE
Add curve.si to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -11821,6 +11821,7 @@
     "curve.fyi",
     "xn--ledgr-9za.com",
     "ledgersupport.io",
-    "loldevs.com"
+    "loldevs.com",
+    "curve.si"
   ]
 }

--- a/src/hosts.txt
+++ b/src/hosts.txt
@@ -1061,3 +1061,4 @@
 0.0.0.0 curve.fm
 0.0.0.0 curve.frl
 0.0.0.0 curve.fyi
+0.0.0.0 curve.si


### PR DESCRIPTION
Curve.si is another phishing site which sends user's deposits to scammer's address