### PR TITLE
www-opeansea.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -739,6 +739,7 @@
     "cactus.chat"
   ],
   "blacklist": [
+    "www-opeansea.io",
     "metamaskswap.io",
     "meta-token.site",
     "metamaskdrop.club",


### PR DESCRIPTION
www-opeansea.io
Fake opensea site phishing for secrets
https://urlscan.io/result/1605b192-dc64-43d7-b56a-71b3009ef6b8/