### PR TITLE
Add seaclaim.xyz to the blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1256,6 +1256,7 @@
     "acus.dev"
   ],
   "blacklist": [
+    "seaclaim.xyz",
     "doc-polygonnetwork.org",
     "opensea-blogs.com",
     "sischan.com",


### PR DESCRIPTION
Phishing website, impersonating OpenSea