### PR TITLE
xn--ledgr-q51b.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -687,6 +687,11 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "ledger.com-client.email",
+    "xn--ledgr-q51b.com",
+    "keepkey.app",
+    "ethgiveaways.me",
+    "ethx2.io",
     "ledger.report",
     "xn--ldger-6za.com",
     "uniairdrop.org",


### PR DESCRIPTION
xn--ledgr-q51b.com
Fake Ledger site hosting malware executables of Ledger Live (sha256sum: 307d9f5e4b85d1209753a90220cb3cf6e590288af57d81fb6a282c5d1a6d68df)  - https://redd.it/jkue2s
https://urlscan.io/result/a2a94fdc-50a4-4205-96c3-c599c11d576b/
https://urlscan.io/result/6cb43ac8-df96-4965-84d3-50a98595728c/

keepkey.app
Fake KeepKey website phishing for secrets with POST /
https://urlscan.io/result/0339e7bf-32c8-4f86-be7b-87fe2d373fab/

ethgiveaways.me
Trust trading scam site
https://urlscan.io/result/5bc0ca30-e5fc-4306-a05e-1110e3c4cfb3/
https://urlscan.io/result/fd4b992a-87b1-4c79-a3d3-74e4844b5a93/
address: 0x0f3257e9513f4812bf015efc5022f16bfef0cfa8 (eth)

ethx2.io
Trust trading scam site
https://urlscan.io/result/ad8eec1e-c4f7-4178-9cd3-69004e34c180/
address: 0x906047a5b110144e12ad2aad35762a51f421492e (eth)