### PR TITLE
Allowlist nfinity.space to avoid fuzzy match

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -736,7 +736,8 @@
     "askzeta.com",
     "fulcra.design",
     "axle.design",
-    "cactus.chat"
+    "cactus.chat",
+    "nfinity.space"
   ],
   "blacklist": [
     "www-opeansea.io",


### PR DESCRIPTION
Re: Issue #5179

I'm working on a project and (maybe stupidly) chose the name Nfinity. This is being fuzzy matched with the domain `dfinity.org`, which I am not trying to imitate in any way.

I'd love if my domain (`nfinity.space`) could be allowlisted, that would save me a lot of time rebranding, recoding, redeploying smart contracts, etc. But I understand the security concerns with any whitelisted item so, understandable if it's not possible.

I'm happy to verify the legitimacy of myself and this project in any way possible. Please reach out if I can provide more info.

Thank you!