### PR TITLE
ethgive.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -699,7 +699,6 @@
     "ladder.to"
   ],
   "blacklist": [
-    "ledger.com.verification-login.app",
     "ethgive.org",
     "elongive.us",
     "uniiswaap.org",

--- a/src/config.json
+++ b/src/config.json
@@ -699,6 +699,12 @@
     "ladder.to"
   ],
   "blacklist": [
+    "ledger.com.verification-login.app",
+    "ethgive.org",
+    "elongive.us",
+    "uniiswaap.org",
+    "cardano2021.us",
+    "newledgerweb.com",
     "uniswapupdate.com",
     "live-tesla.com",
     "elon.fund",


### PR DESCRIPTION
ethgive.org
Trust trading scam site
https://urlscan.io/result/5c0fd298-522c-4a73-a5cd-07a03bb23c11/
https://urlscan.io/result/c29ce456-40ed-47b8-8de2-1107457e518e/
https://urlscan.io/result/c720b868-051f-48ab-bf81-93dbf58f0b04/
address: 0x7C0f8FfdCe15f94e3bC7F3fA4c22a5d0Ee08ae2B (eth)
address: 18i35LKaxwr5br5MtocbiTVYcd6rusUHiv (btc)

elongive.us
Trust trading scam site (Xrp tag: 7777777)
https://urlscan.io/result/ef13dc84-ef77-42a2-ac9b-37b16c4dba84/
https://urlscan.io/result/1146a546-76c0-4b29-93df-c3457ce75ccf/
https://urlscan.io/result/d50f51ba-3e6c-4f36-9c83-0050994462cf/
https://urlscan.io/result/040cf58c-e613-4ba8-b631-7c47b573d0e2/
address: 0xBD2d1cc9627f1d791B184600CA950328644C8eb2 (eth)
address: 1g2cRrGqCX1LCEmtqsQy3YhkSTfTwkmD9 (btc)
address: rE7Gc1GqVG6oLbWkA7vYyySJTxS5gzRxJC (xrp)

uniiswaap.org
Fake uniswap site phishing with POST 
https://urlscan.io/result/bcd5ba6d-43e8-469c-8b84-bf9a10790d49/
https://urlscan.io/result/f318f741-33ac-46cf-8bfe-c778e3ff29c8/

cardano2021.us
Trust trading scam site
https://urlscan.io/result/3b7a2f5b-418c-4bf8-bf9f-e1d1cc1799ff/
address: addr1qyzm8sdsu2u7kj4fnf0egu0ysp4qjr8p27503zy6pggc8m66tfuxswf8qun4d6d8gzlgsll22fe5gs2swxuhfunq9xyscqggxr (ada)

newledgerweb.com
Fake Ledger site hosting malware
https://urlscan.io/result/68a1e95f-b46a-4af4-b697-8d195f097fc1/
https://urlscan.io/result/4e95915d-a5fa-47f8-bb83-38e80a55306c/