### PR TITLE
Revert "Blocking pulsechain.com (#6751)"

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1086,7 +1086,6 @@
     "wallet-connect-meta.com",
     "wallet-meta-connec.com",
     "validationopensea.com",
-    "pulsechain.com",
     "mysecure-dnsserver.com",
     "2ombs.finance",
     "metamaskwebwallet.io",


### PR DESCRIPTION
Hi, I'm a PulseChain Developer.

PulseChain.com has no affiliation with ENS pulsechaindotcom.eth which
prompted this commit. pulsechain.com is a legitimate domain and this
commit is blocking our dApps. Blocking pulsechain.com will not
stop whoever is controlling ENS pulsechaindotcom.eth

This reverts commit d83756a4983b999ad65df154a715a649a4379e16.