### PR TITLE
Add seaclaim.io to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1208,6 +1208,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "seaclaim.io",
     "openports.io",
     "hopbridger.exchange",
     "polygonto.site",


### PR DESCRIPTION
Phishing website - posing as OpenSea, asking users to connect their wallet to claim tokens.