### PR TITLE
zepe.vip

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -759,6 +759,7 @@
     "nfinite.app"
   ],
   "blacklist": [
+    "zepe.vip",
     "walletconnectrestore.io",
     "ff9.info",
     "shibadrop.io",


### PR DESCRIPTION
zepe.vip
Malicious site scamming users from an airdrop
https://urlscan.io/result/79cc97cb-b030-40ec-acc8-e065e4d90199/