### PR TITLE
blacklist acros.to

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14595,6 +14595,7 @@
     "colabration.cc",
     "revokecash.com",
     "thor.fund",
-    "dogaml.net"
+    "dogaml.net",
+    "acros.to"
   ]
 }


### PR DESCRIPTION
Added acros.to to blacklist, which is faking across.to 
Signed-off-by: Tulun <jaykiraly@gmail.com>