### PR TITLE
Undo accidental blocklist change

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1039,7 +1039,7 @@
     "restoremetadata.com",
     "mywalletauthenticator.weebly.com",
     "sandboxgame.app",
-    "shibasocialclub.com",
+    "shibasociaiclub.com",
     "bombcrypto.net",
     "faceless.maison",
     "whitelist-invisiblefriends.com",


### PR DESCRIPTION
A blocklist entry was accidentally modified in #6332, blocking the legitimate site rather than the clone.

Fixes #6337