### PR TITLE
More fake Crypto Site in Google Ads

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1203,6 +1203,8 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "polwygon.com",
+    "povlygon.com",
     "polygonpool.com",
     "polygonwallets.wordpress.com",
     "openseal.im",


### PR DESCRIPTION
Fake sites impersonating Polygon being promoted in Google Ads.