### PR TITLE
ripple-labs.dev + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -708,6 +708,12 @@
     "ladder.to"
   ],
   "blacklist": [
+    "ripple-labs.dev",
+    "winklevoss-gemini.com",
+    "xrp2021.net",
+    "ethuniswap.com",
+    "sushiswapcoin.com",
+    "ledgerlive.io",
     "ripple2021.com",
     "register-ripple.com",
     "stellarwallet.org",


### PR DESCRIPTION
ripple-labs.dev
Trust trading scam site (Xrp tag: 777777)
https://urlscan.io/result/c56e1b64-3fdf-4073-a71c-fbcce4c73c25/
address: r9DSbW8NXn1cYCXEQEpeDCxNos1Wr3fbUT (xrp)

xrp2021.net
Trust trading scam site (Xrp tag: 777777)
https://urlscan.io/result/082a9a67-e5cc-4823-8be5-822258720da5/
address: rfu822JSH4zVRJJmGeUZQbMZcJeTTDXNK4 (xrp)

ethuniswap.com
Fake Uniswap airdrop phishing for secrets with POST /sign.php (promoted by twitter id: 963007081)
https://urlscan.io/result/71fc8fa8-bef4-40c1-aa58-1c1bf8398aaf/
https://urlscan.io/result/cd39094f-c0e6-44c5-8bbc-c197cb5f1b1f/
https://urlscan.io/result/6f81b140-3a67-458a-b685-5c5ce85997f9/

sushiswapcoin.com
Fake Sushi airdrop phishing for secrets with POST /sign.php (promoted by twitter id: 1900436629)
https://urlscan.io/result/aad80815-127e-4648-a3a6-65818d91857a/
https://urlscan.io/result/adb04475-7385-4586-92f6-c10b6ff95092/
https://urlscan.io/result/78700804-c396-4d07-afad-f1be4168951b/

ledgerlive.io
Fake Ledger live applications (sha256sum 75aeace5a0602c78047f26884f71209beb4336fc3a2cb18f8d140afd605e43bb)
https://urlscan.io/result/5ec62d10-f7b9-4a1a-818a-747d8bf85759/
https://urlscan.io/result/4ddcc1af-a5b6-4d7f-921c-e3a88cb5dc5a/

---

installmetamask.com
Fake MetaMask site phishing for secrets
https://urlscan.io/result/0a630b6e-b8a3-4fcd-886d-11477b53cc0b/
https://urlscan.io/result/cdf4e668-a43d-4db7-b61e-89cf83ec3ffe/