### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1275,6 +1275,7 @@
     "finiti.rs"
   ],
   "blacklist": [
+    "ethereum-mixer-anonymous.com",
     "itpml-by.tech",
     "usdter.pro",
     "merge-upgrade.com",


### PR DESCRIPTION
Added to Blacklist: ethereum-mixer-anonymous.com
Copy of the scam: ethereum-mixer-anonymous.ORG (domain just got suspended)