### PR TITLE
Remove balancer-d6h.pages.dev from blacklist (whitelist)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -21,6 +21,7 @@
   "whitelist": [
     "dainty.store",
     "affinity.supply",
+    "balancer-d6h.pages.dev",
     "metamang.org",
     "qactus.fr",
     "fulcrumpd.com",
@@ -1374,7 +1375,6 @@
     "app-1inch.io",
     "app-1inch.io.opiukalai.com",
     "app.1inch.host",
-    "balancer-d6h.pages.dev",
     "binanc-wallet.com",
     "bitbamk-cc.web.app",
     "cellowallet.app",


### PR DESCRIPTION
Yikes, removing 

```
"balancer-d6h.pages.dev"
```

turned out to be legit....

hat tip to @gerrrg for the lead
