### PR TITLE
uniswapgiveaway.com + sushiairdrop.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -705,6 +705,8 @@
     "app.tornado.cash"
   ],
   "blacklist": [
+    "uniswapgiveaway.com",
+    "sushiairdrop.net",
     "coinbase.com.auth-value-token-9929929.ru",
     "coinbase.com.secure-account188.ru",
     "secure-account188.ru",


### PR DESCRIPTION
uniswapgiveaway.com
Trust trading scam site (promoted by twitter id: 1012427454)
https://urlscan.io/result/b9da7f87-f3ab-46e5-8147-b24295ced3d1/
https://urlscan.io/result/3cd1d9e5-df1b-4b52-9c57-f1b118a0ec50/
address: 0xB69149F8b9322EC0cf8020DF22C237640c6791F1 (eth)

sushiairdrop.net
Trust trading scam site (promoted by twitter id: 454174458)
https://urlscan.io/result/aab03f18-2ff2-4006-aeed-c328628c34ff/
https://urlscan.io/result/7aa9b2ff-da49-4b56-9ca2-f1eaf57d4384/
address: 0xBd0A11654D863D95bF5F4396F6D6A1f5fB1698ca (eth)