### PR TITLE
Included scam site beefy.financial in blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -16,7 +16,6 @@
     "makerfoundation.com",
     "fulcrum.trade",
     "launchpad.ethereum.org"
-
   ],
   "whitelist": [
     "vcinity.io",

--- a/src/config.json
+++ b/src/config.json
@@ -16,7 +16,7 @@
     "makerfoundation.com",
     "fulcrum.trade",
     "launchpad.ethereum.org"
-    
+
   ],
   "whitelist": [
     "vcinity.io",
@@ -13309,6 +13309,7 @@
     "polkastarter.world",
     "polkastarter.ltd",
     "polkaslarter.com",
-    "polkastarter.cn.com"
+    "polkastarter.cn.com",
+    "beefy.financial"
   ]
 }


### PR DESCRIPTION
This scam site advertises itself via Google Ads. The site itself imitates the legit DeFi site beefy.finance. Once you launch the "app" site, it asks to connect to your wallet, and after you've chosen your wallet type, it opens a popup window with a mock design intended to look like the wallet extension and asks for your seed phrase, which of course would give the scammers full ownership of your wallet.

[https://urlscan.io/result/71649a8d-ce8f-4a25-a866-6abe05cb5dd6/](https://urlscan.io/result/71649a8d-ce8f-4a25-a866-6abe05cb5dd6/)

![beefy_financial_scam_site](https://user-images.githubusercontent.com/87582564/126048208-87e91d97-9b66-46ac-ab4b-fc4ecb3eda05.jpg)


![beefy_scam_seed_phrase_resized](https://user-images.githubusercontent.com/87582564/126048328-69e77ca7-b98e-41bc-a7b1-d352142a1fc9.jpg)
