### PR TITLE
Add openpa.net to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -111,6 +111,7 @@
     "openia.ae",
     "opener.aero",
     "opendex.network",
+    "openpa.net"
     "punctus.org",
     "openges.es",
     "metamade.io",

--- a/src/config.json
+++ b/src/config.json
@@ -111,7 +111,7 @@
     "openia.ae",
     "opener.aero",
     "opendex.network",
-    "openpa.net"
+    "openpa.net",
     "punctus.org",
     "openges.es",
     "metamade.io",


### PR DESCRIPTION
Appears to have no reason to be blocked; harmless website for documenting a brand of PC workstations.