### PR TITLE
Update config.json - Remove ethereum-france.com from blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1571,7 +1571,6 @@
     "doc-uniswap.org",
     "dogeclub.whitelist-mints.xyz",
     "ethereum-2022.org",
-    "ethereum-france.com",
     "found-eth.org",
     "free-ethereum.biz",
     "integrationnodechain.netlify.app",


### PR DESCRIPTION
REMOVE line 1574  "ethereum-france.com" from blacklist.
See https://github.com/MetaMask/eth-phishing-detect/pull/9724#issuecomment-1339916157