### PR TITLE
boredapeproject.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1110,6 +1110,7 @@
     "everscan.io"
   ],
   "blacklist": [
+    "boredapeproject.com",
     "ammmine.cc",
     "ape-coin.claims",
     "dappsdefichain.com",


### PR DESCRIPTION
boredapeproject.com
Fake Ape coin claim site phishing for funds and secrets with POST /api/addData.php, POST /api/addDataCode.php
https://urlscan.io/result/464812b5-d2b0-4f03-9068-0c98f7e6a592/
address: 0xB566a04F6F6F3BA0aCbc548f4D9b665A50217C38 (eth)