### PR TITLE
eth67.blogspot.com + airdrop-ocean.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -703,6 +703,8 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "eth67.blogspot.com",
+    "airdrop-ocean.com",
     "musk-coins.com",
     "muskprize.fun",
     "getmusk.fun",


### PR DESCRIPTION
eth67.blogspot.com
Trust trading scam site
https://urlscan.io/result/3cc5c14a-73fa-40fa-93da-3f17a261751a/
address: 0xBc8E9A20DAa70D2FFC43a0133A49B0F736CA505c (eth)

airdrop-ocean.com
Fake Ocean airdrop phishing for secrets with POST /sign.php - promoted by twitter id 2296354727
https://urlscan.io/result/e0f98af4-e008-4728-b1af-48f087c21044/
https://urlscan.io/result/7b68b4ba-f97c-486e-925e-e2c9d4a0b244/
https://urlscan.io/result/2e1df9c0-c793-4c21-8cf9-1c7415686789/