### PR TITLE
add elrond to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,10 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "elrond.com",
+    "maiar.com",
+    "maiar.exchange",
+    "maiarlaunchpad.com",
     "usemoralis.com",
     "cryptofitties.com",
     "polkagate.xyz",


### PR DESCRIPTION
add elrond sites to whitelist

As seen in issues, fixes: #8924 , #8919 , #8912 , #8909 , #8908 , #8902 , #8901 , #8899 , #8893 , #8889 , #8888 , #8885 , #8883 , #8882 , #8876 , #8875 , #8870 , #8869 , #8868 and counting