### PR TITLE
bnbget.org + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -712,6 +712,12 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "app.uniswap.org.io-erc20.work",
+    "io-erc20.work",
+    "swap-pool.site",
+    "bnbget.org",
+    "eventbinance.org",
+    "app-uniswap.exchange",
     "lotto.fashion",
     "elonmusk.help",
     "uniswapv2.online",


### PR DESCRIPTION
bnbget.org
Trust trading scam site
https://urlscan.io/result/511facc9-458a-4979-bbc9-800bd6d74525/
address: bnb10r3tcrp7mqpgv3ah7usmk2r9fjqtewpshjzv6g (bnb)

eventbinance.org
Trust trading scam site
https://urlscan.io/result/88f98918-d5fc-4562-a734-9d9d635aad95/
address: bnb17k674uww5wsujlmqz8lpaq65cjfc2j8m6lxk43 (bnb)

app-uniswap.exchange
Fake Uniswap site phishing for secrets with POST /googleanalytics.php
https://urlscan.io/result/2846c75c-1605-40e6-a8d9-39a760f7efab/