### PR TITLE
Whitelist: openrep.foundation

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1047,7 +1047,8 @@
     "metamarc.io",
     "metapass.fyi",
     "roco.finance",
-    "arceus.gg"
+    "arceus.gg",
+    "openrep.foundation"
   ],
   "blacklist": [
     "metamaskwebwallet.io",
@@ -14462,7 +14463,6 @@
     "colabration.cc",
     "revokecash.com",
     "thor.fund",
-    "dogaml.net",
-    "openrep.foundation"
+    "dogaml.net"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -1049,7 +1049,7 @@
     "metapass.fyi",
     "roco.finance",
     "arceus.gg",
-    "openrep.foundation"
+    "openrep.foundation",
     "esa.int",
     "open.esa.int"
   ],

--- a/src/config.json
+++ b/src/config.json
@@ -14462,6 +14462,7 @@
     "colabration.cc",
     "revokecash.com",
     "thor.fund",
-    "dogaml.net"
+    "dogaml.net",
+    "openrep.foundation"
   ]
 }


### PR DESCRIPTION
Fixes #6725 

Adds `openrep.foundation` to whitelist.

**Open Reputation Foundation**
Foundation parallel to Reputation DAO - does not have own socials yet.

**Reputation DAO**
Website: https://repdao.xyz
Discord: https://discord.com/invite/pWBEF6RKPT
Twitter: [@ReputationDAO](https://twitter.com/ReputationDAO)
Mirror:  https://mirror.xyz/0xCdE1977B8bF6C166C8e4724785C300D82817115c

**Links to foundation at this page**
https://repdao.xyz/openreputationfoundation