### PR TITLE
giveawayuniswap.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -705,6 +705,9 @@
     "app.tornado.cash"
   ],
   "blacklist": [
+    "giveawayuniswap.com",
+    "exodus-update.com",
+    "connectionlivewallet.org",
     "uniswapgiveaway.com",
     "sushiairdrop.net",
     "coinbase.com.auth-value-token-9929929.ru",


### PR DESCRIPTION
giveawayuniswap.com
Trust trading scam site (promoted by twitter id: 1012427454)
https://urlscan.io/result/b6228bb2-678f-4987-90e7-8711060679ae/
https://urlscan.io/result/36316689-e7a0-4514-89a1-3556849b5f48/

exodus-update.com
Fake Exodus site phishing for secrets with POST /update?userID=<user_email>
https://urlscan.io/result/83d2c402-7f62-4914-b25d-63bdf1043f45/

connectionlivewallet.org
Fake WalletConnect site phishing for secrets with POST //82746f7aa0a569538ee924c29c3fa16c.m.pipedream.net
https://urlscan.io/result/73f0e009-cd99-44b5-af04-a6d10d04f1a5/