### PR TITLE
akswap.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -759,6 +759,7 @@
     "nfinite.app"
   ],
   "blacklist": [
+    "akswap.net",
     "restore-wallet.online",
     "dapps-plug.com",
     "akswap.io",


### PR DESCRIPTION
akswap.net
Fake airdrop site phishing for user funds - same campaign as https://github.com/MetaMask/eth-phishing-detect/pull/5437
https://urlscan.io/result/3c27da88-39bc-4e46-b2aa-ae1c20e6de79/