### PR TITLE
Block io-ledge.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -863,6 +863,7 @@
   "blacklist": [
     "unlockinglocation.buzz",
     "wallettconnect.co",
+    "io-ledge.com",
     "amazon.tokenpre.sale",
     "tokenpre.sale",
     "the-guardian.news",


### PR DESCRIPTION
Seems to be part of an SMS phishing campaign directed at people who were included in the Ledger user database leak.

<img width="896" alt="Screen Shot 2021-11-21 at 7 53 34 PM" src="https://user-images.githubusercontent.com/542863/142798717-b3c50438-6b36-4212-97e0-1973cad05740.png">

