### PR TITLE
add dfinery.io to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "dfinery.io",
     "infinity.careers",
     "moneyzg.academy",
     "impostors.gg",

--- a/src/config.json
+++ b/src/config.json
@@ -20,6 +20,9 @@
   ],
   "whitelist": [
     "dfinery.io",
+    "dfinery2.io",
+    "dfinery.kr",
+    "dfinery.net",
     "infinity.careers",
     "moneyzg.academy",
     "impostors.gg",


### PR DESCRIPTION
"dfinery.io" is a SaaS Application for data platform and is not crypto-related.

#7750 