### PR TITLE
updated blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1198,6 +1198,15 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "foundationb.fun",
+    "allchainaccess.com",
+    "usdt-pos.org",
+    "dev-web3dappscollabs.pantheonsite.io",
+    "stepn-claims.live",
+    "challnlist.xyz",
+    "dapps-eth.net",
+    "movez-app.com",
+    "liveservernetwork.live",
     "staking-ethereum2.org",
     "staking114388-ethereum.org",
     "staking446652-ethereum.org",


### PR DESCRIPTION
foundationb[dot]fun (ZD 909129)
allchainaccess[dot]com (ZD 910959)
usdt-pos[dot]org (ZD 910524)
dev-web3dappscollabs[dot]pantheonsite[dot]io (ZD 913410)
stepn-claims[dot]live (ZD 913453)
challnlist[dot]xyz (ZD 913828)
dapps-eth[dot]net (914702)
movez-app[dot]com (ZD 916603)
liveservernetwork[dot]live (ZD 916582)