### PR TITLE
coinbase.com.auth-value-token-9929929.ru + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -705,6 +705,12 @@
     "app.tornado.cash"
   ],
   "blacklist": [
+    "coinbase.com.auth-value-token-9929929.ru",
+    "coinbase.com.secure-account188.ru",
+    "secure-account188.ru",
+    "auth-token-authentication-value-4782365234.ru",
+    "authenticate-coinbase.com",
+    "integratewallet.live",
     "synthetix.us",
     "walletsconnect.org",
     "zapperi.fi",


### PR DESCRIPTION
coinbase.com.auth-value-token-9929929.ru
Fake Coinbase site
https://urlscan.io/result/199411ae-e513-4396-ad5b-ee83538c9cfc/

coinbase.com.secure-account188.ru
Fake Coinbase site directing users to //coinbase.com.auth-token-authentication-value-4782365234.ru/base.php?token=checkauth1010101010
https://urlscan.io/result/6475c522-7ef0-4692-9624-37a516d8c7d4/

integratewallet.live
Fake WalletConnect site phishing for secrets with POST //cryptooo-api.herokuapp.com/api/v1/validateOptions
https://urlscan.io/result/25fcae9b-dd5c-433b-b3f2-9a27a367d83a/
https://urlscan.io/result/1f538a9b-a9c4-4da3-989e-d4ca4eb70b19/