### PR TITLE
Allowlist sites 2022-02-01 to 2022-02-07

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -153,6 +153,7 @@
     "metamars.capital",
     "metamart.space",
     "metamasu.com",
+    "metamate.crypto",
     "metamate.game",
     "metamaxx.io",
     "metamese.com",

--- a/src/config.json
+++ b/src/config.json
@@ -184,6 +184,7 @@
     "nfiniti.io",
     "nvinity.nl",
     "wpopensea.com",
+    "open-ed.fyi",
     "openex.io",
     "opengear.tv",
     "openidea.lv",

--- a/src/config.json
+++ b/src/config.json
@@ -145,6 +145,7 @@
     "lucrum.fund",
     "lucrum.pro",
     "lucrus.io",
+    "metaease.com",
     "metaease.io",
     "metahack.games",
     "metajack.org",

--- a/src/config.json
+++ b/src/config.json
@@ -187,6 +187,7 @@
     "opengem.net",
     "opensea.institute",
     "opensea.ru",
+    "opensera.com",
     "openset.co",
     "opensis.com",
     "opensky.blue",

--- a/src/config.json
+++ b/src/config.json
@@ -118,6 +118,7 @@
     "cactus.store",
     "cactus.la",
     "cactus.sh",
+    "ebinity.com",
     "flarum.it",
     "hoctus.win",
     "infinity.co",

--- a/src/config.json
+++ b/src/config.json
@@ -77,6 +77,7 @@
     "fulcrum.ag",
     "fulcrum.org",
     "fulcrum7.com",
+    "fulcrumtx.com",
     "hugtus.com",
     "fvlcrvm.com",
     "futurum.software",

--- a/src/config.json
+++ b/src/config.json
@@ -668,6 +668,7 @@
     "autos.ca",
     "acatus.com",
     "pcrypto.io",
+    "metacash.gg",
     "metacash.online",
     "metacash.it",
     "atfinity.ch",

--- a/src/config.json
+++ b/src/config.json
@@ -144,6 +144,7 @@
     "openseas.gr",
     "lautus.net",
     "metacas.io",
+    "magendao.com",
     "markmeta.finance",
     "masknet.net",
     "lucrum.fund",

--- a/src/config.json
+++ b/src/config.json
@@ -159,6 +159,7 @@
     "metamuse.xyz",
     "metamk.com",
     "metamusk.eu",
+    "metamusk.io",
     "meta-musk.com",
     "metamosa.io",
     "metaoak.com",

--- a/src/config.json
+++ b/src/config.json
@@ -59,6 +59,7 @@
     "aureus.ltd",
     "aurous.cl",
     "au.tts.ru",
+    "avatus.com",
     "avinity.com",
     "aurous.finance",
     "befinity.media",

--- a/src/config.json
+++ b/src/config.json
@@ -174,6 +174,7 @@
     "metapark.land",
     "metapass.world",
     "metalmark.xyz",
+    "metasmas.com",
     "metatalk.id",
     "multus.media",
     "nfiniti.io",

--- a/src/config.json
+++ b/src/config.json
@@ -142,6 +142,7 @@
     "metacas.io",
     "markmeta.finance",
     "masknet.net",
+    "lucrum.fund",
     "lucrum.pro",
     "lucrus.io",
     "metaease.io",

--- a/src/config.json
+++ b/src/config.json
@@ -187,6 +187,7 @@
     "openex.io",
     "opengear.tv",
     "openidea.lv",
+    "openner.vc",
     "openspv.com",
     "opensrc.fans",
     "opensrc.finance",

--- a/src/config.json
+++ b/src/config.json
@@ -125,6 +125,7 @@
     "infinity.fish",
     "infinity.health",
     "infinity.irish",
+    "infinity.nl",
     "infinity.watch",
     "ipensa.com",
     "justus.fun",

--- a/src/config.json
+++ b/src/config.json
@@ -949,6 +949,7 @@
     "metamaps.cc",
     "metamaps.co",
     "metamaps.dev",
+    "metamaps.land",
     "metamats.com",
     "metamax.by",
     "metamax.com",

--- a/src/config.json
+++ b/src/config.json
@@ -187,6 +187,7 @@
     "opensea.institute",
     "opensea.ru",
     "openset.co",
+    "opensis.com",
     "opensky.blue",
     "opensky.com",
     "opensky.kr",

--- a/src/config.json
+++ b/src/config.json
@@ -74,6 +74,7 @@
     "easymeta.fun",
     "revigo.fanclub.rocks",
     "finitty.com",
+    "finityx.com",
     "fulcrum.ag",
     "fulcrum.org",
     "fulcrum7.com",

--- a/src/config.json
+++ b/src/config.json
@@ -153,6 +153,7 @@
     "metajack.org",
     "maddmeta.com",
     "metamac.live",
+    "metamail.ink",
     "metamark.lt",
     "metamars.capital",
     "metamart.space",

--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "9finite.com",
     "opengem.com",
     "infinity.exchange",
     "otterscan.io",

--- a/src/config.json
+++ b/src/config.json
@@ -948,6 +948,7 @@
     "metamaks.ru",
     "metamaps.cc",
     "metamaps.co",
+    "metamaps.dev",
     "metamats.com",
     "metamax.by",
     "metamax.com",

--- a/src/config.json
+++ b/src/config.json
@@ -28,6 +28,7 @@
     "artblocks.io",
     "finite.io",
     "lasmeta.io",
+    "actum.dk",
     "actum.games",
     "metapass.cloud",
     "metamarz.io",

--- a/src/config.json
+++ b/src/config.json
@@ -182,6 +182,7 @@
     "multus.media",
     "nfiniti.io",
     "nvinity.nl",
+    "wpopensea.com",
     "openex.io",
     "opengear.tv",
     "openidea.lv",

--- a/src/config.json
+++ b/src/config.json
@@ -190,6 +190,7 @@
     "opensis.com",
     "opensky.blue",
     "opensky.com",
+    "opensky.es",
     "opensky.kr",
     "opensky.la",
     "openslo.com",


### PR DESCRIPTION
## 9finite.com, ebinity.com, finityx.com, infinity.nl
Fixes #6555.
Fixes #6563.
Fixes #5353.
Fixes #5000.

Not visually similar to DFinity.

## actum.dk, avatus.com, lucrum.fund
Fixes #6588.
Fixes #6562.
Fixes #6502.

Not visually similar to Auctus.

## fulcrumtx.com
Fixes #6576.

Not a phishing scam.

## magendao.com
Fixes #6640.

Doesn't look like it should be blocked, but not a phishing scam, so it doesn't hurt to allowlist it as a troubleshooting step (also to help with peace of mind).

## metacash.gg, metaease.com, metamail.ink, metamaps.dev, metamaps.land, metamate.crypto, metasmas.com
Fixes #6548.
Fixes #6573.
Fixes #6578.
Fixes #6590.
Fixes #6589.
Fixes #6541.
Fixes #6532.

Not visually similar to MetaMask.

## metamusk.io
Fixes #6560.

Not a phishing scam.

## open-ed.fyi, openner.vc, opensera.com, opensis.com, opensky.es
Fixes #6583.
Fixes #6580.
Fixes #6559.
Fixes #6543.
Fixes #6550.

Not visually similar to OpenSea.

## wpopensea.com
Fixes #6579.

Not a phishing scam.