### PR TITLE
Allowlist 10 websites (2021-11-29)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -49,6 +49,7 @@
     "openseas.gr",
     "metamart.space",
     "metamilk.xyz",
+    "metamusk.eu",
     "meta-musk.com",
     "metamosa.io",
     "metaoak.com",

--- a/src/config.json
+++ b/src/config.json
@@ -27,6 +27,7 @@
     "audius.party",
     "aulus.org",
     "fulcrum.org",
+    "fulcrum7.com",
     "cryptotitties.xyz",
     "cutus.in",
     "metapass.ml",

--- a/src/config.json
+++ b/src/config.json
@@ -841,6 +841,7 @@
     "metabase.cc",
     "metabase.one",
     "metabase.network",
+    "metabase.studio",
     "decrypto.net",
     "audius.co",
     "audius.org",

--- a/src/config.json
+++ b/src/config.json
@@ -26,6 +26,7 @@
     "aubtu.biz",
     "audius.party",
     "aulus.org",
+    "befinity.media",
     "fulcrum.org",
     "fulcrum7.com",
     "cryptotitties.xyz",

--- a/src/config.json
+++ b/src/config.json
@@ -836,6 +836,7 @@
     "remme.io",
     "jibrel.network",
     "twinity.com",
+    "metabase.art",
     "metabase.com",
     "metabase.cc",
     "metabase.one",

--- a/src/config.json
+++ b/src/config.json
@@ -31,6 +31,8 @@
     "cryptotitties.xyz",
     "cutus.in",
     "metapass.ml",
+    "openeo.cloud",
+    "openeo.org",
     "opensig.org",
     "opensit.net",
     "openseas.com",

--- a/src/config.json
+++ b/src/config.json
@@ -37,6 +37,7 @@
     "opensit.net",
     "openseas.com",
     "openmha.org",
+    "opensoc.pl",
     "cactus.cards",
     "flarum.it",
     "infinity.irish",

--- a/src/config.json
+++ b/src/config.json
@@ -51,6 +51,8 @@
     "metamilk.xyz",
     "meta-musk.com",
     "metamosa.io",
+    "metaoak.com",
+    "metaoak.xyz",
     "metapass.world",
     "openex.io",
     "opengear.tv",


### PR DESCRIPTION
## befinity.media
Fixes #6012.

Doesn't appear to be related to cryptocurrency.

## fulcrum7.com
Fixes #5997.

Doesn't appear to be related to cryptocurrency.

## metabase.art
Fixes #6003.

Not visually similar to MetaMask.

## metabase.studio
Fixes #6005.
Fixes #6014.
Fixes #6017.
Fixes #6018.
Fixes #6020.
Fixes #6021.
Fixes #6022.
Fixes #6032.
Fixes #6039.

Not visually similar to MetaMask.

## metamusk.eu
Fixes #6015.

Doesn't appear to be a phishing site.

## metaoak.com, metaoak.xyz
Fixes #6011.

Not visually similar to MetaMask.

## openeo.cloud, openeo.org
Fixes #5998.

Not visually similar to opensea.io.

## opensoc.pl
Fixes #5999.

Doesn't appear to be related to cryptocurrency.

