### PR TITLE
moonbird.claims + waliet-polgyon.network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1159,6 +1159,8 @@
     "everscan.io"
   ],
   "blacklist": [
+    "moonbird.claims",
+    "waliet-polgyon.network",
     "dapp.smartokenapps.com",
     "joancornella-fwenclub.com",
     "metamasksslog.azurewebsites.net",


### PR DESCRIPTION
moonbird.claims
Fake Moonbirds NFT site phishing for funds
https://urlscan.io/result/9eb3233f-c251-4c47-aa02-295cb85bf52a/
address: 0xe3de02fC19a211C73A6596dB5E41F5d0E9FA24B9 (eth)

waliet-polgyon.network
Fake Polygon site phishing for secrets with POST /
https://urlscan.io/result/752ea765-048a-40da-93a0-fbb14c9dd7e6/
https://urlscan.io/result/095494b1-df05-473e-a5d4-0101bd5f1640/