### PR TITLE
Add Legitimate Sites to Allowlist [1]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -21,6 +21,7 @@
     "trezor.io"
   ],
   "whitelist": [
+    "tezos.art",
     "opensci.net",
     "aestus.live",
     "tezos.finance",


### PR DESCRIPTION
tezos.art
not a scam site, caught by fuzzy list
#9744