### PR TITLE
Block `1inch.app`

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -685,6 +685,7 @@
     "ladder.to"
   ],
   "blacklist": [
+    "1inch.app",
     "maskmeta.me",
     "maskmeta.org",
     "metamaskwallet.net",


### PR DESCRIPTION
This is a fake version of `1inch.exchange`. We got reports that they were stealing funds from users