### PR TITLE
crypto-gives.s3.us-east-2.amazonaws.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -707,6 +707,10 @@
     "ladder.to"
   ],
   "blacklist": [
+    "crypto-gives.s3.us-east-2.amazonaws.com",
+    "onkbit.com",
+    "ripple.com.pt",
+    "coinbase-payments.blogspot.com",
     "plckle.finance",
     "picklee.finance",
     "tokenpocket-pro.web.app",


### PR DESCRIPTION
crypto-gives.s3.us-east-2.amazonaws.com
Trust trading scam site
https://urlscan.io/result/874f4747-eca0-45fd-838f-b4b87f51a603/
https://urlscan.io/result/dbaa30ce-411c-4db5-9611-a07366a76741/
https://urlscan.io/result/efae57af-79a4-4cd8-84da-54479f49d18c/
address: 18YCvzAakqKXWed2fEaHgsi5sSjBqJpca4 (btc)
address: 0x3c39c2FD79B55827793B0Fa3023980297F796d80 (eth)

onkbit.com
Scam exchange phishing for deposits
https://urlscan.io/result/8db00d6f-5c2d-4536-b4fc-0765d2ddd612/

coinbase-payments.blogspot.com
Trust trading scam site
https://urlscan.io/result/c5863628-3184-45f5-b9d8-461ba784c651/
address: 178B5aQcLnVmer3Hq52HzE1eGPU35QK4jr (btc)