### PR TITLE
Add openbeta.io to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "openbeta.io",
     "betterscan.io",
     "artgobblers.com",
     "zksync.crew3.xyz",


### PR DESCRIPTION
Hi, I'm the founder of openbeta.io, a nonprofit rock climbing wiki.

#8460 
#8027
#7693
#6464

---
<img width="569" alt="Screen Shot 2022-11-07 at 2 59 17 AM" src="https://user-images.githubusercontent.com/3805254/200212476-c11691ae-86b1-4b3a-bd23-cf46cbd60aa3.png">
