### PR TITLE
Add aestus.live to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -2,6 +2,7 @@
   "version": 2,
   "tolerance": 2,
   "fuzzylist": [
+    "aestus.live",
     "auctus.org",
     "cryptokitties.co",
     "dfinity.org",


### PR DESCRIPTION
Hello,

http://aestus.live is an open project aiming to launch a new and neutral MEV relay in the ethereum ecosystem.  

We're been blocked due to fuzzymatch with autcus.org.

Thanks. 

Fixes #9422 