### PR TITLE
new phishing vector found: c0labland.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1306,6 +1306,7 @@
     "louisvuittonnfts.top",
     "tokenfix.net",
     "c0labland.com",
+    "c0labland.io",
     "callabland.cc",
     "otp-metamask.io",
     "wallet-validation.netlify.app",


### PR DESCRIPTION
This site stole wallet creds today.