### PR TITLE
uniswap-crypto.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -699,6 +699,10 @@
     "ladder.to"
   ],
   "blacklist": [
+    "uniswap-crypto.com",
+    "uniswap-defi.com",
+    "uniswapairdrop.org",
+    "updateuniswap.com",
     "muskdrop.life",
     "bitcoinfocus.xyz",
     "epaymentbtc.tumblr.com",


### PR DESCRIPTION
uniswap-crypto.com
Fake Uniswap airdrop phishing for secrets with POST /sign.php - promoted by twitter id: 1227974606448885760
https://urlscan.io/result/4586c2ec-84d5-43a8-add2-ba5b87e1586d/
https://urlscan.io/result/ade45080-b1b7-4000-89d6-4814d53125c7/
https://urlscan.io/result/ce01c049-ce64-4a60-ab08-044513474107/

uniswap-defi.com
Fake uniswap airdrop phishing for secrets with POST /sign.php - promoted by twitter id: 1227974606448885760
https://urlscan.io/result/2cd64e52-cc36-4331-aefd-5cfb247e9248/
https://urlscan.io/result/0baa1f11-9937-4e9a-892f-5f46db5975a7/
https://urlscan.io/result/624cdb5d-da4b-4e70-8406-8677ea0ca042/

uniswapairdrop.org
Fake uniswap airdrop phishing for secrets with POST /sign.php - promoted by twitter id: 1587773215
https://urlscan.io/result/a7582ff0-f77d-4632-a3cb-e40440166eb5/
https://urlscan.io/result/95d892c8-909c-4614-9909-9d3422451a2b/
https://urlscan.io/result/d41d5dcc-5bcd-471e-9012-d36dd10dceaf/