### PR TITLE
eth-airdrop-uniswap.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -710,7 +710,6 @@
     "musk-give.us",
     "gemini-lander2.blogspot.com",
     "gemin-payments.blogspot.com",
-    "gemin-payments.blogspot.com",
     "metamaskconnect.net",
     "airdrop-gemini.blogspot.com",
     "paygemini.blogspot.com",

--- a/src/config.json
+++ b/src/config.json
@@ -705,6 +705,12 @@
     "app.tornado.cash"
   ],
   "blacklist": [
+    "eth-airdrop-uniswap.org",
+    "btchaze.com",
+    "musk-give.us",
+    "gemini-lander2.blogspot.com",
+    "gemin-payments.blogspot.com",
+    "gemin-payments.blogspot.com",
     "metamaskconnect.net",
     "airdrop-gemini.blogspot.com",
     "paygemini.blogspot.com",


### PR DESCRIPTION
eth-airdrop-uniswap.org
Fake Uniswap site phishing for secrets (promoted by twitter id: 111605663)
https://urlscan.io/result/4a8d227f-94fd-4e0d-a6e3-3922d8f6d535/

btchaze.com
Fake exchange scamming for deposits
https://urlscan.io/result/abef69d5-5376-4537-8f0b-4643a3a2f979/

gemini-lander2.blogspot.com
Trust trading scam site directing users to gemin-payments.blogspot.com
https://urlscan.io/result/254968e7-de5a-4ae9-8d80-d6730ea5f4ae/
https://urlscan.io/result/ce1a7123-8a94-442b-a915-f55d96d21bfa/
address: 15Fkb8u9oZRzc47c8hvrgMoak1PggtYTvr (btc)

gemin-payments.blogspot.com
Trust trading scam site
https://urlscan.io/result/f4b5b2cd-5654-4c0f-8e1b-52704a133af2/
address: 15Fkb8u9oZRzc47c8hvrgMoak1PggtYTvr (btc)