### PR TITLE
Add fake/ scam boredapeyachtclub url  

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -792,6 +792,7 @@
     "www.openswap.xyz"
   ],
   "blacklist": [
+    "boredapeyachtclub.app",
     "akswap.info",
     "exsoddus.online",
     "opensea.fo",

--- a/src/hosts.txt
+++ b/src/hosts.txt
@@ -1069,3 +1069,4 @@
 0.0.0.0 curve.so
 0.0.0.0 curvefi.io
 0.0.0.0 curwe.fi
+0.0.0.0 boredapeyachtclub.app


### PR DESCRIPTION
The following url https://boredapeyachtclub.app is being used to trick people into buying genuine https://boredapeyachtclub.com NFT's

Please merge this in to prevent metamask users loss of funds