### PR TITLE
Allow fulcrum.wiki

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -20,6 +20,7 @@
     "ledger.com"
   ],
   "whitelist": [
+    "fulcrum.wiki",
     "aptus.hr",
     "edge.network",
     "actius.mx",


### PR DESCRIPTION
Fixes #4286

We may need to revisit what sites we're willing to maintain on our "fuzzylist", since each entry comes with the burden of monitoring false-positives.