### PR TITLE
yearnyfi.blogspot.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -707,6 +707,12 @@
     "ladder.to"
   ],
   "blacklist": [
+    "yearn-finance-gift.medium.com",
+    "yearnyfi.blogspot.com",
+    "claimocean.com",
+    "maticwallet.network",
+    "2eth.site",
+    "yflinkreward.com",
     "polkadot-airdrop.info",
     "eth-but.top",
     "ethbuterin.top",


### PR DESCRIPTION
yearnyfi.blogspot.com
Trust trading scam site - directed from yearn-finance-gift.medium.com/yearn-finance-announces-1000-yfi-gift-bfac6331b107
https://urlscan.io/result/1198fe9f-da5e-41a5-b2ed-432ff43cf86d/
address: 0x3da35833d1968b12b17488277CE85A0eA1518813 (eth)

claimocean.com
Fake Ocean airdrop phishing for secrets with POST /sign.php - promoted by twitter id 2296354727
https://urlscan.io/result/70b456e3-bfe0-4bdf-8ee5-dd17e20fdb5c/
https://urlscan.io/result/0f259bd7-6a7a-41eb-8f4e-deb3a76c9037/
https://urlscan.io/result/f2aa8f66-24fd-41f5-8af6-1b634bf42951/

maticwallet.network
Fake Metamask wallet phishing for secrets with POST /phpconnect.php
https://urlscan.io/result/a45994de-ad1e-43bb-b66b-6410bb6f7b36/
https://urlscan.io/result/900c6c5d-fde3-46a4-bcbf-732b195d36a9/

2eth.site
Trust trading scam site
https://urlscan.io/result/7cd5faf6-1f46-4a89-b5b8-459cd37e5434/
https://urlscan.io/result/432b6801-232c-4696-a522-ffd99439ca6b/
https://urlscan.io/result/42815675-7466-4d54-99c8-1cb85e19a4cc/
address: 1MpBhH3BkSNFr88A9PNihabxWG6YpHJwHa (btc)
address: 0x26196A80a8A37bdD4ec2E246EB600aA2B7f8289E (eth)

yflinkreward.com
Trust trading scam site
https://urlscan.io/result/ae4d4e9f-2410-4b78-8f7f-fdfd65bf0036/
address: 0xda9C6C6BA4973D99071cEF9D1CE1006cB3545846 (eth)