### PR TITLE
tether.to.epgr.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1198,6 +1198,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "tether.to.epgr.org",
     "lunchdapps.netlify.app",
     "smartchaindefi.org",
     "giveaway-qmall.com",


### PR DESCRIPTION
tether.to.epgr.org
Fake Tether site phishing for funds (erc20 approval abuse)
https://urlscan.io/result/cbae554d-e937-49e8-9a11-141414f51272/
https://urlscan.io/result/7faacdb4-6991-44ea-837f-b4205bce8fe2/
address: 0x82AA1a9d7083020194A847F7bBa662eD0dE99999 (eth)