### PR TITLE
Allowlist form.jotform.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1330,7 +1330,6 @@
 		"dapps-web-synchroznize.pages.dev",
 		"dappscbridge.com",
 		"dynamicvalidate.netlify.app",
-		"form.jotform.com",
 		"hodldefconnections-fixed.live",
 		"integrals-dex-bridge.com",
 		"issue-validator.com",

--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "jotform.com",
     "thecryptobonus.com",
     "metamost.com",
     "matic.network",


### PR DESCRIPTION
It seems main form subdomain of [Jotform](https://www.jotform.com/) which is "form.jotform.com" marked as phishing. Can you please whitelist it asap?

Thanks.