### PR TITLE
Add Legitimate Sites to Allowlist [10]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -20,6 +20,16 @@
     "satoshilabs.com"
   ],
   "whitelist": [
+    "cactus.school",
+    "cactus.ws",
+    "cactus.io",
+    "cactus.bg",
+    "cactus.ly",
+    "cactus.green",
+    "cactus.md",
+    "cactus.fm",
+    "cactus.markets",
+    "cactus.ag",
     "definite.org",
     "definite.app",
     "hyfinity.com",


### PR DESCRIPTION
cactus domains getting hit by fuzzylist "auctus.org"

None are crypto related

cactus.school #4956 
cactus.ws #6678
cactus.io #6864
cactus.bg #7650
cactus.ly #7678
cactus.green #7858
cactus.md #9427 
cactus.fm #9847 
cactus.markets #9858 
cactus.ag #9928