### PR TITLE
Add nounsdao.me to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1190,6 +1190,7 @@
     "nftinit.com"
   ],
   "blacklist": [
+    "nounsdao.me",
     "boredhuman.wl-now.com",
     "boredhuman.presaless.com",
     "bnbpro.me",


### PR DESCRIPTION
NounsDAO Twitter was [hacked](https://twitter.com/nounsdao/status/1541259012511080448)