### PR TITLE
adding phishing site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -895,6 +895,8 @@
     "metamarc.io"
   ],
   "blacklist": [
+    "blockchain-tool.org",
+    "connecttodapps.ga",
     "defiprotocol-online.digital",
     "meta-servers-online.com",
     "livefixrestore.com",


### PR DESCRIPTION
reported in zendesk 595301, 593117

The following is a phishing sites using impersonator on a YouTube channel. I'm new to Github and don't know how it works exactly. But here is a scam sites:

"hex2022.com",

can you add this please?