### PR TITLE
metavas.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "metavas.io",
     "euler.finance",
     "roobet.com",
     "auctic.net",


### PR DESCRIPTION
metavas.io
Fixes https://github.com/MetaMask/eth-phishing-detect/issues/6890
https://urlscan.io/result/fa95259c-11f0-48bb-a37f-ba96443b5471/

None of the hyperlinks work right now - though it's not explicitly on the block list.