### PR TITLE
walletsconnect.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -705,6 +705,7 @@
     "app.tornado.cash"
   ],
   "blacklist": [
+    "walletsconnect.org",
     "zapperi.fi",
     "walletsconnect.top",
     "walletsconnect.online",


### PR DESCRIPTION
walletsconnect.org
Fake Walletconnect site phishing for secrets with POST /wallets/actions.php
https://urlscan.io/result/a4987f1c-4d19-4271-b795-ccc3889ab152/
https://urlscan.io/result/723a0cef-b5b2-4449-ab24-bac76a20bda5/

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/4657