### PR TITLE
Add boggecl.finance to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1161,6 +1161,7 @@
     "everscan.io"
   ],
   "blacklist": [
+    "boggecl.finance",
     "oddstronauts.co",
     "airdropthor.financial",
     "polygonstechnollogi-wallet.com",


### PR DESCRIPTION
Add boggecl.finance to blacklist

Phishing site with fake MetaMask popup that asks for seed phrase.