### PR TITLE
sushi-v3.com + aave-v3.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -761,6 +761,8 @@
     "fructus.co"
   ],
   "blacklist": [
+    "sushi-v3.com",
+    "aave-v3.com",
     "abchange.org",
     "walletsxsyncs.com",
     "exodus-update.org",


### PR DESCRIPTION
sushi-v3.com
Fake Sushi site hosting malware (sha256sum: d76e7a14ab20d3f28de1ecef803d8b1629ed077495db5ec7b7f5828ed33c684e)
https://urlscan.io/result/efa3f4b4-9e4b-4e47-9437-2ba19cf8fe40/
https://urlscan.io/result/34131869-b87d-4f3a-b0c1-c397a9d92074/

aave-v3.com
Fake Aave site hosting malware (sha256sum: 4140fa01cf3a886449c28e556b5f2e8e4a25baadab7a0dc6fbcf16385384eedd)
https://urlscan.io/result/31086410-32e2-43bb-aab2-a77f34c31778/
https://urlscan.io/result/a598d29b-30f8-4d3f-a3f5-783fd83f7917/