### PR TITLE
Added atus.ch to whitelist. Closes #5056.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -18,6 +18,7 @@
     "launchpad.ethereum.org"
   ],
   "whitelist": [
+    "atus.ch",
     "vcinity.io",
     "vcinity.org",
     "vcinity.com",


### PR DESCRIPTION
As mentioned in the issue #5056, Atus has no ties to Ethereum or Cryptos in general.