### PR TITLE
Various Seed Phrase Theft Site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1209,6 +1209,16 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "chainlyist.pw",
+    "polyigonwl.space",
+    "ledger-warllets.pw",
+    "polyigonwl.site",
+    "ledrgerwe.pw",
+    "ledrgerwe.space",
+    "poluygon.pw",
+    "dydx.date",
+    "unlswap.host",
+    "opehsae.org",
     "mydaapslink.live",
     "frenzyducksnft.com",
     "metamaskweb.netlify.app",


### PR DESCRIPTION
Various domains hosted on the same server as an active seed phrase theft site impersonating Polygon.