### PR TITLE
Another Cryptopunks phishing site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -804,6 +804,7 @@
     "maticwallets.net",
     "larvalab.io",
     "larvalabs.to",
+    "larvalabs.me",
     "metamask-io.online",
     "multicoin-wallet.org",
     "validate.multicoin-wallet.org",


### PR DESCRIPTION
Another one similar to #5234.

These are likely going to keep getting set up, would it be preferable or reasonable to add larvalabs.com to the fuzzy list instead? I'm not quite sure how that works, let me know though.

Thanks!