### PR TITLE
Add nexusmutual.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12239,6 +12239,7 @@
     "ledger.com-login-activity.app",
     "xn--lder-cxa8656b.com",
     "ledger.com1628.support",
-    "ledger.com17266548295643.info"
+    "ledger.com17266548295643.info",
+    "nexusmutual.org"
   ]
 }


### PR DESCRIPTION
dot org domain impersonating nexusmutual.io and spreading malware