### PR TITLE
opensea-appeal.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1160,6 +1160,7 @@
     "everscan.io"
   ],
   "blacklist": [
+    "opensea-appeal.com",
     "cryptoblades.club",
     "crptoblades.com",
     "app.crptoblades.com",


### PR DESCRIPTION
opensea-appeal.com
Fake OpenSea site phishing for secrets with POST //roninupdate-9408f.firebaseapp.com
https://urlscan.io/result/0b42f8cd-39c2-4097-b980-3b25333aa22f/
https://urlscan.io/result/39d5d808-5c84-4d0b-bb30-f39b58ef1941/