### PR TITLE
airdrop scam BEP20 token allowance

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -742,6 +742,7 @@
     "caucus.so"
   ],
   "blacklist": [
+    "veranet.info",
     "thevera.io",
     "vera.io",
     "theever.io",


### PR DESCRIPTION
This airdrop scam asks for unlimited BEP20 token allowance to steal user's funds.

Related to: https://github.com/MetaMask/eth-phishing-detect/pull/5265