### PR TITLE
Allowlist sites 2021-06

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -74,6 +74,7 @@
     "fvlcrvm.com",
     "futurum.software",
     "ifinity.ch",
+    "cryptohotties.space",
     "cryptopities.com",
     "cryptotitties.xyz",
     "cutus.in",

--- a/src/config.json
+++ b/src/config.json
@@ -49,6 +49,7 @@
     "astus.app",
     "aubtu.biz",
     "aubus.xyz",
+    "audius.io",
     "audius.party",
     "aulus.org",
     "aulus.xyz",

--- a/src/config.json
+++ b/src/config.json
@@ -117,6 +117,7 @@
     "cactus.la",
     "cactus.sh",
     "flarum.it",
+    "hoctus.win",
     "infinity.co",
     "infinity.fish",
     "infinity.health",

--- a/src/config.json
+++ b/src/config.json
@@ -443,6 +443,7 @@
     "avis.com",
     "axis.li",
     "nafis.co",
+    "trinity.art",
     "trinity.design",
     "trinity.edu",
     "trinity.global",

--- a/src/config.json
+++ b/src/config.json
@@ -65,6 +65,7 @@
     "cryptopatties.xyz",
     "definfty.io",
     "dinify.io",
+    "divinity.ca",
     "divinity.es",
     "doinita.art",
     "easymeta.fun",

--- a/src/config.json
+++ b/src/config.json
@@ -67,6 +67,7 @@
     "doinita.art",
     "easymeta.fun",
     "revigo.fanclub.rocks",
+    "finitty.com",
     "fulcrum.ag",
     "fulcrum.org",
     "fulcrum7.com",

--- a/src/config.json
+++ b/src/config.json
@@ -139,6 +139,7 @@
     "lucrus.io",
     "metaease.io",
     "metahack.games",
+    "metajack.org",
     "maddmeta.com",
     "metamac.live",
     "metamark.lt",

--- a/src/config.json
+++ b/src/config.json
@@ -64,6 +64,7 @@
     "beta.ask.rip",
     "definfty.io",
     "dinify.io",
+    "divinity.es",
     "doinita.art",
     "easymeta.fun",
     "revigo.fanclub.rocks",

--- a/src/config.json
+++ b/src/config.json
@@ -362,6 +362,7 @@
     "uniswap.org",
     "uniswap.exchange",
     "uniswapex.io",
+    "umtswap.finance",
     "auctia.io",
     "sgcrypto.info",
     "mr-crypto.net",

--- a/src/config.json
+++ b/src/config.json
@@ -62,6 +62,7 @@
     "aurous.finance",
     "befinity.media",
     "beta.ask.rip",
+    "bulurum.com",
     "cryptopatties.xyz",
     "definfty.io",
     "dinify.io",

--- a/src/config.json
+++ b/src/config.json
@@ -62,6 +62,7 @@
     "aurous.finance",
     "befinity.media",
     "beta.ask.rip",
+    "cryptopatties.xyz",
     "definfty.io",
     "dinify.io",
     "divinity.es",


### PR DESCRIPTION
## audius.io, hoctus.win
Fixes #5094.
Fixes #5160.

None of these are visually similar to `auctus.org`.

## bulurum.com
Fixes #5140.

Not visually similar to Fulcrum.

## cryptohotties.space, cryptopatties.xyz
Fixes #5095.
Fixes #5126.

Not visually similar to CryptoKitties.

## divinity.ca, divinity.es, finitty.com, trinity.art
Fixes #5134.
Fixes #5111.
Fixes #5103.
Fixes #6720.

None of these are visually similar to Dfinity.

## metajack.org
Fixes #5124.

Not visually similar to MetaMask.

## umtswap.finance
Fixes #5102.

Not visually similar to UniSwap.