### PR TITLE
airdrop scam again

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -759,6 +759,7 @@
     "nfinite.app"
   ],
   "blacklist": [
+    "aaexchange.io",
     "fluxchain.net",
     "akswap.net",
     "restore-wallet.online",


### PR DESCRIPTION
adding airdrop scam token, urlscan and sandbox indicate it directs to fake phishing site designed to steal secrets

see airdrops here:

https://bscscan.com/token/0x7d9c3bd1eb0b0a8921fab9c57e26e05518d87b4d