### PR TITLE
add to blocklist scams targeting Pudgy Penguins

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -27384,6 +27384,7 @@
     "small-bros.wl-pre.com",
     "pudgypenguins.claimit.cc",
     "pudgydrops.com",
-    "zk-sync.art"
+    "zk-sync.art",
+    "thepudgypenguins.xyz"
   ]
 }


### PR DESCRIPTION
Add scam link targetting Pudgy Penguins.

Scam Links

- http://thepudgypenguins.xyz/
  - twitter link https://twitter.com/pudgypenguin_/status/1548320943562297344
  - linktree link https://linktr.ee/pudgypenguinsnft
  
  
<img width="358" alt="image" src="https://user-images.githubusercontent.com/10101970/209001496-48f65e23-b70d-4c0f-bf5f-d21555340534.png">


<img width="714" alt="image" src="https://user-images.githubusercontent.com/10101970/209001464-f58fe944-99a4-4b69-b2d8-18c6abc4d20a.png">
