### PR TITLE
Removed MM Flask support page from blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1272,7 +1272,8 @@
     "victus.sport",
     "victus.team",
     "acus.dev",
-    "finiti.rs"
+    "finiti.rs",
+    "metamask-flask.zendesk.com"
   ],
   "blacklist": [
     "itpml-by.tech",
@@ -5145,7 +5146,6 @@
     "lotteryapi.uniswap.team",
     "mergemetamask.com",
     "metamask-extension.com.yayasantqh.com",
-    "metamask-flask.zendesk.com",
     "metamask.jajawprinters.com",
     "metamask3.repl.co",
     "metamaskio.repl.co",


### PR DESCRIPTION
Removing the MM Flask support page (https://metamask-flask.zendesk.com/hc/en-us) from the blacklist and adding it to the whitelist