### PR TITLE
dodoex.us + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,14 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "dodoex.us",
+    "elon.so",
+    "app.beta-v2-uniswap.org",
+    "app-uniswap.blogspot.com",
+    "elondonate.com",
+    "muskdrop.cc",
+    "elonnow.github.io",
+    "app.uniswap.airdrop-holders-uniswap­.org",
     "restorewalletsio.link",
     "prime-bitgo.com",
     "bitmex-withdrawal-disabled.com",

--- a/src/config.json
+++ b/src/config.json
@@ -721,7 +721,7 @@
     "elondonate.com",
     "muskdrop.cc",
     "elonnow.github.io",
-    "app.uniswap.airdrop-holders-uniswap­.org",
+    "app.uniswap.airdrop-holders-uniswap.org",
     "restorewalletsio.link",
     "prime-bitgo.com",
     "bitmex-withdrawal-disabled.com",


### PR DESCRIPTION
dodoex.us
Fake Dodo site hosting malware - https://twitter.com/dubstard/status/1364662290541330434
https://urlscan.io/result/b87344d7-aaca-4bd3-9e21-ea7c51b5e064/

elon.so
Trust trading scam site
https://urlscan.io/result/ad2e63c1-ba64-47e0-add5-8aa43480881f/
https://urlscan.io/result/6aaf3859-eeb7-48ca-ac5e-964bb3983893/
https://urlscan.io/result/b64a05cb-30cf-4768-956d-3f8cb247f4a6/
https://urlscan.io/result/35fabd25-0b1a-491b-9928-2a5fb89115c4/
address: 1MUSkay6X6yDwkB5E4BwcGRHtFytFsUq61 (btc)
address: 0x419912d0694cA1dECA51fE852A387C47c967D48d (eth)
address: D7mKX7TPddPWjq3sv6cXkX7Um5PEQtRS8h (doge)

app.beta-v2-uniswap.org
Fake Uniswap site phishing for secrets
https://urlscan.io/result/139c699a-305d-4e91-953f-ea9d57adb9ad/
https://urlscan.io/result/0e507fdd-478e-49e9-ae2d-49cb7634d794/

elondonate.com
Trust trading scam site
https://urlscan.io/result/c445a229-e340-40fa-b0c0-a40b8025f622/

muskdrop.cc
Trust trading scam site
https://urlscan.io/result/7ff1b346-654e-455d-a6cd-5478b83c52b2/
address: 0x5AfB4eB7961eA06C0783B09c509725f561475B88 (eth)
address: 1KdsgfWKt76Kxk23B1pCeWDKpmgXuph2B2 (btc)