### PR TITLE
ledgerorigin.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -687,6 +687,8 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "live.ledgerorigin.com",
+    "ledgerorigin.com",
     "ledger.com-client.email",
     "xn--ledgr-q51b.com",
     "keepkey.app",


### PR DESCRIPTION
ledgerorigin.com
Fake Ledger site phishing for secrets with POST / - promoted by chrome extension mdddpanepdpjmhgadcmbcbdcbjcdejnd
https://urlscan.io/result/79231ed4-7f8f-4abb-964c-843fa81a6cf8/
https://urlscan.io/result/b26eb60f-6bae-4344-8498-d7e11b58f747/