### PR TITLE
officialmm.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1032,6 +1032,7 @@
     "roco.finance"
   ],
   "blacklist": [
+    "officialmm.com",
     "metamask-xpubs.web.app",
     "mint-monsterapeclub.art",
     "verifymeta.net",


### PR DESCRIPTION
officialmm.com
Trust trading scam site
https://urlscan.io/result/105ac062-d433-43ec-9d2a-da71f096aaab/
address: 0x6998E3AaD88A30E4DfA99d23af746cEF58E7c98D (eth)