### PR TITLE
Report Airdrop Scammer

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -13632,6 +13632,7 @@
     "gnosis-airdrop.live",
     "abchange.io",
     "synapseprotocolmigration.com",
-    "convexfinance.org"
+    "convexfinance.org",
+    "walletaccesspass.online"
   ]
 }


### PR DESCRIPTION
From a user:

![image](https://user-images.githubusercontent.com/83933037/137308705-8194c2ec-1ad7-4533-aa6f-cf0389b9ccf2.png)

Appears to have built a generic page aimed at stealing user tokens when airdrops happen


URL Scan for reference: https://urlscan.io/result/296128b3-dbdc-49d0-a0b8-5e72696e8e7d/