### PR TITLE
Remove signinwithethereum.org 

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1655,7 +1655,6 @@
 		"metamasky.top",
 		"pancakeswap.mx",
 		"pancakeswapdapp.com",
-		"signinwithethereum.org",
 		"trustwallet-newupdate.estacionamientoaeropuertosantiago.cl",
 		"trustwallet-securitybreach.estacionamientoaeropuertosantiago.cl",
 		"uniswap-eth.com",


### PR DESCRIPTION
- Removes `signinwithethereum.org` from the denylist. 

The site is a community-run IdP hosted with support from the ENS DAO. 