### PR TITLE
binance2021.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,9 @@
     "ladder.to"
   ],
   "blacklist": [
+    "binance2021.com",
+    "s1-ripple.com",
+    "ripple.com.so",
     "muskx.online",
     "metamask.online",
     "mark-direct.com",


### PR DESCRIPTION
binance2021.com
Trust trading scam site
https://urlscan.io/result/04253617-3753-47a0-adb8-0af80702461a/
https://urlscan.io/result/7875c39b-2603-4df6-a0d4-13d2cb2342eb/
https://urlscan.io/result/8a224b66-f278-47a9-9521-c4f202fe3719/
address: 18v6DhnLZQ132Z1fEVW4TyNhtkmieM2qsq (btc)
address: 0xb16742b92f8236a4b92d31b39ea041d9f4336d5f (eth)

ripple.com.so
Fake Ripple site phishing for secrets
https://urlscan.io/result/a80fc7d3-90c2-444a-b3a7-502e25948748/
https://urlscan.io/result/78eaac69-65bb-40a8-a3de-5c6ebc49dd0f/