### PR TITLE
Add collabs.land to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -793,6 +793,7 @@
     "openseal.ch"
   ],
   "blacklist": [
+    "collabs.land",
     "optimusm.io",
     "linkp.io",
     "linkmp.org",


### PR DESCRIPTION
**collabs.land** is a phising website.
 **collab.land** is the legitimate one.