### PR TITLE
cross-chainbot.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1106,6 +1106,7 @@
     "everscan.io"
   ],
   "blacklist": [
+    "cross-chainbot.org",
     "pegasxy.net",
     "tronixdapp.com",
     "ygalaxy168.com",


### PR DESCRIPTION
cross-chainbot.org
Fake WalletConnect site phishing for secrets with POST /phrase
https://urlscan.io/result/1782e84f-41c1-4c30-89ee-f07332259c6c/
https://urlscan.io/result/b93e7aaa-4824-41f1-bacc-73663048ff2a/