### PR TITLE
takebtc.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -708,6 +708,13 @@
     "ladder.to"
   ],
   "blacklist": [
+    "takebtc.net",
+    "bitcoin-revolution2.cashvolume.monster",
+    "btc-gemini.live",
+    "paypal-btc.com",
+    "claim-airdrop-uniswap-v2.info",
+    "app.uniswap.claim-airdrop-uniswap-v2.info",
+    "login-blocklnain.top",
     "uniswaps.app",
     "metamaskwallet.online",
     "makerdao-info.com",


### PR DESCRIPTION
takebtc.net
Trust trading scam site
https://urlscan.io/result/37faf8b6-8946-4f6f-9aeb-19b14fa9ef39/
https://urlscan.io/result/f61ce2f9-e410-4bee-b15c-05513d92a7e9/
https://urlscan.io/result/da04c948-5042-41ee-9e3a-0e3266ddb72b/
address: 0x09552613455a76d5818ba0f2a7eb6b40cec067fe (eth)
address: 3EqxxxS6vPjFavutvSu18duPUWecW5N1Yz (btc)

btc-gemini.live
Trust trading scam site
https://urlscan.io/result/b30303d0-f2a5-4730-8d3f-cd72332fce30/
address: 1PTdn1dQVgg6pve4pBQzWqe8zn7HqWKtrK (btc)

paypal-btc.com
Trust trading scam site
https://urlscan.io/result/2e195e46-9dd1-49bb-8ec4-4ea071945d1d/
address: 1PayPaL86RnzarEsWAZqENKVi1g8bBmNig (btc)

bitcoin-revolution2.cashvolume.monster
Fake investment platform
https://urlscan.io/result/7c624c5a-73a9-4a45-8e4d-fb261aefed5f/

uniswaps.app
Fake uniswap hosting malware
https://urlscan.io/result/c31ef803-a7d0-4411-8d37-dbb1179548d9/
https://urlscan.io/result/69b6dd22-f386-4470-bd49-686a97337901/

app.uniswap.claim-airdrop-uniswap-v2.info
Fake uniswap phishing for secrets with POST /claim.php
https://urlscan.io/result/cbdfbd0d-ee29-4693-993d-4894c7401554/
https://urlscan.io/result/e2e14110-cf93-45da-a040-f644c0831046/
https://urlscan.io/result/edfe6c0a-1c51-4186-9941-8c4a0db9b14d/