### PR TITLE
remove genoverde.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -6135,7 +6135,6 @@
     "binances.pro",
     "bittrex.management",
     "bittrex.promo",
-    "genoverde.com",
     "idexmarket.host",
     "kraken--login.com",
     "meercatox.com",


### PR DESCRIPTION
genoverde.com
https://urlscan.io/result/b5dfbea3-8169-4c48-a3e2-330c5b4b89c8/
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/4725