### PR TITLE
othersidexbayc.xyz + geniexyz.claims

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1161,6 +1161,9 @@
     "everscan.io"
   ],
   "blacklist": [
+    "othersidexbayc.xyz",
+    "bayclands.xyz",
+    "geniexyz.claims",
     "moonbirds-airdrop.com",
     "walletconnect.updatepage.cc",
     "tesla-bitcoin.net",

--- a/src/config.json
+++ b/src/config.json
@@ -1162,7 +1162,6 @@
   ],
   "blacklist": [
     "othersidexbayc.xyz",
-    "bayclands.xyz",
     "geniexyz.claims",
     "moonbirds-airdrop.com",
     "walletconnect.updatepage.cc",


### PR DESCRIPTION
othersidexbayc.xyz
Fake BoredApeYachtClub OtherSide NFT site phishing for funds (backend: a.gastats.xyz)
https://urlscan.io/result/3f5820b5-642d-4a18-a6e5-873348491fb1/
address: 0x4305b1372f1b244da0b32aa2b6f8ae0a124b50b8 (eth)
address: 0x144c5b5141cdab13e5b5b22165bf6688ac7212bc (eth)

geniexyz.claims
Fake Genie site phishing for funds
https://urlscan.io/result/a00905c3-127e-4d1b-b6b3-83383c01a3c7/
address: 0x72Eb3Cf00702E50321BB76F441498A5974f85dFf (eth)