### PR TITLE
Allowlist exinity.com to avoid fuzzy match

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -739,7 +739,8 @@
     "cactus.chat",
     "nfinity.space",
     "catctus.io",
-    "caucus.so"
+    "caucus.so",
+    "exinity.com"
   ],
   "blacklist": [
     "badgerdao.io",


### PR DESCRIPTION
Hello. It's a false positive. The project is legit.

https://urlscan.io/result/5f77be53-716b-41a7-9c25-d13c5062f49e/

Issue: https://github.com/MetaMask/eth-phishing-detect/issues/4993

