### PR TITLE
musk-founder.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -720,7 +720,6 @@
   "blacklist": [
     "musk-founder.com",
     "terolbit.com",
-    "coinrau.com",
     "fixedwallet.org",
     "polkadot-airdropcampaign.network",
     "zapper.ws",

--- a/src/config.json
+++ b/src/config.json
@@ -718,6 +718,12 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "musk-founder.com",
+    "terolbit.com",
+    "coinrau.com",
+    "fixedwallet.org",
+    "polkadot-airdropcampaign.network",
+    "zapper.ws",
     "foundatlon.app",
     "trustwalletrestore.org",
     "metamaskswallets.io",


### PR DESCRIPTION
musk-founder.com
Trust trading scam site
https://urlscan.io/result/c6672218-63db-4206-a107-6e4a40732580/
https://urlscan.io/result/d05e744f-1198-4698-9802-ee3cde8eb7d7/
https://urlscan.io/result/afec4cf3-fa02-46ef-8fc3-8c2443e1d147/
https://urlscan.io/result/3b9f0acc-5e86-4ac8-a78a-5f21f866b3f5/
address: 169GN79kFk68mk3DZ9ffWkbspv7QAihA9N (btc)
address: 0x104A71FaDe2AA952cC0884386843bE80Eb89b709 (eth)
address: DBGsgB942EN37R9XZaSrgfm7Cp5vxb627b (doge)

terolbit.com
Fake exchange scamming for deposits
https://urlscan.io/result/124cde58-8645-4d6b-b95a-2109b2d4da40/

coinrau.com
Fake exchange scamming for deposits
https://urlscan.io/result/7bd09567-8043-40f5-bac8-f32748ab0e6b/

fixedwallet.org
Fake WalletConnect phishing for secrets with POST /forms/contact.php
https://urlscan.io/result/2651d7ef-4560-454b-b3fb-bd000b4c1574/

polkadot-airdropcampaign.network
Trust trading scam site
https://urlscan.io/result/3ff036a4-5c5f-4c19-8ff2-bd5157f61f05/
https://urlscan.io/result/2ca01c0b-7c2e-47da-b200-d44856a62776/
address: 128yJEQjj3chFwgvWwp47tDPP1GewnJLz46et8dvRpq63JPX (dot)

zapper.ws
Fake Zapper site hosting malware (sha256sum: ca71c5a2b40e2c747b6bd860a3bc7a1b51fb6532a4dbd5fba550d3827bf9503b)
https://urlscan.io/result/67c1a9fc-9f8b-404c-97a7-ef1de2ed7f10/