### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1202,6 +1202,8 @@
   "blacklist": [
     "websolution.pages.dev",
     "airdrop3x.com",
+    "lpbalancer.com",
+    "uniclaimv2.com",
     "aavereward.com",
 		"dappsprotocol.netlify.app",
 		"dappwalletvault.com",


### PR DESCRIPTION
Fake "airdrop" liquidity provisioning scams - scammer drops fake token, user checks token name - it contains a bait URL - if the user signs an approval they get rekt.

"lpbalancer.com",
![image](https://user-images.githubusercontent.com/49607867/179792542-bc555c38-bbd8-49e8-b050-552b327aac01.png)
![image](https://user-images.githubusercontent.com/49607867/179793851-ad637304-e895-4197-b085-f4cc8254ee62.png)
`0xeDe11D3d5dd7D5454844f6f121cc106bF1144a45`

Related to https://twitter.com/dubstard/status/1549414764459220993

"uniclaimv2.com",
![image](https://user-images.githubusercontent.com/49607867/179792382-ed57b121-6f1f-4a5b-a8bb-1555142b7113.png)


Both those belong to the same organized e-crime syndicate that has `balancerlp.com` and also `lpuniswap.com`, `v3lpuniswap.com`. `uniswaplp.org`. `lpuniswap.org`, `uniaward.org`, `unilp.org` and `univ3lp.org`, which were already revoked due to abuse reports.

The same faith shall come to `uniclaimv2.com` and `lpbalancer.com` as well.

The scammers likely have dozens if not hundreds more domains prepared on standby.

