### PR TITLE
apecoin.events

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1100,6 +1100,7 @@
     "open.esa.int"
   ],
   "blacklist": [
+    "apecoin.events",
     "cerealentrepreneurs.academy",
     "verifiedmetanow.net",
     "dappintegrates.me",


### PR DESCRIPTION
apecoin.events
Fake Ape coin claim site phishing for funds
https://urlscan.io/result/1db7b034-c19d-4cbd-a065-acecffad0f77/
address: 0x05836c14De1Bf2ec4428F6eF52FeE285D10cba6f (eth)
address: 0x9F6a6b61A46cd68180bFD35Da2996721B60512cC (eth)