### PR TITLE
Add Legitimate Sites to Whitelist - evermart.com.br

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "evermart.com.br",
     "infinity.ai",
     "register.sandbox.game",
     "metablaze.xyz",


### PR DESCRIPTION
This is not a crypto website.