### PR TITLE
synthetix.us

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -705,6 +705,7 @@
     "app.tornado.cash"
   ],
   "blacklist": [
+    "synthetix.us",
     "walletsconnect.org",
     "zapperi.fi",
     "walletsconnect.top",


### PR DESCRIPTION
synthetix.us
Fake Synthetix website hosting malware - sha256sum:02a6412539659cc0b9da432edc3bd982652f1e4adc2b0be7473b691c057f2197 md5sum:a499c34128417a2387cd9b91fc876719
https://urlscan.io/result/2226830d-49c3-44b2-8f43-e167206834d7/