### PR TITLE
elon-crypto.fund + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -699,6 +699,14 @@
     "ladder.to"
   ],
   "blacklist": [
+    "elon-crypto.fund",
+    "bitcupcoins.com",
+    "xn--stllar-4ua.com",
+    "mailsrv-stellar.com",
+    "xn--stllar-cva.com",
+    "ripple.com.lv",
+    "in-ripple.com",
+    "s3-stellar.org",
     "mybc-funds.tumblr.com",
     "mybt.ga",
     "mybi.ga",


### PR DESCRIPTION
elon-crypto.fund
Trust trading scam site
https://urlscan.io/result/62dc5e11-d760-408a-aaad-07e0d9f4672c/
https://urlscan.io/result/a9788164-e2ba-4614-96cf-2246d4bf28a2/
https://urlscan.io/result/7744b740-f111-49b7-8882-791495b76580/
address: 1MUSK1w47VAuqZfzK84maeaMhoZvYBqLyC (btc)
address: 0xC0193a9D5817090A684e6e19ccF9A9f333F13BA6 (eth)

bitcupcoins.com
Fake exchange scamming for deposits
https://urlscan.io/result/5a2b0349-864e-4f30-a601-5fd9eee5ecb6/

xn--stllar-4ua.com
Fake Stellar site phishing for secrets
https://urlscan.io/result/9259ab7e-e4fa-452b-ad1e-f251da52a660/
https://urlscan.io/result/7ebb1afb-a2a9-4a71-8b17-fcbd145b39e1/

mailsrv-stellar.com
Fake Stellar site phishing for secrets
https://urlscan.io/result/39763d9a-ce19-48e7-87fc-bc1f0aa1cae4/

xn--stllar-cva.com
Fake Stellar site phishing for secrets
https://urlscan.io/result/39763d9a-ce19-48e7-87fc-bc1f0aa1cae4/

ripple.com.lv
Fake Ripple site phishing for secrets
https://urlscan.io/result/7dc8be41-a5e6-4992-ada5-edcfdd8c4c36/
https://urlscan.io/result/b7f3d0e7-d4b1-4ccb-886b-dd597f3405d5/