### PR TITLE
Add Hop exchange phishing url to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -2499,6 +2499,7 @@
     "hoopp.exchange",
     "app.hoopps.exchange",
     "hoopps.exchange",
+    "app-hope.exchange",
     "arbitrum-token.io",
     "hop-token.sale",
     "sale-optimism.com",


### PR DESCRIPTION
Add fake phishing site mimicking [app.hop.exchange](https://app.hop.exchange/)