### PR TITLE
geckcoin.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -714,6 +714,15 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "geckcoin.com",
+    "cryptorozi.com",
+    "buncebit.com",
+    "cryptopye.com",
+    "elonevent.org",
+    "1ncih.exchange",
+    "uniswapnewgiveaway.com",
+    "adagift.me",
+    "uniswapv2node.online",
     "wallet-syn.com",
     "fantom-foundation.us",
     "badgerfi.us",


### PR DESCRIPTION
geckcoin.com
Fake exchange scamming for deposits
https://urlscan.io/result/d4ffef7e-ece8-4583-b14f-705ce68d23d5/

cryptorozi.com
Fake exchange scamming for deposits
https://urlscan.io/result/fdac67b0-9e11-4053-8f18-d1449f8cf2f2/

buncebit.com
Fake exchange scamming for deposits
https://urlscan.io/result/091befd8-b164-40a2-94ff-21366b7046f8/

cryptopye.com
Fake exchange scamming for deposits
https://urlscan.io/result/47d3705c-bc0b-4116-a5c4-d9e396ce7653/

elonevent.org
Trust trading scam site
https://urlscan.io/result/a5a14261-3391-49b5-92ea-eb3bace606f8/
https://urlscan.io/result/dd0f49f1-3231-479f-8d22-d6c1ae51b94d/
https://urlscan.io/result/9680a211-b85b-431e-882f-f9f235909192/
address: 1FqBz1V6t5kuUebnmLv8fe9N8KS28y8VtW (btc)
address: 0x62a0E8c5C55224B79aD93447d12b7Fa2d257BC26 (eth)

1ncih.exchange
Fake 1inch site - stealing funds via erc20 approve() 
https://urlscan.io/result/613ee90b-db33-4d45-9342-1618b82087cf/
https://urlscan.io/result/c78a969a-065f-445c-985d-e8328a6b1b40/
address: 0x95a4ee08cd409ca66395fd10ad19cef80258345d (eth)

uniswapnewgiveaway.com
Trust trading scam site
https://urlscan.io/result/728d1d18-c02e-4c4a-893c-2213a3f5a120/
address: 0x79B92cF9E611AAF768881a8762E5F777544F5Ff3 (eth)

adagift.me
Trust trading scam site
https://urlscan.io/result/09f3085c-a096-44c5-aead-18d19bb1b38f/
address: addr1qxncndxuxfstw8ydudrq2qzqa23kd5lgqnnhyzt2yqv2sg67f5xc7nkn6rqnapvy0h8e4kv4tgyexaywsjrhvg6pwy8qzew89d (ada)

uniswapv2node.online
Fake Uniswap site phishing for secrets
https://urlscan.io/result/73eac502-2576-4464-9dee-d7a5ff5162ea/