### PR TITLE
Adding Airdrop Scam token

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -822,6 +822,7 @@
     "openseal.ch"
   ],
   "blacklist": [
+    "swap7.org",
     "pancakeswap-dapps.com",
     "collab.land.io-invest.org",
     "app-beefy.com",


### PR DESCRIPTION
Reported in ZD 457005 amongst others

comments show scam:

https://bscscan.com/address/0x5e48c354a5da2b0a8c203518d0fc7b9c58cc9329#comments