### PR TITLE
Adding new Airdrop scam URLs

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -764,6 +764,8 @@
     "fructus.co"
   ],
   "blacklist": [
+    "xch5.net",
+    "xch5.org",
     "finance.parts",
     "nestfin.net",
     "authenticate-dapps.com",


### PR DESCRIPTION
Reported in ZD 354949, also reported as scam on the block explorer comments:

https://bscscan.com/address/0x4827405d992d4d42f9ff4bb9d13ec9b616a75278#comments

https://urlscan.io/result/4bbc2148-573b-4f80-ac97-9506ad37f74c/