### PR TITLE
metamask.io.web7615.web07.bero-webspace.de

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1093,6 +1093,7 @@
     "open.esa.int"
   ],
   "blacklist": [
+    "metamask.io.web7615.web07.bero-webspace.de",
     "metamakrecovery2022.com",
     "c0llabland.com",
     "app.dinolland.io",


### PR DESCRIPTION
metamask.io.web7615.web07.bero-webspace.de
Fake MetaMask site phishing for secrets with POST /log.php
https://urlscan.io/result/86aae44d-f6e9-46c3-af63-80f593f38a3c/