### PR TITLE
Reporting Airdrop scam token

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -763,6 +763,7 @@
     "fructus.co"
   ],
   "blacklist": [
+    "nestfin.net",
     "authenticate-dapps.com",
     "openisea.com",
     "palmsync.io",


### PR DESCRIPTION
https://urlscan.io/result/7ce3e56b-8436-4832-a253-30a8783d6f70/

Indicates Airdrop scam token.

Also reported as scam in ZD 344702