### PR TITLE
Block acrossbridgeapp.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -26077,6 +26077,7 @@
     "acroos.to",
     "acros.to",
     "across.run",
+    "acrossbridgeapp.com",
     "acrosstoken.com",
     "across-token.sale",
     "trezor.run",


### PR DESCRIPTION
The correct address is across.to.

![2022-11-23-184658_795x706_scrot](https://user-images.githubusercontent.com/108695806/203614667-930bbd02-ff14-4c86-8136-641190ee2d4a.png)