### PR TITLE
WhiteList Pinksale.finance

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -13920,6 +13920,6 @@
     "optimism.trade",
     "cowswap.sale",
     "metamask-wallet-security.web.app",
-    "lyra.sale",
+    "lyra.sale"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -19,7 +19,6 @@
     "launchpad.ethereum.org"
   ],
   "whitelist": [
-    "pinksale.finance",
     "sanctus.audio",
     "affinity.solutions",
     "actis.no",

--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "launchpad.ethereum.org"
   ],
   "whitelist": [
+    "pinksale.finance",
     "sanctus.audio",
     "affinity.solutions",
     "actis.no",
@@ -13921,6 +13922,5 @@
     "cowswap.sale",
     "metamask-wallet-security.web.app",
     "lyra.sale",
-    "pinksale.finance"
   ]
 }


### PR DESCRIPTION
Hello all,

First, welcome to decentralized platform.
I would like to kindly ask you to remove Pinksale from blacklist.
I saw some Screenshots in this topic but in the group there are more than 50K members and it's almost impossible to audit 1 by 1 all the Launchpads. BUT you have to know that Pinksale Owners recently started a SCAMLESS, RUGLESS project where a firm is reporting SCAM and RUGS with real reason and Proof. If the reason is valable then the launchpad is cancelled.

![image](https://user-images.githubusercontent.com/95449573/145304720-e41aecda-90b8-4691-8e74-11903195cdc3.png)

![image](https://user-images.githubusercontent.com/95449573/145304751-eb899359-4ed3-4009-bdc1-539576339fb8.png)

![image](https://user-images.githubusercontent.com/95449573/145304767-2c5c3315-ce52-480f-b01b-da49aa990a8c.png)

![image](https://user-images.githubusercontent.com/95449573/145304783-79abfdef-fc3e-4c3b-a401-f68b326aa727.png)

![image](https://user-images.githubusercontent.com/95449573/145304796-ecd80872-60f0-4367-b8d8-39c7711f0c2a.png)

![image](https://user-images.githubusercontent.com/95449573/145304884-922b58a3-d4dc-407a-ae23-366c0a086771.png)

![image](https://user-images.githubusercontent.com/95449573/145304953-0229aa64-1d9a-4341-ae39-cefa7451b78b.png)


Again it's impossible to see all of them because huge number of Launchpads are created, but at least they are working hard to make a platform clean.

Thanks to remove them from blacklist asap, 50K members are waiting for this.

Reverts https://github.com/MetaMask/eth-phishing-detect/pull/6088