### PR TITLE
musk-coins.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -703,6 +703,11 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "musk-coins.com",
+    "muskprize.fun",
+    "getmusk.fun",
+    "spacexlive.top",
+    "elonbtcx.com",
     "chain-ledger.info",
     "ledger-chain.live",
     "xn--ledgr-251b.com",


### PR DESCRIPTION
musk-coins.com
Trust trading scam site
https://urlscan.io/result/fc77de0b-497c-43a3-ae6a-baea9e3edc58/
https://urlscan.io/result/21995a82-2654-4f5b-a555-d7ca8cf89b4d/
https://urlscan.io/result/700e4262-6c53-4d97-b0da-bb8eb04e87ac/
address: 17QHRv8nwvHFRLxMmrHN4bkku1x9iFveq7 (btc)
address: 0x99F3D11527C4ca9Dd4E7E2320Ccec21c08abAec5 (eth)

muskprize.fun
Trust trading scam site
https://urlscan.io/result/ca6295b6-e38b-4b7b-a007-0986ee5e5fa1/
https://urlscan.io/result/ca6295b6-e38b-4b7b-a007-0986ee5e5fa1/
address: 0xde9A8E63E74a13C4b19ab736d9296fB1C14919a2 (eth)
address: 1FEvSo3JrsRZ4fLyftNrmdgZ9EiKcahMWJ (btc)

getmusk.fun
Trust trading scam site
https://urlscan.io/result/10db2851-9607-404e-8423-feb54a836518/
https://urlscan.io/result/20dd0c07-f6a0-4f09-9e69-8bf8c7b40dc3/
address: 0xde9A8E63E74a13C4b19ab736d9296fB1C14919a2 (eth)
address: 1FEvSo3JrsRZ4fLyftNrmdgZ9EiKcahMWJ (btc)

spacexlive.top
Trust trading scam site
https://urlscan.io/result/005cafe1-3d6c-41b6-a7d2-d6dcc2a32326/
address: 19TRvAmAnJgvAAPTJCwX1we9WborRobzfG (btc)

elonbtcx.com
Trust trading scam site
https://urlscan.io/result/5dfb4516-0365-4b3d-816f-201132152dbb/
address: 1LECt1tmoZeKVN1KuERjoT6o5hgck8M2J1 (btc)