### PR TITLE
slolzfr.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -684,6 +684,9 @@
     "ladder.to"
   ],
   "blacklist": [
+    "slolzfr.com",
+    "xrp.limited",
+    "ripple.promo",
     "bittque.com",
     "letmecrypto.com",
     "xn--lectrum-s8a.org",


### PR DESCRIPTION
slolzfr.com
Fake Uniswap phishing for secrets with POST /uniswap/submit.php (apk namespace com.labose.trabolle)
https://urlscan.io/result/02197ec8-0b7a-4bff-b838-1af27f497b74/

xrp.limited
Trust trading scam site (Xrp tag: 7777777)
https://urlscan.io/result/3580ea3f-cd86-4f68-8252-1459dff75a02/
address: rMGaqB9cz6E9ZcaWptx25kVX4niFUtFGn2 (xrp)

ripple.promo
Trust trading scam site
https://urlscan.io/result/53428ec1-a6bb-4bf2-95ab-978f5cd994ef/
address: rKjov4pGUFz3Ez7f8yUckhQWiUKfpmN2tZ (xrp)