### PR TITLE
Add Legitimate Sites to Whitelist [1]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "infinity.ai",
     "metablaze.xyz",
     "elrond.com",
     "maiar.com",


### PR DESCRIPTION
infinity.ai
non-crypto site caught by fuzzylist
#8996