### PR TITLE
elontrust.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -712,7 +712,7 @@
     "askzeta.com"
   ],
   "blacklist": [
-    "app.uniswap.protocol-airdrop­.com",
+    "app.uniswap.protocol-airdrop.com",
     "elontrust.com",
     "getbitcap.com",
     "eth20staking.org",

--- a/src/config.json
+++ b/src/config.json
@@ -712,6 +712,10 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "app.uniswap.protocol-airdrop­.com",
+    "elontrust.com",
+    "getbitcap.com",
+    "eth20staking.org",
     "zapperi.finance",
     "walletconect.info",
     "musk.help",


### PR DESCRIPTION
elontrust.com
Trust trading scam site
https://urlscan.io/result/fff97235-0c80-4c55-b104-0905c0e8fa43/
https://urlscan.io/result/719ef4b7-d668-4882-b5a7-077cb57e2d47/
address: 1BVt2h5P5TEPX8Ai9mdifpgN1efrWfhzcS (btc)

getbitcap.com
Fake exchange scamming for deposits
https://urlscan.io/result/e6c1b6ed-1627-4a0f-89de-29222ac8ce53/

eth20staking.org
Fake Eth2 staking platform
https://urlscan.io/result/48d34a6b-9f17-4a9f-826b-a98da06875b5/
address: 0xb0366bbe8cf7ed6f332ae366419515d4a5bdf8a0 (eth)