### PR TITLE
Update `trim` from v0.0.1 to v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "author": "kumavis",
   "license": "DBAD",
+  "resolutions": {
+    "tap-summary/tap-out/trim": "^0.0.3"
+  },
   "dependencies": {
     "fast-levenshtein": "^2.0.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1381,10 +1381,10 @@ timers-browserify@^1.0.1:
   dependencies:
     process "~0.11.0"
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 tty-browserify@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
There were no breaking changes between these versions. This update addresses a security vulnerability that doesn't affect us.