### PR TITLE
Phishing site in Google ads results

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -5376,6 +5376,7 @@
     "xn--myethrwllet-q7a1340h.com",
     "xn--trzor-7za.net",
     "xn--trzor-csa.com",
+    "xn--trzor-csa.co",
     "toke.online",
     "binancexrpjan.blogspot.com",
     "ethercontest.com",


### PR DESCRIPTION
xn--trzor-csa[.]co ( trézor[.]co )

https://urlscan.io/result/fe2f34db-96e0-44f2-8b39-1686e91ba62a/

<img width="960" alt="fake_trezor" src="https://user-images.githubusercontent.com/72138609/131906720-bffa1094-9b37-4aed-8978-42d0a4a210d3.png">
