### PR TITLE
Allow trinity.studio which is legitimate

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -621,6 +621,7 @@
     "trinity.one",
     "trinity.org",
     "trinity.pw",
+    "trinity.studio",
     "trinity.tech",
     "axis.com",
     "oasa.co",


### PR DESCRIPTION
fixes #9036

This domain is not for phishing site.