### PR TITLE
URL used in the Google ads that used to point to www - opeansea . io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -740,6 +740,7 @@
     "nfinity.space"
   ],
   "blacklist": [
+    "myetlhervwallet.com",
     "www-opeansea.io",
     "metamaskswap.io",
     "meta-token.site",

--- a/src/config.json
+++ b/src/config.json
@@ -740,7 +740,7 @@
     "nfinity.space"
   ],
   "blacklist": [
-    "myetlhervwallet.com",
+    "myewetlhervwallet.com",
     "www-opeansea.io",
     "metamaskswap.io",
     "meta-token.site",


### PR DESCRIPTION
Screenshot of the Google ad with this malicious URL https://twitter.com/jamiebxne/status/1414973623203467271