### PR TITLE
Added arfinity.io to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "launchpad.ethereum.org"
   ],
   "whitelist": [
+    "arfinity.io",
     "efinity.io",
     "finite.ltd",
     "auus.cloud",


### PR DESCRIPTION
arfinity.io is not associated with any crypto-/blockchain or related activity.