### PR TITLE
add optimism-token.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1159,6 +1159,7 @@
     "everscan.io"
   ],
   "blacklist": [
+    "optimism-token.io",
     "supports-opensea.com",
     "optimism-sale.com",
     "opentoken.sale",


### PR DESCRIPTION
optimism-token.io
Fake Optimism crowdsale site phishing for funds
address: 0x672cCd3805012E75d357b17DeF6763a07758bd54
https://urlscan.io/result/a157be9a-914d-442d-bce0-29b9233c1657/