### PR TITLE
remove false positive from blacklist to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -20,6 +20,7 @@
   ],
   "whitelist": [
     "infinity.ai",
+    "uniswapfoundation.org",
     "register.sandbox.game",
     "metablaze.xyz",
     "elrond.com",
@@ -1821,7 +1822,6 @@
     "uniswapassets.tech",
     "uniswapbuybot.com",
     "uniswapc.net",
-    "uniswapfoundation.org",
     "uniswapi.cloud",
     "uniswapj.com",
     "uniswapk.com",


### PR DESCRIPTION
remove false positive from blacklist to whitelist

`uniswapfoundation.org` is legit, 100% my fault
![image](https://user-images.githubusercontent.com/49607867/197173020-11c7f192-c3bb-4fd5-8a50-ada0e7f35004.png)
