### PR TITLE
Add Lifinity.io to white list

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -760,7 +760,8 @@
     "amatus.capital",
     "nfinite.app",
     "fructus.xyz",
-    "fructus.co"
+    "fructus.co",
+    "lifinity.io"
   ],
   "blacklist": [
     "nestfin.net",


### PR DESCRIPTION
Lifinity is a DEX on Solana. We are temporarily using a different URL to avoid this issue, but would like to change it back ASAP.