### PR TITLE
Removing Ledger from Fuzzylist (for now)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -17,7 +17,6 @@
     "makerfoundation.com",
     "fulcrum.trade",
     "uniswap.org",
-    "ledger.com",
     "launchpad.ethereum.org"
   ],
   "whitelist": [


### PR DESCRIPTION
Unfortunately, Ledger is far too similar to far too many other words. We do not currently have the support required to keep up with all of the false positives caused by including ledger on the fuzzylist.

MetaMask will be reducing its tolerance to "2" soon, and we'll also be getting much more bandwidth dedicated to managing this site, but until then it is unfair to leave so much of the unbeknownst web blocked. We'll just need to be responsive about explicit blocks related to ledger phishing attacks. MetaMask plans to have more staff helping curate this list next week, and may be ready to re-add it then.

@409H @btchip