### PR TITLE
[Legitimate Site Blocked] macarena.finance

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1260,7 +1260,6 @@
     "innerdegens.wtf",
     "ninjadao-cnp-pj.com",
     "premintnfts.xyz",
-    "macarena.finance",
     "otherside-nft.app",
     "piecesofshits.wtf",
     "murakamiflowers.club",


### PR DESCRIPTION
Macarena.finance was blocked by [this](https://github.com/MetaMask/eth-phishing-detect/pull/7816) PR.

This is not a phishing website, but a forkable project from yearn.finance: 
```
Macarena finance is a simple UI for Yearn Finance, made to be forked!

Running your own instance of Yearn makes you eligible to earn fees on top of all deposits made through your UI. See information on how partnership and profit-sharing work at our [Partner Docs](https://docs.yearn.finance/partners/introduction#profit-share-model)
```

Repo is available on the official Yearn's Github here: https://github.com/yearn/macarena-finance
Official communication here: https://twitter.com/iearnfinance/status/1537524949061181446?s=20&t=pXaL6dN4kpaj0THpzMvBtw

Linked to #7868 