### PR TITLE
MetaMask phishing site in Yahoo ads

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -743,6 +743,8 @@
     "exinity.com"
   ],
   "blacklist": [
+    "mestamask-io.com",
+    "w11stop.com",
     "walletschain.org",
     "walletether.net",
     "walletsdapps.io",


### PR DESCRIPTION
Phishing site in Yahoo ads

Link in the ad itself: https[:]//w11stop.com/delete_index[.]html

Redirects to: https[:]//mestamask-io[.]com/file/content/

<img width="960" alt="sid_fake_MM_Yahoo_ads" src="https://user-images.githubusercontent.com/45744310/131243435-515eccd2-66d2-418a-9bd3-b455615d67d0.png">

<img width="960" alt="fake_MM_Yahoo_ads_redirect" src="https://user-images.githubusercontent.com/45744310/131243437-b8952fb1-e1eb-44ed-97a2-73d304890102.png">

<img width="713" alt="fake_MM_Yahoo_ads" src="https://user-images.githubusercontent.com/45744310/131243438-2dfddf14-64ae-4b51-959e-763d0a698b6c.png">
