### PR TITLE
myetherwallet.comim.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -699,6 +699,8 @@
     "ladder.to"
   ],
   "blacklist": [
+    "myetherwallet.comim.org",
+    "musk-event.org",
     "elon-crypto.fund",
     "bitcupcoins.com",
     "xn--stllar-4ua.com",


### PR DESCRIPTION
myetherwallet.comim.org
Fake MyEtherWallet phishing for secrets with POST /Record.php
https://urlscan.io/result/e8bc67ec-01ab-476f-8d4a-50f7ee92bdef/

musk-event.org
Trust trading scam site
https://urlscan.io/result/693ed430-05d6-447b-b216-019d9ae9d69c/
https://urlscan.io/result/d1e168ca-a79f-482a-96aa-f8df61049710/
https://urlscan.io/result/82be635d-10c9-424f-b9a7-bb55bdc943a5/
address: 1MusK15oUKXF3x6B3g1p4FDJc3zPuLQ9PM (btc)
address: 0x33431508fF6df7e16D7dDe03f76b037a164Ecf97 (eth)