### PR TITLE
Adding ethspecial21.com + free-eth.org to scam list

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -884,6 +884,7 @@
     "metamarc.io"
   ],
   "blacklist": [
+    "ethspecial21.com",
     "fixwallettoken.com",
     "meta-giveway.io",
     "walletapisync.com",

--- a/src/config.json
+++ b/src/config.json
@@ -884,6 +884,7 @@
     "metamarc.io"
   ],
   "blacklist": [
+    "free-eth.org",
     "ethspecial21.com",
     "fixwallettoken.com",
     "meta-giveway.io",


### PR DESCRIPTION
This site is actively being used in a YouTube phishing campaign.  Uses the classic "send ETH, get ETH" scam tactic.