### PR TITLE
adding site to allowlist [1]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -21,6 +21,7 @@
     "trezor.io"
   ],
   "whitelist": [
+    "texor.org",
     "tezos.art",
     "opensci.net",
     "aestus.live",


### PR DESCRIPTION
fixes #9792

Only adding to the allowlist to prevent being caught in fuzzylogic against trezor domain