### PR TITLE
add scam site impersonating pudgy penguins

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -26032,6 +26032,7 @@
     "cowswep.com",
     "bitbonus.fun",
     "pudgypenguins.net",
-    "pudgyegg.com"
+    "pudgyegg.com",
+    "pudgyigloos.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -26030,6 +26030,7 @@
     "fi-cow.net",
     "cow-fi.net",
     "cowswep.com",
-    "bitbonus.fun"
+    "bitbonus.fun",
+    "pudgypenguins.net"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -26031,6 +26031,7 @@
     "cow-fi.net",
     "cowswep.com",
     "bitbonus.fun",
-    "pudgypenguins.net"
+    "pudgypenguins.net",
+    "pudgyegg.com"
   ]
 }


### PR DESCRIPTION
These scam sites are impersonating the real pudgy penguins, real site: https://www.pudgypenguins.com/

Scam Sites
- https://pudgypenguins.net/raffle/
- https://pudgyegg.com/
- http://pudgyigloos.com/



<img width="565" alt="image" src="https://user-images.githubusercontent.com/10101970/207159489-12b2f8dd-2a87-4bf9-ad8c-524e9748bc48.png">

<img width="1588" alt="image" src="https://user-images.githubusercontent.com/10101970/207159539-f5b2af52-a9bf-43f1-aa95-e463f0f3bcf9.png">

<img width="1545" alt="image" src="https://user-images.githubusercontent.com/10101970/207167819-34e1e6cb-25c2-4a9a-96e0-583972f1b27a.png">

<img width="571" alt="image" src="https://user-images.githubusercontent.com/10101970/207168373-8b446f1d-6f38-466e-8040-21a850baa0eb.png">

