### PR TITLE
[Legitimate Site Blocked] darkmeta.xyz

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1107,6 +1107,7 @@
     "openrep.foundation",
     "esa.int",
     "open.esa.int",
+    "darkmeta.xyz",
     "everscan.io"
   ],
   "blacklist": [


### PR DESCRIPTION
Adding `darkmeta.xyz` to whitelist.

Background: This is a static page for our company, DarkMeta. There is no wallet integration or crypto transactions of any sorts and we are in **no** way affiliated to maskmeta.org. 

![image](https://user-images.githubusercontent.com/102981875/161593911-500da67c-6547-4457-9495-7c39e87ceb10.png)

Closes #6941