### PR TITLE
Added altus.cr, altus.co.cr, altus.one and altus.global to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -18,6 +18,10 @@
     "launchpad.ethereum.org"
   ],
   "whitelist": [
+    "altus.cr",
+    "altus.co.cr",
+    "altus.one",
+    "altus.global",
     "atus.ch",
     "vcinity.io",
     "vcinity.org",

--- a/src/config.json
+++ b/src/config.json
@@ -19,7 +19,6 @@
   ],
   "whitelist": [
     "altus.cr",
-    "altus.co.cr",
     "altus.one",
     "altus.global",
     "atus.ch",


### PR DESCRIPTION
Domains altus.cr, altus.co.cr, altus.one and altus.global are being incorrectly flagged as phishing sites due to similarity with auctus.org.

My company, Altus Consulting, based in Costa Rica, owns all these domains and we have nothing to do with the crypto industry. We need these domains to be whitelisted as many our customers are unable to access our web site, especially after the growing adoption of MetaMask.

Thanks in advance.