### PR TITLE
azukishop.live + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1152,6 +1152,12 @@
     "everscan.io"
   ],
   "blacklist": [
+    "azukishop.live",
+    "etherealart.nfts-mints.com",
+    "nfts-mints.com",
+    "moonbirds.tv",
+    "moonbirds.gifts",
+    "free-azuki.com",
     "nft-moonbirds.net",
     "cryptolaunchs.webflow.io",
     "bscbnb.vip",


### PR DESCRIPTION
azukishop.live
Fake Azuki NFT mint site phishing for funds
https://urlscan.io/result/cc442602-94a7-47fc-884a-c4b0bcbacffe/
address: 0x2CcdbFC13aDa8567eb716901408394dDCaE742Db (eth)

etherealart.nfts-mints.com
Fake Ethereal NFT minting site phishing for funds
https://urlscan.io/result/3adc07dd-034e-44f1-8154-c94597c33284/
address: 0x2cD6259e9285C650C738198Ed734103c4BB1282E (eth)

moonbirds.tv
Fake Moonbirds NFT site phishing for funds - backend: //api.worthinnft.info:8000/check?address={address}
https://urlscan.io/result/43fb5794-c33b-4211-b872-774058ea67f2/
address: 0x2A2f378F41567E48AC0D4321540D1bdB222c4A51 (eth)

moonbirds.gifts
Fake Moonbirds NFT site phishing for funds
https://urlscan.io/result/622c4806-7129-4a14-9e32-ca7ad82396e1/

free-azuki.com
Fake Azuki NFT mint site phishing for funds
https://urlscan.io/result/bdeeacb3-29d1-4c09-925b-afd1e99bdb1b/
address: 0xF324Af68CdC25D79EF88c0B6e58f94fB5E169d53 (eth)