### PR TITLE
add to blocklist scams targeting Zetachain, DAO Maker, Pudgy Penguins, ZenAcademy, and Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1112,7 +1112,7 @@
     "ethereum-erc.me",
     "ethereumcode-platform.com",
     "ethereumcode-trade.com",
-    "ethereumhub33.com",    
+    "ethereumhub33.com",
     "ethereumhub33.me",
     "ethereumkk.com",
     "fast-ethereum.icu",
@@ -28157,6 +28157,7 @@
     "mutanthoundsnft.com",
     "animalconcert.net",
     "pudgypenguinsmass.xyz",
-    "daomaker.art"
+    "daomaker.art",
+    "daomaker.zone"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -28158,6 +28158,7 @@
     "animalconcert.net",
     "pudgypenguinsmass.xyz",
     "daomaker.art",
-    "daomaker.zone"
+    "daomaker.zone",
+    "mint-pudgypenguins.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -28159,6 +28159,8 @@
     "pudgypenguinsmass.xyz",
     "daomaker.art",
     "daomaker.zone",
-    "mint-pudgypenguins.com"
+    "mint-pudgypenguins.com",
+    "zenacademynft.xyz",
+    "arbitrum.su"
   ]
 }


### PR DESCRIPTION
Scam site pretending do be daomaker.com is being used to setup a phishing page for Zetachain users

and another scam pretending to be Pudgy Penguins

Scam Links

- https://daomaker.zone/company/zeta-chain/
  - Scam telegram source https://t.me/zettachainofficial
- https://mint-pudgypenguins.com
- https://zenacademynft.xyz
  - scam twitter post https://twitter.com/Zens_Academy/status/1610298875595874304
- https://arbitrum.su
  - scam twitter post https://twitter.com/cornwellstyling/status/1610389725415718918 


<img width="923" alt="image" src="https://user-images.githubusercontent.com/10101970/210432001-a4d37282-9f20-40ad-a3ba-fabae0476e27.png">

<img width="1761" alt="image" src="https://user-images.githubusercontent.com/10101970/210432884-272a5f0e-6050-4a0e-b027-e9ebd1c5ff9c.png">

<img width="531" alt="image" src="https://user-images.githubusercontent.com/10101970/210494654-7307584a-b9c1-4cbc-a2c8-ab39c32f3597.png">

<img width="1532" alt="image" src="https://user-images.githubusercontent.com/10101970/210494755-a0fe7065-8371-4129-bad4-a17a16d49a5e.png">


<img width="530" alt="image" src="https://user-images.githubusercontent.com/10101970/210494718-cd6f772a-53e2-4332-8e8b-18a26ac4786f.png">

