### PR TITLE
uniswapgiveaway.info + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,12 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "uniswapgiveaway.info",
+    "newuniswap.com",
+    "4link.one",
+    "ethlegit.com",
+    "fxopel.com",
+    "doge21.net",
     "uniswapaddress.com",
     "rocld.com",
     "stellar-airdrop.com",


### PR DESCRIPTION
uniswapgiveaway.info
Trust trading scam site (promoted by twitter id: 484975566)
https://urlscan.io/result/8de2b1ab-7d5e-4079-936f-e8dc4d9d7296/
https://urlscan.io/result/63b02d92-d068-483f-ae2c-aeb2efd829fb/

newuniswap.com
Trust trading scam site (promoted by twitter id: 2984108125)
https://urlscan.io/result/d3671ffe-f813-4b0c-8570-2aa5f200c803/
https://urlscan.io/result/d5b06470-6cd9-444f-9e74-fba8a23982df/
address: 0x6bBfC1e0127Fe52b391efEF48a5509bB0A8ea25F (eth)

4link.one
Trust trading scam site
https://urlscan.io/result/723e42c1-0c5f-4134-a864-66301973ff17/
https://urlscan.io/result/fd52ada0-8a1f-4a0e-94a0-ee6b739636c3/
address: 0xfB611E1d66b6477cCfA8aF9980F9d1203F892604 (eth)

ethlegit.com
Fake exchange scamming for deposits
https://urlscan.io/result/3470e8f6-361d-4f12-bae2-1cdeeb20761d/

fxopel.com
Fake exchange scamming for deposits
https://urlscan.io/result/f97cd6fb-587f-409e-879c-f54cacc92f90/

doge21.net
Trust trading scam site
https://urlscan.io/result/df18cc33-84e9-4bb6-9ae9-34184e3e53a9/
https://urlscan.io/result/9ba5f067-a47e-4942-a5fd-5e3646e4894f/
address: AAMDvf9zWoUf4zbXiEeM5ziJTmWU77nQxy (doge)

----

eth-get.org
Trust trading scam site
https://urlscan.io/result/08d190c8-a073-4976-8d33-104a13bd661c/
https://urlscan.io/result/06fcf5f6-11aa-4c7d-a134-4dfba86540be/
https://urlscan.io/result/eb466fac-c965-40bd-8267-7da2e87c7fc2/
address: 19xrkxrcFCRa8dQb5mNFrmuD9b6CmxnaBN (btc)
address: 0x26f83beb9808a23A23DcA1a7Ed334578FC7337AA (eth)