### PR TITLE
deny: raydium.us

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -739,6 +739,7 @@
     "nfinity.space"
   ],
   "blacklist": [
+    "raydium.us",
     "poncakeswap.center",
     "contactmetamask.com",
     "walletvalidation.info",


### PR DESCRIPTION
# phishing user to download exe

https://raydium.us/dowland.php 302 to https://raydium.us/download/Raydium-App-v2.1.1.exe

# dns resolve

185.212.130.16 now
50.63.202.58 history

# virustotal detection

https://www.virustotal.com/gui/file/4977973c03c8178b643b88e114ca7c477a1863dc9c9d912ef3927f90e4a36c1d/detection

# exe http requests

https://backupcost.gq/liverpool-fc-news/features/steven-gerrard-liverpool-future-dalglish--goal-30D5CFAFEC1D06F3E4FD121BD7DA467F.html

# some domains exist in the following list

https://blocklistproject.github.io/Lists/alt-version/ads-nl.txt

- scripts.webcontentassessor.com
- indexww.com
- etc..