### PR TITLE
Add fake aave site to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -708,6 +708,7 @@
     "ladder.to"
   ],
   "blacklist": [
+    "aaveapp.com",
     "installmeta.com",
     "maskmeha.io",
     "chainlink.click",


### PR DESCRIPTION
Similar to uniswap seen a few days ago

![image](https://user-images.githubusercontent.com/528959/100486297-f92fe900-310b-11eb-9561-916e157db103.png)
