### PR TITLE
Adding Legitimate Website tremor.so to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -21,6 +21,7 @@
     "trezor.io"
   ],
   "whitelist": [
+    "tremor.so",
     "tezos.domains",
     "tenor.com",
     "tenzor.capital",


### PR DESCRIPTION
This is the domain name of the tremor website, which is a legitimate open-source React project. GitHub Repo [here](https://github.com/tremorlabs/tremor). 

The `tremor.so` domain is currently blocked because of the domain name `trezor.io` being included in the fuzzylist. We would appreciate if this could be resolved soon.