### PR TITLE
add metamars.ai to phishing detect's whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -40,6 +40,7 @@
     "msmeta.fun",
     "metamap.com",
     "metamars.org",
+    "metamars.ai",
     "sanctus.audio",
     "affinity.ad",
     "affinity.ro",


### PR DESCRIPTION
This is fix for https://github.com/MetaMask/eth-phishing-detect/issues/6747
Our site is: https://metamars.ai/
Our project is a legitimate one.

Please help us to review this. Thanks!