### PR TITLE
Block metamask.online

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -685,6 +685,7 @@
   ],
   "blacklist": [
     "muskx.online",
+    "metamask.online",
     "mark-direct.com",
     "trust-myfood.com",
     "enjin-books.com",


### PR DESCRIPTION
Obvious phish, probably caught by fuzzylist but still blocking for safety.