### PR TITLE
add gnosis-airdrop.live to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -13428,6 +13428,7 @@
     "beefy.financial",
     "fortes.life",
     "mooncakebsc.com",
-    "gnosis-safe.org"
+    "gnosis-safe.org",
+    "gnosis-airdrop.live"
   ]
 }


### PR DESCRIPTION
gnosis-airdrop.live is a fake website, when clicking SmartContract button on the site the visitor is redirected to a scam GNO contract on Binance Chain.

The only legit website for Gnosis is gnosis.io.