### PR TITLE
adidasnfts.net + more

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -799,6 +799,8 @@
     "satoshilabs.design"
   ],
   "blacklist": [
+    "metamask.io.merge.bizzcarts.com",
+    "adidasnfts.net",
     "direct.traderjjoe.xyz",
     "sstqkeqamble.com",
     "dragonrichclub.co",


### PR DESCRIPTION
adidasnfts.net
Fake Adidas NFT site phishing for funds
https://urlscan.io/result/09ee678c-2f11-482c-afb8-100b34101bed/ address: 0xB1eC2A23d60E6D903b1Bc6F09094557ba0a65E9c (eth)

metamask.io.merge.bizzcarts.com
Fake MetaMask site phishing for secrets
https://urlscan.io/result/5b76ce0c-d4b2-44df-a4a3-d98f2c8dca88/