### PR TITLE
Add Casper.limited and https: //casper - sale . link 

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,7 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "casper-sale.link",
     "casper.limited",
     "wall.prohoster.biz",
     "teslab.us",

--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,7 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "casper.limited",
     "wall.prohoster.biz",
     "teslab.us",
     "elonmusk-gives.s3.amazonaws.com",


### PR DESCRIPTION
Casper.Limited  and https: //casper - sale . link (link spaced as it contains malware) are phishing sites targeting users of the legitimate casperlabs.io and casper.network domains 