### PR TITLE
add to blocklist scam targeting Mutant Hounds Collars

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -27777,6 +27777,7 @@
     "pudgypenguinss.web3prmint.com",
     "pudgypenguins.prize.gift",
     "trezorsuites.com",
-    "pudgypenguinsmass.xyz"
+    "pudgypenguinsmass.xyz",
+    "mutanthoundsnft.com"
   ]
 }


### PR DESCRIPTION
The official Mutant Hounds Twitter has been hacked. Here is announcement from another group https://twitter.com/mutant_cartel/status/1608515051891179520?s=46&t=gHzqgQn3WfbnR_O-G1mRQw 

Scam Links
- https://mutanthoundsnft.com/
  - Twitter Source: Announcing scam airdrop https://twitter.com/MutantHounds/status/1608528581856227328 
  
 
<img width="532" alt="image" src="https://user-images.githubusercontent.com/10101970/209993988-ac0ef7bf-54cd-4dfd-9cc4-1e5125bab74b.png">

<img width="543" alt="image" src="https://user-images.githubusercontent.com/10101970/209994047-16030444-d254-4414-9584-d64ecc341860.png">

<img width="1752" alt="image" src="https://user-images.githubusercontent.com/10101970/209994117-78f392d2-c745-4b06-bce3-1f57f23b42ed.png">
