### PR TITLE
raydium.fi

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1258,6 +1258,7 @@
     "acus.dev"
   ],
   "blacklist": [
+    "raydium.fi",
     "trezoriowallett.com",
     "app-trezor.io",
     "cryptosmartrestore.com",


### PR DESCRIPTION
raydium.fi
Fake DEX phishing for assets (tokens and NFTs) - API: //kai.worldofwomen-claim.art/ https://urlscan.io/result/416bde91-03e2-47fb-9167-80523ee62f85/
address: 0xfec8b2fc82379763efe06b986b52359460a998bf (eth)