### PR TITLE
uniswapupdate.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -699,6 +699,10 @@
     "ladder.to"
   ],
   "blacklist": [
+    "uniswapupdate.com",
+    "live-tesla.com",
+    "elon.fund",
+    "ledger-chain.co.uk",
     "1inch.dev",
     "uniswapsite.com",
     "metamask-online-io.com",


### PR DESCRIPTION
uniswapupdate.com
Fake uniswap site phishing for secrets with POST /sign.php
https://urlscan.io/result/8c8244a8-bd29-4da0-9f95-4e6601a599d5/
https://urlscan.io/result/96c4a798-d1b1-4e20-86fc-b56a26dd3f98/
https://urlscan.io/result/ec69afbb-f883-4cdb-afcc-4d618627837c/

live-tesla.com
Trust trading scam site
https://urlscan.io/result/32f0a7e4-6ef4-4994-acfa-e0c0b5a131d7/
https://urlscan.io/result/a1691d85-b6e9-46df-a0fc-83c242b0eb16/
address: 188GXACkWA9MEiXA1df4rHynn992iV93TE (btc)
address: 0x31efcbf8ae69dcbe6770b1ce7f0c61c216aa2236 (eth)

elon.fund
Trust trading scam site
https://urlscan.io/result/c42e7694-94a2-4a9c-a14e-90303beadc6a/
https://urlscan.io/result/5ed1aa87-d547-4e0b-9bff-04c74d134486/
https://urlscan.io/result/ade8ee48-2b01-455c-b0bc-581044a88f40/
address: 1MusKazBTGrxfAXKSeVM9kBKmFdBPUkQ5V (btc)
address: 0xE30a737e9a711D24bDEb0afF7e1f87A1c0E53636 (eth)