### PR TITLE
Add Legitimate Sites to Whitelist [1]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "usemoralis.com",
     "cryptofitties.com",
     "polkagate.xyz",
     "keeper-wallet.app",


### PR DESCRIPTION
usemoralis.com
seems to be getting flagged by the fuzzy list
#8615