### PR TITLE
uniswapsite.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -699,6 +699,7 @@
     "ladder.to"
   ],
   "blacklist": [
+    "uniswapsite.com",
     "metamask-online-io.com",
     "maskmetaa.io",
     "mooniswap.app",


### PR DESCRIPTION
uniswapsite.com
Fake Uniswap site phishing for secrets with POST /sign.php - promoted by twitter id 1900436629
https://urlscan.io/result/cd0a8b82-4469-4d2b-b207-f7cf66b24cbb/
https://urlscan.io/result/fb43c4ae-963b-44b7-b84b-c0683db29c53/
https://urlscan.io/result/146afcac-5618-47a4-993e-f6d45501d31c/