### PR TITLE
uniswapv3lp.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1200,6 +1200,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "uniswapv3lp.com",
     "xn--trzor-7za.io",
     "ethdw.top",
     "ethju.xyz",


### PR DESCRIPTION
uniswapv3lp.com
Fake Uniswap site phishing for funds 
https://urlscan.io/result/7afc93f2-54d4-4a35-98d9-79677da22a89/
address: 0x112893F553D48a3917475FEc16867a063d15e89d (eth)
address: 0xEAB5FD5c3C781514C1264730fCfD8420e6df6E8e (eth)
address: 0xcAB2FD99E002fB29E4Ac6aacDA371971de1F6Bf8 (eth)
address: 0xFFB2b004D89983D55dDa6Beb927b7d43fBfaDf7f (eth)
address: 0xd9D49546c9353f6EbfD6eE28c6Db506Ca0645381 (eth)
address: 0x51d2bF67fAaf714c248e5624E02aC74D75378F47 (eth)
address: 0x8239Fc719F4Fb9184Eb3D1c50F79a9b52B23eD1B (eth)