### PR TITLE
Whitelist: matic.network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "matic.network",
     "divity.app",
     "metamask-institutional.io",
     "pastelindustries.usermd.net",


### PR DESCRIPTION
Please whitelist the official 'Polygon (previously Matic)' domain: 'matic.network', as there are still subdomains/services in-use on matic.network.

Web: https://matic.network - redirects to https://polygon.technology
Official Polygon Web:: https://polygon.technology
Official Polygon Github (Verified): https://github.com/maticnetwork