### PR TITLE
dropmusk.in

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -708,6 +708,7 @@
     "ladder.to"
   ],
   "blacklist": [
+    "dropmusk.in",
     "chrome-extension.link",
     "money-tesla.com",
     "airdrop-uniswap.com",


### PR DESCRIPTION
dropmusk.in
Trust trading scam site
https://urlscan.io/result/7100265a-c415-416a-8be2-2de8e4babf04/
https://urlscan.io/result/92cf72bd-1b5b-4649-b5f3-7df7bf4d4488/
https://urlscan.io/result/4e411b18-859a-423e-8289-c3648174fa2e/
address: 14wgjXQxXu34pycusw155yAqTxaSGs6i91 (btc)
address: 0x2B227C59510bAffc02A844d0f95baA33B9C640fc (eth)