### PR TITLE
Block lyra[dot]sale active phishing/scam site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -13883,6 +13883,7 @@
     "sfar.io",
     "optimism.trade",
     "cowswap.sale",
-    "metamask-wallet-security.web.app"
+    "metamask-wallet-security.web.app",
+    "lyra.sale"
   ]
 }


### PR DESCRIPTION
lyra[dot]sale is actively phishing and is unrelated to https://lyra.finance/ (the legit site)