### PR TITLE
removing switchere.com from blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1580,7 +1580,6 @@
     "dex-cex.org",
     "ethpk.top",
     "launchairdrop-dapp.com",
-    "switchere.com",
     "eth-radar.com",
     "convex.finance",
     "ethpw.top",


### PR DESCRIPTION
this site was incorrectly flagged as phishing