### PR TITLE
wall.prohoster.biz + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,9 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "wall.prohoster.biz",
+    "teslab.us",
+    "elonmusk-gives.s3.amazonaws.com",
     "newunigiveaway.com",
     "teslacrypto.top",
     "pancakesswap.com",


### PR DESCRIPTION
wall.prohoster.biz
Fake TrustWallet phishing for secrets with POST /claim.php
https://urlscan.io/result/12ec53e5-2054-41e9-a585-e98d1caa3bee/
https://urlscan.io/result/2dd361c5-a9ba-469c-a957-dcdcad15cf60/
https://urlscan.io/result/1d113bf8-98d6-4ff9-bc95-f0613c61a12a/

elonmusk-gives.s3.amazonaws.com
Trust trading scam site
https://urlscan.io/result/a732b6da-fb58-4ed6-be99-083a3bc3589d/
https://urlscan.io/result/7dde6c27-ab38-4f29-ac54-80865a90fbe0/
address: 1NxPjKQrrhRuALSKy1XJa34im1C3cFzCeR (btc)