### PR TITLE
Add opensel.su to the blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1257,6 +1257,8 @@
     "acus.dev"
   ],
   "blacklist": [
+    "nft.opensel.su",
+    "opensel.su",
     "xn--opensablog-vmb.com",
     "seaclaim.xyz",
     "doc-polygonnetwork.org",


### PR DESCRIPTION
This is a phishing website.
Example: https://nft.opensel.su/assets/0x531cfc9515407312491308xc3b97x938x9bx8dfc3 (phishing link)
URLscan: https://urlscan.io/result/a4555c5b-5e2d-422c-b356-a35c8f7a0495