### PR TITLE
airdropocean.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -689,6 +689,7 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "airdropocean.com",
     "ocean-airdrop.com",
     "bestcheinge.com",
     "lbestchenge.com",


### PR DESCRIPTION
airdropocean.com
Fake ocean airdrop phishing for secrets with POST /sign.php - promoted by twitter id 2296354727
https://urlscan.io/result/a15446e8-efdf-49c8-9041-28cbce7bf17c/
https://urlscan.io/result/99247208-0765-4778-954b-ef2ce0b18192/
https://urlscan.io/result/e85110f2-6b6f-479a-b0c0-4f33221e4079/