### PR TITLE
app-chainlist.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1179,6 +1179,7 @@
     "everscan.io"
   ],
   "blacklist": [
+    "app-chainlist.org",
     "polkastarter.website",
     "polkastarterweb.org",
     "metamask-active-instant-suppor.nelify.online",


### PR DESCRIPTION
app-chainlist.org
Fake Chainlist site phishing for secrets with POST /metamask.php
https://urlscan.io/result/5ec57637-9a61-45bc-b192-053e77880702/
https://urlscan.io/result/56a15307-462d-453d-900b-94de19d503ab/