### PR TITLE
allow euler.finance, block phishing sites

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "euler.finance",
     "roobet.com",
     "auctic.net",
     "metavas.com",
@@ -1160,6 +1161,8 @@
     "everscan.io"
   ],
   "blacklist": [
+    "appeuler.finance",
+    "euler.claims",
     "event-ether22.com",
     "moonbirds.ml",
     "moonbirds.sale",


### PR DESCRIPTION
Hi! I'm from Euler (euler.finance), a lending protocol that's been around for a little over a year. A couple of our users have been hit by a phishing scam (`appeuler.finance` instead of `app.euler.finance`). And also we get a lot of discord scammers trying to get people to visit `euler.claims`. Thank you!