### PR TITLE
charles-hoskinson.live + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -708,6 +708,9 @@
     "ladder.to"
   ],
   "blacklist": [
+    "charles-hoskinson.live",
+    "uniswapdrop.finance",
+    "uniswap-airdrop.io",
     "88mph.app.defi-universe.vip",
     "axieinfinity.com.aave.defi-universe.vip",
     "aaveapp.com",


### PR DESCRIPTION
charles-hoskinson.live
Trust trading scam site
https://urlscan.io/result/8e058b53-d025-48db-81a5-02ea7ef376df/
address: addr1qxmzd3np2kpyg6nxrjeeht4w6638xkg3azkas0xnurxzrtthn8xfcjphkne7ytdg2elppeawx8jcx2jcjj7n5xdnq7kszv8ud0 (ada)

uniswapdrop.finance
Trust trading scam site
https://urlscan.io/result/f77ee067-c0a4-4447-8e25-bed3466d6f55/
address: 0x80e8374A89c514340a7886dEFabFc338dff34d86 (eth)

uniswap-airdrop.io
Fake uniswap airdrop phishing for secrets with POST /claim.php
https://urlscan.io/result/121a49b4-62dc-4c30-b706-601d34c89235/
https://urlscan.io/result/8b8bc97e-e859-40c5-b5b1-ed4882e92fac/
https://urlscan.io/result/3e59d273-c77e-433a-85f6-97a9e0471bf7/