### PR TITLE
Allowlist sites 2021-01

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -67,6 +67,7 @@
     "cactus.cards",
     "flarum.it",
     "infinity.co",
+    "infinity.fish",
     "infinity.health",
     "infinity.irish",
     "ipensa.com",

--- a/src/config.json
+++ b/src/config.json
@@ -78,6 +78,7 @@
     "fvlcrum.com",
     "openseas.gr",
     "lautus.net",
+    "lucrus.io",
     "metaease.io",
     "metahack.games",
     "maddmeta.com",

--- a/src/config.json
+++ b/src/config.json
@@ -78,6 +78,7 @@
     "fvlcrum.com",
     "openseas.gr",
     "lautus.net",
+    "lucrum.pro",
     "lucrus.io",
     "metaease.io",
     "metahack.games",

--- a/src/config.json
+++ b/src/config.json
@@ -40,6 +40,7 @@
     "aubtu.biz",
     "audius.party",
     "aulus.org",
+    "aurous.finance",
     "befinity.media",
     "beta.ask.rip",
     "fulcrum.org",


### PR DESCRIPTION
These are some remaining sites from the month of January 2021 that are both active and currently fuzzy-blocked.

## infinity.fish
Fixes #4641.

Not visually similar to `dfinity.org`.

## lucrum.pro
Fixes #4615.

Not visually similar to `auctus.org` or `fulcrum.trade`.

## aurous.finance, lucrus.io
Fixes #4632.
Fixes #4578.

Not visually similar to `auctus.org`.