### PR TITLE
30/8/2021 Respond to A Handful of Issues

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -751,10 +751,10 @@
     "factus.ru",
     "etherscene.com",
     "metamash.io",
-    "cactus.black"
+    "cactus.black",
+    "amatus.capital"
   ],
   "blacklist": [
-    "amatus.capital",
     "axielinfinity.com",
     "axieinfinitypage.one",
     "skymaviswalletupdate.com",

--- a/src/config.json
+++ b/src/config.json
@@ -754,6 +754,7 @@
     "cactus.black"
   ],
   "blacklist": [
+    "amatus.capital",
     "axienflinity.com",
     "dapp-walletsconnect.com",
     "metamask.io-updated.app",

--- a/src/config.json
+++ b/src/config.json
@@ -744,7 +744,14 @@
     "nfinity.space",
     "catctus.io",
     "caucus.so",
-    "exinity.com"
+    "exinity.com",
+    "markeeta.sk",
+    "markeeta.cz",
+    "cryptoknitties.io",
+    "factus.ru",
+    "etherscene.com",
+    "metamash.io",
+    "cactus.black"
   ],
   "blacklist": [
     "t-opensea.io",
@@ -3411,7 +3418,6 @@
     "blokchiain.com",
     "vitaliketh.com",
     "hoxbit.com",
-    "free-ethereum.io",
     "elon.market",
     "tmdl3.online",
     "multisupport.live",

--- a/src/config.json
+++ b/src/config.json
@@ -3426,6 +3426,7 @@
     "blokchiain.com",
     "vitaliketh.com",
     "hoxbit.com",
+    "free-ethereum.io",
     "elon.market",
     "tmdl3.online",
     "multisupport.live",


### PR DESCRIPTION
The following easy-to-resolve issues came up in the last week:

These sites were incorrectly fuzzy-listed:
1. `markeeta.sk` and `markeeta.cz`  https://github.com/MetaMask/eth-phishing-detect/issues/5343
2. `cryptoknitties.io` - cardano nfts! https://github.com/MetaMask/eth-phishing-detect/issues/5339
3. `factus.ru` https://github.com/MetaMask/eth-phishing-detect/issues/5337
4. `etherscene.com` https://github.com/MetaMask/eth-phishing-detect/issues/5335
5. `metamash.io` https://github.com/MetaMask/eth-phishing-detect/issues/5318
6. `cactus.black` https://github.com/MetaMask/eth-phishing-detect/issues/5305
7. `amatus.capital` https://github.com/MetaMask/eth-phishing-detect/issues/5290

~~This site was `denylisted`/`blacklisted` however there is a lot of user feedback saying that this was incorrectly added to the denylist:~~
~~`free-ethereum.io` https://github.com/MetaMask/eth-phishing-detect/issues?q=is%3Aissue+is%3Aopen+free%3Dethereum~~