### PR TITLE
add 2 new bad urls

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12924,6 +12924,8 @@
     "login.xn--bockchaln-vpb.com",
     "www.lblhblockchain.com",
     "walletconnecl.org",
+    "walletsconnect.host",
+    "walletsconnectapp.com",
     "dropelon.io",
     "givemusk.space",
     "muskx.digital",


### PR DESCRIPTION
walletsconnect.host
walletsconnectapp.com
Shared DNS A 198.54.126.114
![image](https://user-images.githubusercontent.com/49607867/112642708-3f901d00-8e4c-11eb-8988-e47095d09a0e.png)
