### PR TITLE
add to blocklist scams targetting Small Bros

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -27250,6 +27250,8 @@
     "defi-event.net",
     "stablefixprotocol.online",
     "pudgy-drop.com",
-    "pudgy-claim.com"
+    "pudgy-claim.com",
+    "small-bros.xyz",
+    "small-bros.wl-pre.com"
   ]
 }


### PR DESCRIPTION
Scam targetting Small Bros NFT, real site https://smallbrosnft.app/ , real twitter https://twitter.com/SmallBrosNFT

Scam Links
- https://small-bros.xyz
- https://small-bros.wl-pre.com

![image](https://user-images.githubusercontent.com/10101970/208754249-ba0ea74f-efb3-41d7-b5d9-2413dc60a3ad.png)

<img width="1755" alt="image" src="https://user-images.githubusercontent.com/10101970/208754306-f73f592b-865e-4ef6-879a-4b61ab9c48e0.png">
