### PR TITLE
feat: add openscan.it to the whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -366,6 +366,7 @@
     "openset.com",
     "opensteak.com",
     "openscan.eu",
+    "openscan.it",
     "openswan.org",
     "affinity.locus",
     "opendev.at",


### PR DESCRIPTION
<openscan.it> is a legitimate domain owned by [NaturalSelectionLabs](https://github.com/NaturalSelectionLabs) (I'm a dev member of the organization).

The domain, openscan.it, is going to gradually replace rss3.io, for its memorability. For more info please visit <https://docs.rss3.io>

Close #10042.