### PR TITLE
Facebook ad with phishing site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -763,6 +763,7 @@
     "fructus.co"
   ],
   "blacklist": [
+    "finance.parts",
     "nestfin.net",
     "authenticate-dapps.com",
     "openisea.com",


### PR DESCRIPTION
Both URLs in the phishing ad point to a fake Pancakeswap site.

The Facebook ad shows the real Pancakeswap URL apparently because Facebook let the advertiser set it as custom or shows only the subdomain part.

![C2DFD3E1-ECCF-46E2-BB28-E42765189A30](https://user-images.githubusercontent.com/2995401/134956322-901e655b-c224-4742-b736-6d01d49762ce.jpeg)

![829D20F4-E65B-4A30-A48A-AFA66E977AD4](https://user-images.githubusercontent.com/2995401/134956333-b92f6db5-a41b-47f7-a6bb-f56c1608a44e.jpeg)

![E755A3E8-8737-4B06-A36C-32B2E787B91C](https://user-images.githubusercontent.com/2995401/134956336-4e7f7cd0-aa67-4cba-9013-cbf427940f6a.jpeg)

![6C8DB219-D9F0-4030-8CCA-B7AF9AA9489D](https://user-images.githubusercontent.com/2995401/134956339-572a3715-4107-4948-95cc-10ddcc52943a.jpeg)
