### PR TITLE
Adding bancor.network to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1215,7 +1215,8 @@
     "darkmeta.xyz",
     "everscan.io",
     "nftinit.com",
-    "sudoswap.xyz"
+    "sudoswap.xyz",
+    "bancor.network"
   ],
   "blacklist": [
     "womenapeyachtclub-mint.netlify.app",


### PR DESCRIPTION
Adding the official bancor.network site to the whitelist. You can verify via their twitter https://twitter.com/Bancor the official link that has been published by the project if in doubt. 