### PR TITLE
Revert #5373

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -760,7 +760,7 @@
   "blacklist": [
     "pancakeswap.finance.delivery",
     "import-mestamask.com",
-    "com.ng",
+    "tridoknigeria.com.ng",
     "metasmasks.io",
     "syncwalletlivetokenrestore.org",
     "dappsconnects.net",


### PR DESCRIPTION
This reverts https://github.com/MetaMask/eth-phishing-detect/pull/5417. Lots of issues in the past day were due to the `com.ng` blacklist. It seems like this is a common top-level domain. 