### PR TITLE
Add dfinitiv.io to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -185,6 +185,7 @@
     "cryptopatties.xyz",
     "definfty.io",
     "difinite.com",
+    "dfinitiv.io",
     "dinify.io",
     "divinity.ca",
     "divinity.es",


### PR DESCRIPTION
When checking the domain `dfinitiv.io` against https://metamask.github.io/eth-phishing-detect/, the reason provided is `This domain was blocked for its similarity to dfinity.org, a historical phishing target.`

`dfinitiv.io` is a domain belonging to a legitimate startup with no affinity of any kind to `dfinity.org`