### PR TITLE
add scams targetting cow swap

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -26448,6 +26448,8 @@
     "pudgyegg.com",
     "pudgyigloos.com",
     "blurs.io",
-    "pudgypenguinsdrop.xyz"
+    "pudgypenguinsdrop.xyz",
+    "protocolcowswap.com",
+    "fi-cow.com"
   ]
 }


### PR DESCRIPTION
These scam sites are impersonating the real cow swap, real site: https://cow.fi

Scam Sites

- https://protocolcowswap.com
- https://fi-cow.com

![image](https://user-images.githubusercontent.com/10101970/207478515-926417c6-021e-4685-b470-4c58388e14ad.png)
![image](https://user-images.githubusercontent.com/10101970/207478527-a8dcedcd-a2ab-4325-9ae3-f2f4ed34a884.png)
![image](https://user-images.githubusercontent.com/10101970/207478539-00de3532-f14f-4fc7-b8a9-7444d3aa39b8.png)


