### PR TITLE
uniswapofficial.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -689,6 +689,9 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "uniswapofficial.com",
+    "bitcoins-gift.blogspot.com",
+    "eth-gift.blogspot.com",
     "metamask.bonus-erc20-token.info",
     "dice2win.co",
     "bonus-erc20-token.info",


### PR DESCRIPTION
uniswapofficial.com
Fake Uniswap airdrop phishing for secrets with POST /sign.php
https://urlscan.io/result/05a28e00-cc1a-4206-8dea-daa1355ba89a/
https://urlscan.io/result/8f798d80-9be7-4d31-b593-6f9f62546b08/
https://urlscan.io/result/285dfacc-3434-40cb-81c1-2320c9e5a3a3/

bitcoins-gift.blogspot.com
Trust trading scam site
https://urlscan.io/result/d959ddeb-4593-42fb-8a5f-eba6076a076e/
address: 1Pt1AJSrVba6NuprSkKWcUMzs1MfgfsPJP (btc)

eth-gift.blogspot.com
Trust trading scam site
https://urlscan.io/result/82e76759-d737-4c2e-9d9e-be6260741c3f/
address: 0x3c39c2FD79B55827793B0Fa3023980297F796d80 (eth)