### PR TITLE
adding phishing site/airdrop scam token sites

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -907,6 +907,9 @@
     "metapass.fyi"
   ],
   "blacklist": [
+    "apesinspace.app",
+    "pownft.net",
+    "pownft.pro",
     "meta-recovery-phrase.com",
     "blockchain-tool.org",
     "connecttodapps.ga",

--- a/src/config.json
+++ b/src/config.json
@@ -908,7 +908,6 @@
   ],
   "blacklist": [
     "apesinspace.app",
-    "pownft.net",
     "pownft.pro",
     "meta-recovery-phrase.com",
     "blockchain-tool.org",


### PR DESCRIPTION
ZD 597096. see URLSCAN for pownft, and etherscan page:

https://urlscan.io/result/7b3c86dd-c456-4165-a243-ccb06b85d00a/

https://bscscan.com/address/0x893C25C46bFAa9b66Cd557837D32Af3FE264a07b#comments