### PR TITLE
Add teamredminer to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1210,7 +1210,7 @@
   "blacklist": [
     "teamredminer.info",
     "teamredminer.com",
-    "www.teamredminer.com"
+    "www.teamredminer.com",
     "hopbridger.exchange",
     "polygonto.site",
     "coinrecovery.org",

--- a/src/config.json
+++ b/src/config.json
@@ -1208,6 +1208,9 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "teamredminer.info",
+    "teamredminer.com",
+    "www.teamredminer.com",
     "coinrecovery.org",
     "hopl.exchange",
     "deficentralnode.com",


### PR DESCRIPTION
Currently, [it ships with ransomware](https://opentip.kaspersky.com/19696FB9D56448054914AB9E7068A2127B857F655B10101169544D9E487F50AA/).

![image](https://user-images.githubusercontent.com/45835846/184934608-e773b7de-e65c-4a1b-888e-918f7bdee688.png)

(The relevant one here is [`Trojan-PSW.Win32.Disco.ezh`](https://howtofix.guide/trojan-psw-win32-disco/))