### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -18311,6 +18311,7 @@
     "withdrawal-support-polygon-matic.site",
     "woliet-poiygen.com",
     "wollat-pejygen.com",
-    "xn--app-plygon-kbb.com"
+    "xn--app-plygon-kbb.com",
+    "captcha.fi"
   ]
 }


### PR DESCRIPTION
Added captcha.fi to blacklist. It's linked to a fake captcha bot on discord that then asks for metamask seed phrase. See https://captcha.fi/meta/unlock.html for an example.