### PR TITLE
myetpwallet.000webhostapp.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -712,6 +712,10 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "myetpwallet.000webhostapp.com",
+    "opexchange24.com",
+    "senduniswap.com",
+    "cryptogiftsgive.neocities.org",
     "myetherwallet.comat.cc",
     "stellar.org.ag",
     "accountviewer.stellar.org.ag",


### PR DESCRIPTION
myetpwallet.000webhostapp.com
Fake MetaVerse wallet phishing for secrets with POST /validate.php
https://urlscan.io/result/e3714858-1ec8-4465-b8c0-6c2f7f2ffd7f/
https://urlscan.io/result/1227bb6e-7adc-4d1a-9b57-dcb2e9893fc6/
https://urlscan.io/result/2afedd92-c28a-4143-b210-b8a8b9a3af4a/

opexchange24.com
Fake exchange scamming for deposits
https://urlscan.io/result/f1771bc1-c30d-4b79-9284-0db8cbe87c64/

cryptogiftsgive.neocities.org
Trust trading scam site
https://urlscan.io/result/55e308a5-3024-420a-8731-b8ed40b56b44/
address: 0xc6A098044200726e7f0edB9927B2531757ADB59f (eth)