### PR TITLE
metamaskbridge.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1196,6 +1196,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "metamaskbridge.org",
     "multi-launchpad.org",
     "pokemoney.info",
     "revival-terra.money",


### PR DESCRIPTION
metamaskbridge.org
Fake MetaMask site phishing for secrets with POST //walletconnect-us.herokuapp.com/tsubmit
https://urlscan.io/result/0df1421b-2dcd-40b2-a6ae-05883ca2bf72/
https://urlscan.io/result/4bf656bb-d68a-4b82-862c-753fb14d3d92/