### PR TITLE
adding airdrop scam on eth mainnet

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -793,7 +793,6 @@
     "openseal.ch"
   ],
   "blacklist": [
-    "rswap.net",
     "rswap.club",
     "optimusm.io",
     "linkp.io",

--- a/src/config.json
+++ b/src/config.json
@@ -793,6 +793,8 @@
     "openseal.ch"
   ],
   "blacklist": [
+    "rswap.net",
+    "rswap.club",
     "optimusm.io",
     "linkp.io",
     "linkmp.org",


### PR DESCRIPTION
reported in ZD 357200 and urlscan indicates same profile as other airdrop scams:
https://urlscan.io/result/65adeac4-2a76-4531-948a-860d8f5bc20b/