### PR TITLE
add scam urls targeting pudgy penguins

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -26070,6 +26070,7 @@
     "bitbonus.fun",
     "pudgypenguins.net",
     "pudgyegg.com",
-    "pudgyigloos.com"
+    "pudgyigloos.com",
+    "pudgypenguinsdrop.xyz"
   ]
 }


### PR DESCRIPTION
This scam sites is impersonating the real pudgy penguins, real site: https://www.pudgypenguins.com/

Scam Sites

- https://pudgypenguinsdrop.xyz

Twitter Scam link

- https://twitter.com/pudgypenguins_n/status/1602438573294223362?s=46&t=W78GmijkVLiAZPcnbYpNjg


<img width="575" alt="image" src="https://user-images.githubusercontent.com/10101970/207192169-c08e9bee-9493-4cca-8b98-7e3ca0a439eb.png">

<img width="1765" alt="image" src="https://user-images.githubusercontent.com/10101970/207192320-23eb6442-26af-47a7-9dd9-45309c7c4351.png">
