### PR TITLE
Remove uniswap from fuzzylist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -16,7 +16,6 @@
     "makerdao.com",
     "makerfoundation.com",
     "fulcrum.trade",
-    "uniswap.org",
     "launchpad.ethereum.org"
   ],
   "whitelist": [


### PR DESCRIPTION
We are currently having trouble keeping up with the whitelist requests for some names that are very popular and generic around the web. In particular, the two parts of uniswap: "uni" and "swap" are hard to fuzzylist for different reasons: "Uni" is so short that any levenshtein distance is small, and "swap" is so common in crypto that fuzzylisting it effectively squats a very popular word on behalf of uniswap.

We hope to improve our fuzzylisting so that we catch fewer false positives, but until we catch up with our false-positive backlog, we need to fuzzy-list fewer domains.