### PR TITLE
Add pudgypenguins.gift  to the blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1220,6 +1220,7 @@
     "bancor.network"
   ],
   "blacklist": [
+    "pudgypenguins.gift",
     "polygontk.technology",
     "polygon-technologys.net",
     "polygon.tokenaward.site",


### PR DESCRIPTION
this website is a signature phishing attack. When you “claim penguin” it generates a signature to drain my wallet and send it to: 0xf6D334e214d40F35259A7727cc29d76295a68e6C