### PR TITLE
uniswaplp.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1199,6 +1199,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "uniswaplp.com",
     "tokensproofxyz.claims",
     "smarttokenfixtool.com",
     "tronfunds.net",


### PR DESCRIPTION
uniswaplp.com
Fake Uniswap site phishing for funds - hits //66312712367123.com/secure.php to store address and client details
https://urlscan.io/result/e211e149-4cc7-42ad-aae7-2243525c0cd0/
address: 0x24a4b33bfa8e32b3456f95381de429c11c2c6fd6 (eth)
address: 0x727a4BfE7FB2F70C218A2408709651706ec60A81 (eth)
address: 0xcf39b7793512f03f2893c16459fd72e65d2ed00c (eth)