### PR TITLE
wave-airdrop.live + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -700,6 +700,18 @@
     "ladder.to"
   ],
   "blacklist": [
+    "wave-airdrop.live",
+    "connectionlivewallet.io",
+    "dai-stablecoin.com",
+    "enjin-books.com",
+    "coingccko.com",
+    "jxxll.fun",
+    "libertyjaxx.live",
+    "branch-trust-wallet.000webhostapp.com",
+    "org-appconnect.com",
+    "io-update.com",
+    "liquidity-pool-uniswap.org",
+    "app.liquidity-pool-uniswap.org",
     "gemini-giveaways.blogspot.com",
     "geminipaymewnt.blogspot.com",
     "ledger-updates.com",

--- a/src/config.json
+++ b/src/config.json
@@ -702,8 +702,6 @@
   "blacklist": [
     "wave-airdrop.live",
     "connectionlivewallet.io",
-    "dai-stablecoin.com",
-    "enjin-books.com",
     "coingccko.com",
     "jxxll.fun",
     "libertyjaxx.live",


### PR DESCRIPTION
wave-airdrop.live
Trust trading scam site
https://urlscan.io/result/34defd19-6e77-4b65-a435-07cb06dc26e2/
https://urlscan.io/result/1d5e50f1-a546-4a54-b530-8b39ddfe4403/
address: 3P3RchRFHbmeyb4nuBWKnAHGNoAcjSQt3rZ (waves)

connectionlivewallet.io
Fake WalletConnect site phishing for secrets
https://urlscan.io/result/4e122118-8938-4e20-927e-892fe382f27a/

dai-stablecoin.com
Fake MakerDao wallet phishing for secrets with POST /submit.php
https://urlscan.io/result/811398eb-a6b1-45a4-aa7d-19477fd7a4f1/
https://urlscan.io/result/e75c95c1-9e1e-43be-a3b8-5abe1c57c585/
https://urlscan.io/result/85f45fc5-f15f-4cb4-addb-31bbc1a3ce7f/
https://urlscan.io/result/6e0755c1-d87b-4fed-8f91-c8d825d7287b/

enjin-books.com
Fake TrustWallet site phishing for secrets with POST /submit.php
https://urlscan.io/result/5e8b7acc-2eea-4d02-a37f-51d021229154/
https://urlscan.io/result/127bb0a9-58fb-4c07-b54e-ce3fce7e06c1/

jxxll.fun
Fake Jaxx site phishing for secrets with POST /api.php
https://urlscan.io/result/a9cace43-3c84-433c-8ee5-91d5708ebab5/
https://urlscan.io/result/ee30d191-f7ef-48b8-a964-3325356db089/

libertyjaxx.live
Fake Jaxx site phishing for secrets with POST /api.php
https://urlscan.io/result/93cb6a8d-3613-47d7-b064-686331254dec/
https://urlscan.io/result/a3cf1b24-5a7f-44c7-9d98-52c0d2ee477a/

branch-trust-wallet.000webhostapp.com
Fake TrustWallet site phishing for secrets with POST /login.php
https://urlscan.io/result/ce6cfa2e-efb7-4e9f-97ce-556b678f018b/

org-appconnect.com
Fake Uniswap phishing for secrets with POST /callback.php
https://urlscan.io/result/d8ebc900-9fe0-4d09-ae61-802c852647bb/

io-update.com
Fake Uniswap phishing for secrets with POST /callback.php
https://urlscan.io/result/b530a8bf-446e-4b9a-aea7-6d9448973017/

app.liquidity-pool-uniswap.org
Fake Uniswap phishing for secrets with POST /claim.php
https://urlscan.io/result/cc7a55dd-132a-4cfd-adfc-8923c3082e30/
https://urlscan.io/result/a650d118-a43f-43c9-9123-38d9141b2d63/