### PR TITLE
receiveuniswap.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -705,6 +705,12 @@
     "app.tornado.cash"
   ],
   "blacklist": [
+    "receiveuniswap.com",
+    "exodus-supports.com",
+    "claim-crypto.site",
+    "xn--accounts-bnance-epb.com",
+    "musk2.top",
+    "token-giveaway.com",
     "socialcapital.page",
     "bitmycap.com",
     "binexor.com",


### PR DESCRIPTION
receiveuniswap.com
Fake Uniswap site phishing for secrets with POST / (promoted by twitter id: 1900436629)
https://urlscan.io/result/c57ee74f-27e9-4037-a208-3c9e84701c0b/
https://urlscan.io/result/62357cdd-4052-4ccc-ae32-498eabc40366/
https://urlscan.io/result/09e68c16-5a51-4bbd-974b-89772e2c74be/

claim-crypto.site
Trust trading scam site
https://urlscan.io/result/a3c79949-711f-4bbb-8086-bfdfe2c38609/
https://urlscan.io/result/288e6cf6-132b-41b3-895a-7cb09b0ffaaa/
https://urlscan.io/result/bfe3b73a-8834-458b-af76-fcec5e36130d/
address: 0x2A48544b3b91FC52423067545fC4b86930e7F32b (eth)
address: 1HaBWr9HFGaagU6v1B9KzXT9UfAg76scLA (btc)

xn--accounts-bnance-epb.com
Fake Binance site phishing for logins with POST /_ini.php
https://urlscan.io/result/3609a805-4bc0-4a63-bb7a-903b91ce4d27/

musk2.top
Trust trading scam site
https://urlscan.io/result/1c977e6f-e6fb-4b17-a65a-58eb7cd15d10/
https://urlscan.io/result/e4955d6a-3032-4acc-bdb1-e29a1827d069/
https://urlscan.io/result/1c1a9311-e45a-42a9-a444-04fa649b82d3/
address: 1FzWsY4yhF9VQJjxVXTTgPetnoizVESHpQ (btc)
address: 0xa7ec44b9a0b7d45b3fb6eadd10bb7c29d076739c (eth)