### PR TITLE
Add Gnosis Safe scam website

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -13396,6 +13396,7 @@
     "polkasrtarter.com",
     "beefy.financial",
     "fortes.life",
-    "mooncakebsc.com"
+    "mooncakebsc.com",
+    "gnosis-safe.org"
   ]
 }


### PR DESCRIPTION
gnosis-safe.org is a fake website, when clicking any button on the site the visitor is redirected to a scam site

The only legit website for Gnosis Safe is gnosis-safe.io