### PR TITLE
freematic.gifts

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -742,6 +742,7 @@
     "cactus.chat"
   ],
   "blacklist": [
+    "freematic.gifts",
     "myewerthevakleth.com",
     "ewalletsupport.com",
     "curve.wtf",


### PR DESCRIPTION
freematic.gifts
Trust trading scam site
https://urlscan.io/result/db413306-b2ab-4620-bb67-94a78b69d2aa/
https://urlscan.io/result/7c291a25-9699-4e6d-92db-abc5612cbbd0/
address: 0xB661a8C0872FAc5a4ea5714c1E034E5Fd6e40ca4 (eth)