### PR TITLE
remove invity.io from fuzzylist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -18,12 +18,10 @@
     "opensea.io",
     "originprotocol.com",
     "satoshilabs.com",
-    "trezor.io",
-    "invity.io"
+    "trezor.io"
   ],
   "whitelist": [
     "tezos.domains",
-    "unity.com",
     "tenor.com",
     "tenzor.capital",
     "deefinity.com",


### PR DESCRIPTION
Reverts part of https://github.com/MetaMask/eth-phishing-detect/pull/9412/files

This has a lot of false positives - among others:

https://github.com/MetaMask/eth-phishing-detect/issues/9518
https://github.com/MetaMask/eth-phishing-detect/issues/9559
https://github.com/MetaMask/eth-phishing-detect/issues/9554


Probably `trezor.io` should be removed as well but this seems more urgent.

