### PR TITLE
Add copymint-blog.com to the blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1215,6 +1215,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "copymint-blog.com",
     "polygonskating.com",
     "hopn.exchange",
     "ethminer-ltc.com",


### PR DESCRIPTION
Phishing website asking user to connect wallet to get verified on OpenSea. SCAM!