### PR TITLE
oceanairdrop.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -704,6 +704,10 @@
     "oneswap.net"
   ],
   "blacklist": [
+    "oceanairdrop.info",
+    "eth-generator.com",
+    "tether-tumbler.com",
+    "uni-promo.net",
     "stellar-info.org",
     "stake-ethereum.org",
     "eth67.blogspot.com",


### PR DESCRIPTION
oceanairdrop.info
Fake Ocean airdrop phishing for secrets with POST /sign.php - promoted by twitter id 2296354727
https://urlscan.io/result/503e459b-7fed-4b8d-9739-2bb1f2cb604b/
https://urlscan.io/result/eb0a9a2d-bb6c-4156-9449-1e96251e78c2/
https://urlscan.io/result/d0ea0249-cf6b-4b17-ab1b-b7033ddd81b6/

eth-generator.com
Trust trading scam site
https://urlscan.io/result/5d0e0adf-7e0f-44b4-9f10-24622edb795d/
address: 0x3cd6ef508c1c448e293075f1de2ae96a49e18895 (eth)

tether-tumbler.com
Fake mixer scamming funds
https://urlscan.io/result/6366e9be-3876-4641-abee-aaac2b3714bb/
https://urlscan.io/result/8d36f06b-7f3e-4abb-bebd-89ac5f003b24/
https://urlscan.io/result/99805ddc-dedf-4f21-8c69-9825bd6801e4/
address: 0xDA314D80D6440254bAfdf555d917193f769D46BD (eth)

uni-promo.net
Trust trading scam site
https://urlscan.io/result/9038f974-0f7c-40cf-b8f9-a4d923e0b2bc/
address: 0x953a16aA90ff214a8572447293E6a06A057211AB (eth)