### PR TITLE
Remove Legitimate Site from Blacklist [1]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1677,7 +1677,6 @@
     "woliat-poiygom.com",
     "blockhasha.com",
     "coinresolution.click",
-    "dapp.tenup.io",
     "dappswallets.schlimited.com",
     "dappsynch.xyz",
     "dashnity.com",


### PR DESCRIPTION
dapp.tenup.io
domain was inadvertently added to the blacklist
#8607