### PR TITLE
Add tezos.domains to the whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1289,7 +1289,8 @@
     "dasmeta.com",
     "metamask-flask.zendesk.com",
     "tezos.com",
-    "tezos.foundation"
+    "tezos.foundation",
+    "tezos.domains"
   ],
   "blacklist": [
     "claim-sea.com",


### PR DESCRIPTION
Please add tezos.domains to the whitelist.

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/9591