### PR TITLE
cecd33.fr

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1196,6 +1196,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "cecd33.fr",
     "dappconnectpad.com",
     "exchange-otc.info",
     "app.step-launchpad.com",


### PR DESCRIPTION
cecd33.fr
Fake Ledger site phishing for secrets with POST /wp-includes/js/crop/ledger/com/support/reset/seed/send.php
https://urlscan.io/result/26c640f7-0ba7-44fc-bdea-a80421dd55a4/