### PR TITLE
wallettconnect.co + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -860,6 +860,10 @@
     "openseal.ch"
   ],
   "blacklist": [
+    "wallettconnect.co",
+    "amazon.tokenpre.sale",
+    "tokenpre.sale",
+    "the-guardian.news",
     "alpacafninance.com",
     "idapps-tokens.com",
     "crypto.e-access.host",

--- a/src/config.json
+++ b/src/config.json
@@ -860,6 +860,7 @@
     "openseal.ch"
   ],
   "blacklist": [
+    "unlockinglocation.buzz",
     "wallettconnect.co",
     "amazon.tokenpre.sale",
     "tokenpre.sale",


### PR DESCRIPTION
wallettconnect.co
Fake WalletConnect site phishing for secrets with POST api.php
https://urlscan.io/result/5d366107-c601-436c-8f0b-75604faab7e7/
https://urlscan.io/result/1bead6e0-0612-4586-a285-63e17259920a/

amazon.tokenpre.sale
Fake Amazon tokensale
https://urlscan.io/result/fdf77d5d-7f53-4d53-bc92-578502b24eeb/
https://urlscan.io/result/5f14646e-33fa-437d-b059-6e3b31c16e30/

the-guardian.news
Fake Guardian website promoting fake ICO
https://urlscan.io/result/c3f1935d-54bc-459b-9094-ff4022238783/

unlockinglocation.buzz
Fake MetaMask site phishing for secrets with POST /metamask/send.php
https://urlscan.io/result/c1cbb5a1-0688-4587-b7fd-cbacbfaa52b1/
https://urlscan.io/result/c81412b4-90c9-49bf-a4da-f3dca7b08fae/
https://urlscan.io/result/c1cbb5a1-0688-4587-b7fd-cbacbfaa52b1/