### PR TITLE
Add malicious site to block list

### DIFF
--- a/src/hosts.txt
+++ b/src/hosts.txt
@@ -1069,3 +1069,4 @@
 0.0.0.0 curve.so
 0.0.0.0 curvefi.io
 0.0.0.0 curwe.fi
+0.0.0.0 curve-claims-rewards-programs.com


### PR DESCRIPTION
There is a fake telegram group that posted a link to hxxps://curve-claims-rewards-programs.com/claim-bonus.

The page looks like MEW and it asks the user for their private key/mnemonic.