### PR TITLE
airdrop-uniswap.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -705,6 +705,7 @@
     "hedget.com"
   ],
   "blacklist": [
+    "airdrop-uniswap.com",
     "oceanairdrop.info",
     "eth-generator.com",
     "tether-tumbler.com",


### PR DESCRIPTION
airdrop-uniswap.com
Fake Uniswap airdrop phishing for secrets with POST /sign.php - promoted by twitter id 1679558912
https://urlscan.io/result/bb6eab69-1f31-4751-9531-e01c39e4093b/
https://urlscan.io/result/a47b4d3c-8410-44b4-9c88-b89360735833/
https://urlscan.io/result/da6e060b-cc20-4f39-8be2-db4b309dfc5d/