### PR TITLE
Add "victus.finance" to the whitelist.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -372,6 +372,7 @@
     "gocrypto.bet",
     "scrypto.club",
     "victus.gg",
+    "victus.finance",
     "mycryptoro.com",
     "infinity.black",
     "nactus.com",


### PR DESCRIPTION
Issue was raised earlier but I read that PRs are reviewed quicker, my website has been blacklisted due to similarity to "auctus.org". I don't bear any connection with them, this is my own site and isn't fraudulent.

Thanks for reviewing!

#5364 