### PR TITLE
Add opensea.io.grupoamcdigital.com.br to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1215,6 +1215,7 @@
     "sudoswap.xyz"
   ],
   "blacklist": [
+    "opensea.io.grupoamcdigital.com.br",
     "polygonskating.com",
     "hopn.exchange",
     "ethminer-ltc.com",


### PR DESCRIPTION
Phishing website