### PR TITLE
sushi-swap.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -742,6 +742,7 @@
     "caucus.so"
   ],
   "blacklist": [
+    "sushi-swap.net",
     "sushicom.site",
     "app.sushicom.site",
     "myewetlhervwallet.com",


### PR DESCRIPTION
sushi-swap.net
Fake Sushiswap site hosting malware (sha256sum 3cf56a5ef3afb3091c824dd517c2526c352bc46ee5bc7384d385b3523a30693a)
https://urlscan.io/result/7586d7c3-06ed-47f1-92e9-a0ce031a7463/
https://urlscan.io/result/4b0aa109-ecbc-4801-8e66-8d2d7d8274c3/