### PR TITLE
Fake Validator Site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1211,6 +1211,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "polygonearn.com",
     "sea-gives.art",
     "polygonto.tech",
     "secure.transaction.openseal",


### PR DESCRIPTION
Site impersonates Polygon claiming to be a validator service and attempts to get victims to approve spending USDT.