### PR TITLE
updated blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1032,6 +1032,7 @@
     "roco.finance"
   ],
   "blacklist": [
+    "bayc-nft.com",
     "metadata.io.tambooks.vn",
     "killergf.mintin.org",
     "officialmm.com",


### PR DESCRIPTION
ZD # 763947 - 'bayc-nft[dot]com'