### PR TITLE
adding two new BSC Airdrop scams

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -792,6 +792,10 @@
     "www.openswap.xyz"
   ],
   "blacklist": [
+    "linkp.io",
+    "linkmp.org",
+    "tu7.org",
+    "tu7.io",
     "boredapeyachtclub.app",
     "akswap.info",
     "exsoddus.online",


### PR DESCRIPTION
tu7 reported in ZD 364403

https://urlscan.io/result/e278ffe9-b7f5-4fc6-831f-c761793aaff0/

Urlscan indicates it is a scam.

linkp reported in ZD 372125 amongst others

https://urlscan.io/result/b23eb911-abda-4790-ad1e-e559250fed30/

URLscan also indicates it is a scam