### PR TITLE
xrp21.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,9 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "xrp21.net",
+    "dodoex.live",
+    "ada-cardano.us",
     "xn--unswaep-sfb.com",
     "webwalletsconnect.link",
     "sushifinance.us",


### PR DESCRIPTION
xrp21.net
Trust trading scam site
https://urlscan.io/result/9249c71e-41f5-4af2-afcb-a1ae187e9296/

dodoex.live
Fake Dodo site hosting malware (MD5: edfb11930ae84f31b3040c3e8cb79355)
https://urlscan.io/result/16f38b0a-7b0b-4f97-bb28-a83e997747b4/

ada-cardano.us
Trust trading scam site
https://urlscan.io/result/f616755f-ed5b-482c-bd20-1b03ed7c191c/
address: addr1qy0hf7rkkgpu94raw07lulkpvs70gcq0m86yrcfty65ruvh7ktwhp7rsmrf30w678mknrc767aj7fratdsfjk0yz8myqz3u7zd (ada)