### PR TITLE
Allow arfinity.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -20,6 +20,7 @@
     
   ],
   "whitelist": [
+    "arfinity.io",
     "cactus.tools",
     "cactus.bm",
     "ascetus.com",


### PR DESCRIPTION
Reported in #4942:

>arfinity.io is not associated with any crypto-/blockchain or related activity.