### PR TITLE
add scam sites to blocklist impersonating cow swap real site cow.fi

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1280,6 +1280,7 @@
     "metamask-flask.zendesk.com"
   ],
   "blacklist": [
+    "robinswap.in",
     "swapxy.xyz",
     "metaworld1935.com",
     "etherswaps.io",

--- a/src/config.json
+++ b/src/config.json
@@ -1280,6 +1280,7 @@
     "metamask-flask.zendesk.com"
   ],
   "blacklist": [
+    "swapxy.xyz",
     "metaworld1935.com",
     "etherswaps.io",
     "sqrls-flow.com",

--- a/src/config.json
+++ b/src/config.json
@@ -1280,6 +1280,8 @@
     "metamask-flask.zendesk.com"
   ],
   "blacklist": [
+    "metaworld1935.com",
+    "etherswaps.io",
     "sqrls-flow.com",
     "3commas-platform.art",
     "3commas-platform.shop",

--- a/src/config.json
+++ b/src/config.json
@@ -1280,6 +1280,10 @@
     "metamask-flask.zendesk.com"
   ],
   "blacklist": [
+    "startcowswap.com",
+    "cowswapmirror.com",
+    "cowswaper.com",
+    "officialcowswapfi.com",
     "robinswap.in",
     "swapxy.xyz",
     "metaworld1935.com",


### PR DESCRIPTION
Report for

- officialcowswapfi.com
- cowswaper.com
- cowswapmirror.com
- startcowswap.com

Google Ad Scams Image

![Scam Image](https://imgur.com/dgaQcDO.png)