### PR TITLE
metamask1.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1036,6 +1036,7 @@
     "arceus.gg"
   ],
   "blacklist": [
+    "metamask1.io",
     "c-01nftmint.com",
     "hapebeast-nft.io",
     "moodyapeclub.app",


### PR DESCRIPTION
metamask1.io
Fake MetaMask site hosting malware (sha256sum: ac59174079a58da92abc82d88bfd6273c5bbb3318cd0f1725cf01ebd6454e8de)
https://urlscan.io/result/89359211-845f-4f39-a0af-52db551f87c9/