### PR TITLE
Allow metabank.li

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -24,6 +24,7 @@
     "walletconnect.com",
     "ensea.fr",
     "openvia.io",
+    "metabank.li",
     "metayasi.io",
     "eastmeta.cc",
     "ethersign.app",


### PR DESCRIPTION
Was only blocked for similarity for metamask.io

Fixes #7499
Fixes #7368