### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14,6 +14,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "ducatus.com",
     "binance.net",
     "binance.cloud",
     "binance.vision",


### PR DESCRIPTION

Hi,
I visited metavas.jp and was given an alert that "Ethereum Phishing Detection".
metavas.jp is a 
I'm sure this is mistakenly detected as "Phishing" site because I'm one of time users for this service.

Also I checked the reason with online tool , says "This domain was blocked for its similarity to metamask.io, a historical phishing target." There's no similarity or connection between them.

hope you guys whitelist metavas.jp ASAP.
Their company website is here: https://www.metavas.jp/


Thanks,