### PR TITLE
add scam sites to blocklist impersonating cow swap real site cow.fi

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -799,6 +799,10 @@
     "satoshilabs.design"
   ],
   "blacklist": [
+    "startcowswap.com",
+    "cowswapmirror.com",
+    "cowswaper.com",
+    "officialcowswapfi.com",
     "sync-cointracker.com",
     "auth0-cointracker.com",
     "btc-polygon.com",


### PR DESCRIPTION
Report for

- officialcowswapfi.com
- cowswaper.com
- cowswapmirror.com
- startcowswap.com

Google Ad Scams Image

![Scam Image](https://imgur.com/dgaQcDO.png)