### PR TITLE
Add 3 phishing scam sites to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -793,6 +793,9 @@
   ],
   "blacklist": [
     "boredapeyachtclub.app",
+    "moonpotrewards.com",
+    "beefy-finance.com",
+    "apps-beefy.finance",
     "app-beefy.finance",
     "akswap.info",
     "exsoddus.online",

--- a/src/config.json
+++ b/src/config.json
@@ -793,6 +793,7 @@
   ],
   "blacklist": [
     "boredapeyachtclub.app",
+    "app-beefy.finance",
     "akswap.info",
     "exsoddus.online",
     "opensea.fo",


### PR DESCRIPTION
phishing site 1: beefy-finance.com
scam window: https://beefy-finance.com/connect/metamask/index
url scan: https://urlscan.io/result/420ac81a-6ba8-46dd-85c6-2403a011eb7b/

phishing site 2: apps-beefy.finance
scam window: https://apps-beefy.finance/metamask/index
url scan: https://urlscan.io/result/1cac957d-e4f7-4d7a-9e57-cc87af9181f7/

phishing site 3: moonpotrewards.com
scam window: click connect wallet (scam window is a popunder)
url scan: https://urlscan.io/result/a1b77ee8-a7d1-4d6e-8692-4f6f4e373a56/