### PR TITLE
Allowlist audius.party, opensea.institute, openset.co

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -29,6 +29,7 @@
     "opensig.org",
     "opena.tv",
     "opener.pl",
+    "openset.co",
     "eap.gr",
     "open.eap.gr",
     "ua.edu",

--- a/src/config.json
+++ b/src/config.json
@@ -29,6 +29,7 @@
     "opensig.org",
     "opena.tv",
     "opener.pl",
+    "opensea.institute",
     "openset.co",
     "eap.gr",
     "open.eap.gr",

--- a/src/config.json
+++ b/src/config.json
@@ -20,6 +20,7 @@
   ],
   "whitelist": [
     "aubtu.biz",
+    "audius.party",
     "aulus.org",
     "openscad.info",
     "noctus.cc",


### PR DESCRIPTION
Fixes #4538.
Fixes #5898.
Fixes #5900.
Fixes #5901.
Fixes #5904.

## audius.party
Discord bot information page.

## openset.co
Dataset site? Not relevant to cryptocurrency scams.

## opensea.institute
Psychiatric services.