### PR TITLE
Add phishing domain usdtgift.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -5118,6 +5118,7 @@
     "usdtbnb.top",
     "usdtbnb.xyz",
     "usdtbsc888.com",
+    "usdtgift.com",
     "usdtmining.asia",
     "usdtmining.biz",
     "usdtmining.click",


### PR DESCRIPTION
`usdtgift.com` is pretending to be **tether**.