### PR TITLE
live-drop.net + swap7.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -822,6 +822,8 @@
     "openseal.ch"
   ],
   "blacklist": [
+    "live-drop.net",
+    "swap7.io",
     "dappsbrowser.online",
     "pancakeswap-dapps.com",
     "collab.land.io-invest.org",


### PR DESCRIPTION
live-drop.net
Trust trading scam site
https://urlscan.io/result/38dc1069-0aec-45cc-8b6b-42d0e8ad2708/
https://urlscan.io/result/6abd8776-6e67-413d-980d-7f398c94d907/
https://urlscan.io/result/d2dce5de-1ba4-4403-95da-81907398c77b/
https://urlscan.io/result/bed38f7c-d0d3-48f3-ab99-f6c32922cedd/

swap7.io
Malicious airdrop site phishing for funds
https://urlscan.io/result/27b19535-e462-4007-943a-687506f1073e/
address: 0x02DadC91DACa7c058004d4882D2D7825705e5d56 (eth)