### PR TITLE
adding airdrop scam

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -759,6 +759,7 @@
     "nfinite.app"
   ],
   "blacklist": [
+    "shibadrop.io",
     "fluxchain.net",
     "akswap.net",
     "restore-wallet.online",


### PR DESCRIPTION
Seen here in this acct:

https://bscscan.com/address/0xf23068e62bce0ce1d63dad05b35acff9c9f460e4#tokentxns

https://bscscan.com/token/0xab57aef3601cad382aa499a6ae2018a69aad9cf0?a=0xf23068e62bce0ce1d63dad05b35acff9c9f460e4


This is an airdrop scam impersonating shiba swap. URLscan confirms this.