### PR TITLE
elon-found.tumblr.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -699,6 +699,11 @@
     "ladder.to"
   ],
   "blacklist": [
+    "elon-found.tumblr.com",
+    "coix.ga",
+    "paytopayethx.tumblr.com",
+    "paytopaybtcx.tumblr.com",
+    "bancora.network",
     "uniswap-crypto.com",
     "uniswap-defi.com",
     "uniswapairdrop.org",


### PR DESCRIPTION
elon-found.tumblr.com
Trust trading scam site
https://urlscan.io/result/bfaac0c5-07f0-4de4-b2c4-983eb7f05992/
address: 0x18531881be3dbda5894077ab0cf6db4d039970b0 (eth)
address: 39Gof9kcr51Hw44MTu65KERjYhYp199ji9 (btc)

paytopayethx.tumblr.com
Trust trading scam site
https://urlscan.io/result/5fe3c6fc-ef18-4efe-8fcd-ead32931e256/
address: 0x18531881be3dbda5894077ab0cf6db4d039970b0 (eth)

paytopaybtcx.tumblr.com
Trust trading scam site
https://urlscan.io/result/0638ac87-24ef-49ff-b4ae-590ddc43a1d0/
address: 39Gof9kcr51Hw44MTu65KERjYhYp199ji9 (btc)

bancora.network
Fake Bancor site phishing for keys with POST /googleanalytics.php
https://urlscan.io/result/d2366c89-289d-45d8-a11f-16743ac0f449/
https://urlscan.io/result/da1420b0-22de-4e20-b45e-d48b9d979b48/