### PR TITLE
live-nft-mint.com + ape-coin.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1093,6 +1093,8 @@
     "open.esa.int"
   ],
   "blacklist": [
+    "live-nft-mint.com",
+    "ape-coin.net",
     "pegaxy.pw",
     "pegax.yvte.com",
     "protocolsresolvesite.com",


### PR DESCRIPTION
live-nft-mint.com
Fake NFT minting site phishing for funds
https://urlscan.io/result/b969832a-efdd-4d3d-9ccb-4b5d838f3ba1/
https://urlscan.io/result/bafad9bb-5d0f-4e03-af5c-df3c238d7189/
address: 0x084BAdb343DbB1F4387cFd71fD32c91020E0Fe03 (eth)

ape-coin.net
Fake Ape coin claim site phishing for funds
https://urlscan.io/result/aa88f792-bc13-4784-88ed-7cdcf5ec9fc8/
address: 0xc4b19a285d68a085912e7ecd200Eb6e8f292C11d (eth)