### PR TITLE
Added cactus.bm to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -105,6 +105,7 @@
     "pass.org",
     "yasiv.com",
     "tasks.org",
+    "cactus.bm",
     "audus.net",
     "osris.org",
     "otis.is",


### PR DESCRIPTION
cactus.bm is not affiliated with any of the other cactus.* domains. It is a small technology company based in Bermuda.