### PR TITLE
oferonrain.web.app + thegraph.us

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,9 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "oferonrain.web.app",
+    "thegraph.us",
+    "nucypher.biz",
     "musk.info",
     "claim-now.me",
     "smartintegration.live",


### PR DESCRIPTION
oferonrain.web.app
Fake Rainbow wallet phishing for keys (Firebase oferonrain.firebaseapp.com) - https://twitter.com/mikedemarais/status/1370087746845433858
https://urlscan.io/result/a488dece-2f25-432f-9f14-90fba85701ad/

thegraph.us
Fake TheGraph site hosting malware (sha256sum: 70df2e7cd045758efffee7eea44557edfb9abc751b183f155a45e4672b48aad0)
https://urlscan.io/result/f7e820af-7846-4d7f-9396-213a86a6648c/