### PR TITLE
add-hosts: omit redundant hosts from result

### DIFF
--- a/src/add-hosts.js
+++ b/src/add-hosts.js
@@ -83,13 +83,14 @@ if (require.main === module) {
   }
 
   const detector = new PhishingDetector(config);
+  let newHosts = [];
 
   try {
-    hosts.filter(h => validateHostRedundancy(detector, section, h));
+    newHosts = hosts.filter(h => validateHostRedundancy(detector, section, h));
   } catch (err) {
     console.error(err);
     process.exit(1);
   }
 
-  addHosts(SECTION_KEYS[section], hosts, destFile);
+  addHosts(SECTION_KEYS[section], newHosts, destFile);
 }


### PR DESCRIPTION
Existing version warns about redundant hosts but still includes them. After this change, redundant hosts are not added to the list.