### PR TITLE
Remove dfninity from fuzzylist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -4,7 +4,6 @@
   "fuzzylist": [
     "auctus.org",
     "cryptokitties.co",
-    "dfinity.org",
     "launchpad.ethereum.org",
     "etherscan.io",
     "fulcrum.trade",


### PR DESCRIPTION
I kindof think we should just deprecate the fuzzylist. This repo has 1.3k issues on it, almost all of which are probably overly aggressive fuzzylist blocking. This is unfair to the blocked sites.

Fixes #9503