### PR TITLE
hosts.txt: Add across.cc

### DIFF
--- a/src/hosts.txt
+++ b/src/hosts.txt
@@ -1071,3 +1071,4 @@
 0.0.0.0 curwe.fi
 0.0.0.0 boredapeyachtclub.app
 0.0.0.0 convexfinance.org
+0.0.0.0 across.cc


### PR DESCRIPTION
across.cc is a fraudulent domain, impersonating https://across.to.