### PR TITLE
yfiairdrop.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,8 +714,6 @@
     "eth66.blogspot.com",
     "bitfuryltd.com",
     "bitfurygroupltd.com",
-    "stellar.org.ma",
-    "accountviewer.stellar.org.ma",
     "ethpos.org",
     "geminigift.org",
     "bitcoin-revolution.2020-order.monster",

--- a/src/config.json
+++ b/src/config.json
@@ -708,6 +708,15 @@
     "ladder.to"
   ],
   "blacklist": [
+    "ledgerweb.digital",
+    "litecoingiveaway-live.com",
+    "yfiairdrop.com",
+    "eth66.blogspot.com",
+    "bitfuryltd.com",
+    "bitfurygroupltd.com",
+    "stellar.org.ma",
+    "accountviewer.stellar.org.ma",
+    "ethpos.org",
     "geminigift.org",
     "bitcoin-revolution.2020-order.monster",
     "bitcoin-revolution.inestovo2020.xyz",


### PR DESCRIPTION
yfiairdrop.com
Fake YFI airdrop phishing for secrets with POST /sign.php - promoted by twitter id 1900436629
https://urlscan.io/result/0c10066c-d032-4867-9f6c-575e236fcd8f/
https://urlscan.io/result/cee4f2dd-d692-40dd-b8df-b3a5aa972401/
https://urlscan.io/result/33ee5777-4892-4922-b8cb-0313000890a0/

eth66.blogspot.com
Trust trading scam site
https://urlscan.io/result/d789a52c-eaa7-4f2f-8e43-1c947956bbec/
address: 0x49202aa9D52c0f4352d31d731eB50822f9D8525b (eth)

accountviewer.stellar.org.ma
Fake Stellar site phishing for secrets
https://urlscan.io/result/61d0ead2-bf38-4b65-a1da-f78148e9a847/

ethpos.org
Malicious Ethereum 2 PoS staking platform
https://urlscan.io/result/f145a5ab-b744-48f5-bdaf-1552e672ecaa/
address: 0x36d52e59a2f498db8f45838fe468c0424bc3c3d0 (eth)