### PR TITLE
remove officialnft.xyz from blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1210,7 +1210,6 @@
     "c0labland.com",
     "callabland.cc",
     "otp-metamask.io",
-    "officialnft.xyz",
     "wallet-validation.netlify.app",
     "automaticdexsynchr.com",
     "cryptowalletconnector.com",


### PR DESCRIPTION
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/6938