### PR TITLE
block scam uniswap airdrop - eligible-uni.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -799,6 +799,7 @@
   ],
   "blacklist": [
     "hashflow.cn.com",
+    "eligible-uni.org",
     "layer-zero.io",
     "airdrop-uniswap.net",
     "app-balancer-fi.com",


### PR DESCRIPTION
block scam uniswap airdrop - `eligible-uni.org`

Scam twitter promoting this https://twitter.com/Event_Uniswap
![scam uniswap airdrop](https://user-images.githubusercontent.com/49607867/204450844-434196f1-2595-43a7-bf69-718020124ac9.png)
