### PR TITLE
Removed idexcorp.com from the blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -7487,7 +7487,6 @@
     "blcokchain.lloqin.com",
     "lloqin.com",
     "ldax.market",
-    "idexcorp.com",
     "idexcorp.comgg.gg",
     "investment2x.online",
     "electrumsecuredownload.com",

--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "idexcorp.com",
     "walletconnect.com",
     "ensea.fr",
     "openvia.io",


### PR DESCRIPTION
idexcopr.com is a Fortune 500 company and is a legitimate site
https://github.com/MetaMask/eth-phishing-detect/issues/7462