### PR TITLE
Add uniswaplp.com to the blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1199,6 +1199,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "uniswaplp.com",
     "polakstrater.com",
     "polkrastarter.com",
     "uniswaplp.com",


### PR DESCRIPTION
Currently being used for an active phishing campaign against Uniswap users