### PR TITLE
azuki-drop.com + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1112,6 +1112,9 @@
     "everscan.io"
   ],
   "blacklist": [
+    "azuki-drop.com",
+    "beanz-azuki.com",
+    "azuki-airdrop.com",
     "synchronization-collab.land",
     "coindapps.webflow.io",
     "kycs-for-metalocation.live",


### PR DESCRIPTION
azuki-drop.com
Fake Azuki site phishing for funds
https://urlscan.io/result/fbc02300-0c94-4c07-b46c-01acc0cad725/
address: 0x5DF6FFED8B8ac44c49930A5Ae9B39c94A9fCa351 (eth)

beanz-azuki.com
Fake Azuki site phishing for funds
https://urlscan.io/result/4a9057d1-f176-43b6-adae-9d0996910a20/

azuki-airdrop.com
Fake Azuki site phishing for funds
https://urlscan.io/result/72e06dd1-1e6a-44ab-a452-b42d6ac15e54/