### PR TITLE
Remove from blocklist & allowlist officialnft.xyz

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1210,7 +1210,6 @@
     "c0labland.com",
     "callabland.cc",
     "otp-metamask.io",
-    "officialnft.xyz",
     "wallet-validation.netlify.app",
     "automaticdexsynchr.com",
     "cryptowalletconnector.com",

--- a/src/config.json
+++ b/src/config.json
@@ -212,6 +212,7 @@
     "multus.media",
     "nfiniti.io",
     "nvinity.nl",
+    "officialnft.xyz",
     "wpopensea.com",
     "open-ed.fyi",
     "openex.io",


### PR DESCRIPTION
Fixes #6938. Please refer to that issue.

This is to accelerate the process of allowlist `officialnft.xyz` if it's determined that the block on `officialnft.xyz` was incorrect. This isn't my personal support of the site's being allowlisted.