### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -6870,6 +6870,7 @@
     "localbitcouins.biz",
     "localbitscoins.biz",
     "meetherwallet.website",
+    "metamaskconnect.org",
     "meyetherwallct.com",
     "meytferwallet.com",
     "meytherwallet.co",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49607867/122107873-3e0b3b00-ce24-11eb-91a5-18137ecb986d.png)

Even if the end user does not have metamask installed, the website pops up a iframe to make it look like metamask is there, in order to lure victims into revealing their seed phrase or json

![image](https://user-images.githubusercontent.com/49607867/122107946-524f3800-ce24-11eb-9b56-3b920123fd95.png)
