### PR TITLE
adding maskmeta.org to fuzzylist - due to phishers

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -3,6 +3,7 @@
   "tolerance": 2,
   "fuzzylist": [
     "metamask.io",
+    "maskmeta.org",
     "myetherwallet.com",
     "cryptokitties.co",
     "mycrypto.com",


### PR DESCRIPTION
many maskmeta.x domains used for phishing atm