### PR TITLE
meta-words.xyz + nikeminting.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -997,6 +997,7 @@
     "roco.finance"
   ],
   "blacklist": [
+    "nikeminting.com",
     "meta-words.xyz",
     "invisible-friends.co",
     "mydecentraland.shop",

--- a/src/config.json
+++ b/src/config.json
@@ -997,6 +997,7 @@
     "roco.finance"
   ],
   "blacklist": [
+    "meta-words.xyz",
     "invisible-friends.co",
     "mydecentraland.shop",
     "blockchains-tool.com",


### PR DESCRIPTION
meta-words.xyz
Fake MetaMask site phishing for secrets with POST /metamaskwallet/send.php
https://urlscan.io/result/a93472a9-3a76-47dd-b123-94bb16fbfae6/
https://urlscan.io/result/5c3bd981-3bee-4ffb-be0c-c4b23b4267eb/
https://urlscan.io/result/aff11d80-d9ae-45c5-b50f-e74a6c312616/

nikeminting.com
Fake Nike NFT minting site phishing for deposits
https://urlscan.io/result/f31f48ee-9f1e-4e1c-98a8-abcd4987730b/
address: 0x9785E66639b6b8741616181801Fadb7b87a6f25D (eth)