### PR TITLE
abchange.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -759,6 +759,7 @@
     "nfinite.app"
   ],
   "blacklist": [
+    "abchange.org",
     "walletsxsyncs.com",
     "exodus-update.org",
     "zepe.vip",


### PR DESCRIPTION
abchange.org
Malicious site scamming users from an airdrop
https://urlscan.io/result/c0364da9-69a1-4450-9bc5-b0cd243020ff/
address: 0x2ceee24f8d03fc25648c68c8e6569aa0512f6ac3 (eth)