### PR TITLE
Site Redirect to Seed Phrase Theft

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1203,6 +1203,8 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "porlygon.com",
+    "polxygon.com",
     "polygonpool.com",
     "polygonwallets.wordpress.com",
     "openseal.im",


### PR DESCRIPTION
Adding two domains who redirect to a seed phrase theft site hosted on polwygon[.]com