### PR TITLE
boredapeyc.design + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1161,6 +1161,9 @@
     "everscan.io"
   ],
   "blacklist": [
+    "metamask-verify.co",
+    "boredapeyc.design",
+    "earnshibtoken.com",
     "ethswap.site",
     "othersidemeta.gifts",
     "bayclands.io",


### PR DESCRIPTION
boredapeyc.design
Fake BoredApeYachtClub NFT site phishing for funds
https://urlscan.io/result/0c4dadef-faea-4aca-85b3-ebbad90017bd/
address: 0x24f49eA03998550716804963327fFCC1d0AF5098 (eth)

earnshibtoken.com
Fake TrustWallet site phishing for secrets with POST /send.php
https://urlscan.io/result/0c874220-664c-44d1-9834-5cbbc5e0298c/