### PR TITLE
add 2 new bad URLs

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1251,6 +1251,8 @@
     "trezor-hardware-wallet.reklama-ads.com",
     "trezor-hardware.reklama-ads.com",
     "claim-airdrop-uniswap.org",
+    "www.app.uniswap.org-claim-airdrop.com",
+    "app-uniswap.org-v3.site",
     "crryptod3423.blogspot.com",
     "uniswapbalance.com",
     "ethereumgift.us",


### PR DESCRIPTION
Both have already been revoked, adding for completeness.
![image](https://user-images.githubusercontent.com/49607867/112743596-441a1a00-8fa1-11eb-96f4-2eede5c5e8f0.png)

Have seen TLDs being 'reborn' after some time before.

↘app-uniswap.org-v3.site
https://urlscan.io/result/2c5d3a6c-6ac3-4570-a21b-abd7f9c36805/

↘org-claim-airdrop.com
https://urlscan.io/result/0d0e156d-7cdd-4a9a-bb30-e79d29f9e72b/