### PR TITLE
opensae-collection.cc + adidasminting.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -920,6 +920,7 @@
     "metapass.fyi"
   ],
   "blacklist": [
+    "opensae-collection.cc",
     "ogn-airdrops.com",
     "axie-box.one",
     "crazybabiesnft.com",

--- a/src/config.json
+++ b/src/config.json
@@ -920,6 +920,7 @@
     "metapass.fyi"
   ],
   "blacklist": [
+    "adidasminting.com",
     "opensae-collection.cc",
     "ogn-airdrops.com",
     "axie-box.one",


### PR DESCRIPTION
opensae-collection.cc
Fake OpenSea site phishing for secrets with POST /sendform.php
https://urlscan.io/result/088751c0-b199-405f-aa1b-8efeb51733f1/
https://urlscan.io/result/8d3ba1ee-7e1e-42e7-aa57-989a7f35c189/

adidasminting.com
Fake Adidas NFT site phishing for funds
https://urlscan.io/result/b119d443-eb64-4f1f-96fa-61ce003d4cf9/
https://urlscan.io/result/cd23ccfe-112b-4658-baaf-99cb864a2c8c/
address: 0x8b61F3b22866dbeD67312fE19c2E729346289c05 (eth)