### PR TITLE
Whitelisting gensea.io [#7162]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -23,6 +23,7 @@
     "eastmeta.cc",
     "ethersign.app",
     "archus.jp",
+    "gensea.io",
     "openseed.co",
     "metaosk.com",
     "aucties.com",


### PR DESCRIPTION
Gensea.io will be a generative art NFTs gallery, which is being released soon. The GenSea name is purposely similar to OpenSea because it will be a marketplace for **gen**erative art.

#7162 