### PR TITLE
ethereum-announce.net + univswap.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -793,6 +793,8 @@
     "openseal.ch"
   ],
   "blacklist": [
+    "ethereum-announce.net",
+    "univswap.org",
     "rswap.club",
     "optimusm.io",
     "linkp.io",


### PR DESCRIPTION
ethereum-announce.net
Trust trading scam site
https://urlscan.io/result/40bf4175-f1e9-444c-bd73-6fc23ddddb5c/
https://urlscan.io/result/19e37972-9068-4f6c-89c2-1e173638b8e2/
address: 0x41A23374CD3460461CF4F628cB20Cde4b2fec934 (eth)

univswap.org
Fake uniswap site phishing for funds
https://urlscan.io/result/4a80ea37-8883-46c0-b507-c2d8dc1dab8e/
address: 0x9c166c4dfC6fc1a9322cd6cD1dfDA004E9E695cD (eth)