### PR TITLE
Remove impostors.gg from the blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "impostors.gg",
     "idexcorp.com",
     "walletconnect.com",
     "ensea.fr",
@@ -1214,7 +1215,6 @@
     "synlaunchpad.io",
     "claim.rocket-pool.app",
     "nasa-nft.co",
-    "impostors.gg",
     "staking.oxyaorigin.com",
     "s.metascape-graph.live",
     "trezor-community.com",


### PR DESCRIPTION
Our site [impostors.gg](https://impostors.gg) was recently whacked by the MetaMask phishing detection system; this pull request fixes that. This closes issues #7469, #7481, and #7484. We're currently having a planned launch disrupted by our addition to the MetaMask blacklist in #7464.

We are a relatively-major NFT project (top-100 by volume on OpenSea) who've been around for several months, are built by [SuperFarm](https://superfarm.com) and publicly associated with [EllioTrades](https://twitter.com/elliotrades). We are a fully-doxxed team who have been in the crypto space for a long time. I even helped fix a MetaMask bug [nearly four years ago](https://github.com/MetaMask/metamask-extension/issues/4957).

It's worth having a discussion about how this happened. Our hunch is that we may have triggered some automatic abuse detection system with recent DNS changes on our end. The changes are, however, completely routine and were made by our own engineers in support of our own upcoming launch. Just a hunch.

In our opinion, there should be a much stronger human review process involved before blacklisting a site due to the damage that a false positive in the MetaMask blacklist can cause. In our case, it is quite easy to do some digging and see that we are a legitimate project.

There also needs to be better tooling for sites that do get falsely included in the blacklist. The MetaMask phishing notice suggests that the source of blacklisted sites is CryptoScamDB, which in our case does not include [impostors.gg](https://impostors.gg). Nor does the MetaMask phishing detector tool tell us that our site is even blocked. This sent our team down a bit of a wild goose chase before we were able to actually identify the `config.json` file in this repository and make this remedial PR.

Thank you, we hope we can have this situation fixed soon. 🙏🏻