### PR TITLE
Add opensea-token.live to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1202,6 +1202,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "opensea-token.live",
     "mettamaskzendesk.com",
     "ammearn.club",
     "twblocknet.com",


### PR DESCRIPTION
Phishing website (not endorsed by OpenSea)