### PR TITLE
installmeta.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -708,6 +708,9 @@
     "ladder.to"
   ],
   "blacklist": [
+    "ripple-xrp.live",
+    "dropbinance.exchange",
+    "bithomp.work",
     "ripplebonus.us",
     "litecoin-event.net",
     "btcminerapp.com",


### PR DESCRIPTION
installmeta.com
Fake MetaMask site phishing for secrets with POST /check.php
https://urlscan.io/result/09482e68-6c99-4cba-bd09-b0d63cc2bb20/
https://urlscan.io/result/09cb45a1-e611-4bff-9473-a43c4ea86e08/

ripple-xrp.live
Trust trading scam site
https://urlscan.io/result/966fe96c-6ec8-49cd-80e4-02fd3b7c6b09/
address: r4uknNUEi5WSPGtgzGbLJY1tDmWbMsb9DE (xrp)

dropbinance.exchange
Trust trading scam site
https://urlscan.io/result/34fece40-9e0d-4d46-a2aa-4ef3bf5e2fa7/
https://urlscan.io/result/b20c14c5-d29e-4fd6-a335-0ad95c1512b4/
https://urlscan.io/result/308a44e2-0f83-4ea1-9609-961070a2a482/
https://urlscan.io/result/767f3436-3d7a-45cc-b9e3-cf08dd9b2dcc/
address: bc1qxegrjz4hq38acqrqt4f02staecdx8gpdan7da2 (btc)
address: 0x6710d545500350470244a7C7A722491Cc6540C81 (eth)
address: 0x6710d545500350470244a7C7A722491Cc6540C81 (eth)

bithomp.work
Trust trading scam site
https://urlscan.io/result/8cef3b93-9403-40d3-98f4-c6a91f1e9e50/
address: rE4QWibTgheDaKZurfGi3ybsfXk4ohFByS (xrp)