### PR TITLE
wallet.exodus.com.b37dx.sehzadelerdagitim.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -715,6 +715,8 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "casper-tokensale.com",
+    "wallet.exodus.com.b37dx.sehzadelerdagitim.com",
     "1nich.com",
     "metamask-api.io",
     "token-airdrop.com",
@@ -12956,7 +12958,6 @@
     "bitzau.com",
     "yfinew.com",
     "metamaskrestores.link",
-    "hohbit.com",
-    "casper-tokensale.com"
+    "hohbit.com"
   ]
 }


### PR DESCRIPTION
casper-tokensale.com
Fake Casper crowdsale site
https://urlscan.io/result/9696c08e-1ca2-4bd5-b63b-1318ff0f4495/
address: 0x0cEC142D56c27b7973fd067EA906eeAA511DBb25 (eth)

wallet.exodus.com.b37dx.sehzadelerdagitim.com
Fake Exodus wallet phishing for secrets with POST /Terms.php
https://urlscan.io/result/c054abd0-5097-4bbc-b664-34f1e769ca87/
https://urlscan.io/result/2cb0ccdb-7e48-422a-a8ab-de76caf45533/