### PR TITLE
Revert "Unfuzzy maskmeta.org"

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -3,6 +3,7 @@
   "tolerance": 2,
   "fuzzylist": [
     "metamask.io",
+    "maskmeta.org",
     "myetherwallet.com",
     "cryptokitties.co",
     "mycrypto.com",


### PR DESCRIPTION
Reverts MetaMask/eth-phishing-detect#4582

This listing was deliberate to prevent sites that try to bypass the detector by swapping the meta-mask words and varying the letters. Maskmeta is also blocked for that reason.