### PR TITLE
Added looksrare.org related blocks

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -16,6 +16,7 @@
     "metamask.io",
     "myetherwallet.com",
     "opensea.io",
+    "looksrare.org",
     "originprotocol.com"
   ],
   "whitelist": [
@@ -88,6 +89,7 @@
     "opensit.net",
     "openseas.com",
     "opensees.pro",
+    "looksrare.org",
     "openmha.org",
     "openres.io",
     "openresa.com",
@@ -1032,6 +1034,9 @@
     "roco.finance"
   ],
   "blacklist": [
+    "looksraresupport.org",
+    "looik-rares.org",
+    "looksralre.org",
     "killergf.mintin.org",
     "officialmm.com",
     "metamask-xpubs.web.app",

--- a/src/config.json
+++ b/src/config.json
@@ -16,7 +16,6 @@
     "metamask.io",
     "myetherwallet.com",
     "opensea.io",
-    "looksrare.org",
     "originprotocol.com"
   ],
   "whitelist": [
@@ -1037,6 +1036,13 @@
     "looksraresupport.org",
     "looik-rares.org",
     "looksralre.org",
+    "looksrare.org.ua",
+    "looksrares.org",
+    "looksare.top",
+    "liooksrare.com",
+    "looksarare.org",
+    "looksrarem.org",
+    "looksarare.tech",
     "killergf.mintin.org",
     "officialmm.com",
     "metamask-xpubs.web.app",


### PR DESCRIPTION
Hey the NFT marketplace https://looksrare.org/ has been targeted by a lot of phishing sites.

We have been quite successful in having them taken down but hope this helps protects our users.


Also added a few more that have been hard to take down:
looksraresupport[.]org
looik-rares[.]org
looksralre[.]org -> tries to fool you into looking it's legit but try looksralre[.]org/connectt/