### PR TITLE
Add scam/fake beefyfinance url to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -793,6 +793,7 @@
   ],
   "blacklist": [
     "boredapeyachtclub.app",
+    "app-beefy.finance",
     "akswap.info",
     "exsoddus.online",
     "opensea.fo",


### PR DESCRIPTION
Added the phishing scam site app-beefy.finance to the blacklist.
scam window: https://app-beefy.finance/metamask/index
url scan: https://urlscan.io/result/67bb8654-282d-4663-8d98-a7cadf6d988e/