### PR TITLE
metawallet.com.travelplus.gr

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1036,6 +1036,7 @@
     "arceus.gg"
   ],
   "blacklist": [
+    "metawallet.com.travelplus.gr",
     "looksraresupport.org",
     "looik-rares.org",
     "looksralre.org",


### PR DESCRIPTION
metawallet.com.travelplus.gr
Fake MetaMask site phishing for secrets with POST /id/d41d8cd98f00b204e9800998ecf8427e/hc/en/id40301/send.php
https://urlscan.io/result/16f08490-ac7c-4342-9cd5-a99defe90fda/