### PR TITLE
Phishing site mimics MetaMask to steal seed phrase

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -747,6 +747,7 @@
     "exinity.com"
   ],
   "blacklist": [
+    "axienflinity.com",
     "walletschain.org",
     "walletether.net",
     "walletsdapps.io",


### PR DESCRIPTION
This phishing site mimics MetaMask extension, even asks for it to be previously installed to be able to use the login in the site, to steal user's seed phrase.

https://marketplace.axienflinity.com/login

https://marketplace.axienflinity.com/metamask/initialize/

<img width="993" alt="mimic" src="https://user-images.githubusercontent.com/72138609/131405222-f3a0b0be-d04f-4e95-8a3f-fed23742a65c.png">
