### PR TITLE
eth-radar.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1192,6 +1192,7 @@
     "nftinit.com"
   ],
   "blacklist": [
+    "eth-radar.com",
     "usdtpos.net",
     "othrverse.xyz",
     "thegodanft.io",


### PR DESCRIPTION
eth-radar.com
Fake YearnFinance site phishing for funds
https://urlscan.io/result/ca365792-198c-4717-b7c1-50901a61cf0a/#summary
address: 0xb6af46be91b1ba4043c99f968c18871d3a763059 (eth)