### PR TITLE
wallet-syn.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,9 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "wallet-syn.com",
+    "fantom-foundation.us",
+    "badgerfi.us",
     "app.cream.finance",
     "pancakeswap.finance",
     "api-walletconnect.org",


### PR DESCRIPTION
wallet-syn.com
Fake WalletConnect phishing for secrets with POST /import/post.php
https://urlscan.io/result/21d10c15-7aa7-4637-a060-ad801c9eadd2/
https://urlscan.io/result/7c0469a6-2406-4346-917e-510044972231/

fantom-foundation.us
Fake Fantom site hosting malware FantomUI-v2.1.5.exe (sha256sum: 99199bdb0251a207f87d8a1948dfaa91cd04d7f62826f35ee0bfb3667ca487ff)
https://urlscan.io/result/d0f5a72d-45f2-4380-b140-c4da5fbb848f/

badgerfi.us
Fake BadgerDAO site hosting malware   BadgerApp-v2.1.0.exe (sha256sum: 26821d0ffc00ff0cdb591df87e509811020a036c9684e2c9c65424229b5b0fa8)
https://urlscan.io/result/e195fa38-9bc3-4b97-b425-4170e94ed591/