### PR TITLE
newunigiveaway.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,14 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "newunigiveaway.com",
+    "teslacrypto.top",
+    "pancakesswap.com",
+    "justswap.us",
+    "hiveproject.us",
+    "ravenproject.net",
+    "bakeryswap.us",
+    "daedaluswallet.net",
     "oferonrain.web.app",
     "thegraph.us",
     "nucypher.biz",


### PR DESCRIPTION
newunigiveaway.com
Trust trading scam site (promoted by twitter id: 1363121774527930380)
https://urlscan.io/result/e9b7d5cd-9eb2-49bb-9563-283da9dca635/
https://urlscan.io/result/65186b8e-b0e4-4a2f-8945-ba3d4d9a4cc5/
address: 0x748f71497843cde8DF4dB3b46176699F2B0d2d52 (eth)

teslacrypto.top
Trust trading scam site
https://urlscan.io/result/b0aa2b16-af1c-4b63-adbb-20a66dc3ac2a/
https://urlscan.io/result/7f1ea368-eab6-44a8-ab52-ba5811a5b466/
https://urlscan.io/result/15cba061-3900-4d6a-aa49-33a9b2733529/
address: 0x4Ee43484796AEBEe01eE8e39d3A4CCcbbbac136b (eth)
address: 3MPEnnuzA9avCR7VqzdJ1cotjhEwhKup8J (btc)

pancakesswap.com
Fake Pancake swap site hosting malware
https://urlscan.io/result/74e8bbb7-2b70-4726-9950-069cd631139e/

daedaluswallet.net
Fake Daedalus site hosting malware
https://urlscan.io/result/e4996177-667a-4661-be28-cf7829e99ad5/