### PR TITLE
uniswapaddress.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,10 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "uniswapaddress.com",
+    "rocld.com",
+    "stellar-airdrop.com",
+    "uni-project.org",
     "connectionlivewallets.org",
     "httpsappmycryptocom.slack.com",
     "claim-btc.net",


### PR DESCRIPTION
uniswapaddress.com
Trust trading scam site (promoted by twitter id: 2984108125)
https://urlscan.io/result/8f15ac29-33ed-4506-a974-ff290a4aa7d1/
https://urlscan.io/result/639987bd-554a-4860-a88e-0cea4965f366/
address: 0x90Debc62a8c541c1b3bB5e5D18dbD01661125Ee6 (eth)

stellar-airdrop.com
Fake Stellar site hosting malware
https://urlscan.io/result/df9f309e-6f62-4947-bd80-3ff23861aa5d/
https://urlscan.io/result/41cc9d0e-8c9a-41ef-a986-25d31fba8728/

uni-project.org
Fake Uniswap site hosting malware (sha256: CE9E56AF0D46C6178787CFC2A63B8C2BC74B8A48803157CCCE06B57E60491607)
https://urlscan.io/result/b8a21b9e-7dfd-4dc6-a1f8-e28d362e584b/