### PR TITLE
Add Trezor phising sites

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14747,6 +14747,12 @@
     "revokecash.com",
     "thor.fund",
     "dogaml.net",
-    "acros.to"
+    "acros.to",
+    "trezor.run",
+    "trezor.us",
+    "satoshilabs.co",
+    "trezornews.io",
+    "suite.trezor.run",
+    "trezorwallet.org"
   ]
 }


### PR DESCRIPTION
Recent [Trezor phishing campaign](https://blog.trezor.io/ongoing-phishing-attacks-on-trezor-users-edd840b17304) domains.