### PR TITLE
Allow opensend.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -24,6 +24,7 @@
     "otterscan.io",
     "olympusdao.finance",
     "bifinity.com",
+    "opensend.com",
     "artblocks.io",
     "finite.io",
     "lasmeta.io",


### PR DESCRIPTION
Fixes #6666

A result of fuzzy-blocking for opensea.

If we can't keep up with these false positives, we should un-fuzzy-list OpenSea.