### PR TITLE
Removing wrongly blocked sites gaiaworld and unilayer

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -823,9 +823,6 @@
   ],
   "blacklist": [
     "swap7.org",
-    "gaiaworld.com",
-    "unilayer.app",
-    "unilayer.com",
     "live-drop.net",
     "swap7.io",
     "dappsbrowser.online",


### PR DESCRIPTION
I cannot find any evidence that these were phishing sites, and the reason for their blocking was not easily found in issues or PRs. They have many requests coming in for wrongful blocking.

I can see they were all added 15 hours ago yesterday here:
https://github.com/MetaMask/eth-phishing-detect/pull/5765

No evidence was provided at that time but the PR was approved.