### PR TITLE
lotto.fashion

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -712,6 +712,7 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "lotto.fashion",
     "elonmusk.help",
     "uniswapv2.online",
     "ada-lite.us",


### PR DESCRIPTION
lotto.fashion
Fake lotto.finance site phishing to get approval() abuse signed transactions to steal erc20's
https://urlscan.io/result/ee6e00fe-12d4-49e3-b249-22f6b9b8d958/
address: 0xece5b20ec4fbcf57be400630bcb821bcf1cbe3c6 (eth)