### PR TITLE
dpitokendrops.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -712,6 +712,9 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "dpitokendrops.com",
+    "uniswap-free.com",
+    "1inchx.exchange",
     "accounts-binance-log-in.com",
     "uniswapnodev2.com",
     "aave.pw",


### PR DESCRIPTION
dpitokendrops.com
Trust trading scam site
https://urlscan.io/result/0f5a92aa-8271-4919-a08f-d312cfb94cb1/
address: 0x5821cFB6D4E8a8B04dBFD6410e9D37955aFEa3CD (eth)

uniswap-free.com
Fake Uniswap site phishing for secrets
https://urlscan.io/result/d43508b2-5061-471b-a337-21f701693738/

1inchx.exchange
Fake 1inch site
https://urlscan.io/result/af154793-a81c-41d8-8a0e-580ba252c251/