### PR TITLE
Site Impersonating Polygon Wiki

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1256,6 +1256,7 @@
     "acus.dev"
   ],
   "blacklist": [
+    "doc-polygonnetwork.org",
     "opensea-blogs.com",
     "sischan.com",
     "bridgehopprotocol.com",


### PR DESCRIPTION
Site impersonates Polygon Wiki to attempt to connect users to fake support staff.