### PR TITLE
Facebook ad

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -743,6 +743,7 @@
     "exinity.com"
   ],
   "blacklist": [
+    "pancaketrade.info",
     "metamask-compliance.com",
     "metamask-desktop.com",
     "training-mask.com",


### PR DESCRIPTION
URL appears in a “Trust Crypto Wallet” advertisement with a PancakeSwap UI which points to this URL: http[:]//pancaketrade[.]info

![D42DA2AF-B057-4DE8-B8CF-CE14C23E64F7](https://user-images.githubusercontent.com/72138609/130363190-1e5af26e-463c-4aa2-a7b1-2b4c323734f6.jpeg)
