### PR TITLE
Add metadash.app to allowlist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -760,7 +760,8 @@
     "amatus.capital",
     "nfinite.app",
     "fructus.xyz",
-    "fructus.co"
+    "fructus.co",
+    "metadash.app"
   ],
   "blacklist": [
     "nestfin.net",


### PR DESCRIPTION
Metadash is a cloud SaaS product, no connection to crypto/ETH/Metamask. Thanks.