### PR TITLE
add scam targeting blur

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -26070,6 +26070,7 @@
     "bitbonus.fun",
     "pudgypenguins.net",
     "pudgyegg.com",
-    "pudgyigloos.com"
+    "pudgyigloos.com",
+    "blurs.io"
   ]
 }


### PR DESCRIPTION
This scam sites is impersonating the real blur nft marketplace, real site: https://blur.io/

Scam Sites

- https://blurs.io/
  - Twitter scam link https://twitter.com/blur_io__/status/1600858370185256960


<img width="549" alt="image" src="https://user-images.githubusercontent.com/10101970/207201456-b4dbd452-48ae-4994-ac1f-d9ee403c7f42.png">

<img width="1586" alt="image" src="https://user-images.githubusercontent.com/10101970/207201618-64bb1b21-9959-46f1-af9f-382bc91d3943.png">
