### PR TITLE
thortrading.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -721,6 +721,9 @@
     "askzeta.com"
   ],
   "blacklist": [
+    "thortrading.com",
+    "snlmusk.com",
+    "uniholders.com",
     "walletnetworks.org",
     "connectionwallet.live",
     "walletconnect.to",


### PR DESCRIPTION
thortrading.com
Fake exchange scammin for deposits
https://urlscan.io/result/a9660536-6146-4b0f-afc3-3f440fd33f2d/

snlmusk.com
Trust trading scam site
https://urlscan.io/result/f67344b2-6914-490e-9919-07cfe4745a84/
https://urlscan.io/result/18a68c8e-3b93-4b51-aec1-717f09f80387/
https://urlscan.io/result/1e75242e-2e6c-4871-a8e2-d6f73933e772/
https://urlscan.io/result/25514f0b-83cc-40e1-8e69-8e5d10acbc81/
address: 18PGZEDKrVQCSWCFbu3kY9y6vxQe1965Pb (btc)
address: 0xB35871708771080feaD87E5b0F93293B1eea5E55 (eth)
address: D6A9twP63p2QwZy2FbVw3K9moXRZvZ7U9i (doge)

uniholders.com
Trust trading scam site (promoted by twitter id: 446364639)
https://urlscan.io/result/d872686a-c5df-453c-a321-45d1e1960619/
https://urlscan.io/result/0910f10f-3cd6-4a2c-9236-0f13b7759b9a/
address: 0x3483Fe6152626b4d3A1D2D3217BA8d1BEC6efcB2 (eth)