### PR TITLE
Add Openswap.one to the allowlist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -51,6 +51,7 @@
     "myetpwallet.com",
     "fulcrum.rocks",
     "mycrpro.com",
+    "openswap.one",
     "ycryptos.com",
     "mrcrypto.space",
     "mrcrypto.me",


### PR DESCRIPTION
Related to issue #5480   . Add https://openswap.one to allowlist .

Alex, dev for OpenSwap, opened 5480 and included additional information there.

