### PR TITLE
Add efinity.io to whitelist.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "launchpad.ethereum.org"
   ],
   "whitelist": [
+    "efinity.io",
     "finite.ltd",
     "auus.cloud",
     "masternodes.online",


### PR DESCRIPTION
The [efinity.io](https://efinity.io) domain is erroneously being detected as phishing due to having a similar match to the historical phishing domain `dfinity.org`. This pull requests adds the domain `efinity.io` to the whitelist.

This domain is controlled by [Enjin (enjin.io)](https://enjin.io) and can be verified by [this page](https://enjin.io/sites.txt), thank you.