### PR TITLE
nft-moonbirds.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1152,6 +1152,7 @@
     "everscan.io"
   ],
   "blacklist": [
+    "nft-moonbirds.net",
     "cryptolaunchs.webflow.io",
     "bscbnb.vip",
     "dappsnftconnect.netlify.app",


### PR DESCRIPTION
nft-moonbirds.net
Fake NFT Moonbirds site - https://twitter.com/sniko_/status/1516115584592883713
https://urlscan.io/result/38b9fa45-f527-4118-9b25-b49a43c96885/
address: 0x7B532F02726E66Fb9447CaC7d5a028b9C2a69A5b (eth)