### PR TITLE
add to blocklist scams targeting Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -28457,6 +28457,7 @@
     "daomaker.zone",
     "mint-pudgypenguins.com",
     "zenacademynft.xyz",
-    "coolcatsnft.io"
+    "coolcatsnft.io",
+    "arbitrum.su"
   ]
 }


### PR DESCRIPTION
Add to blocklist scam targeting Arbitrum, real site https://arbitrum.io/

Scam Links

- https://arbitrum.su
  - scam twitter post https://twitter.com/cornwellstyling/status/1610389725415718918 
  
  
<img width="581" alt="image" src="https://user-images.githubusercontent.com/10101970/210610401-bbfa6fe1-c9ff-480e-a79b-cd38c4e81706.png">

  
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/10101970/210610350-b0fc78ea-36d8-44f8-8010-a7ff5f71e8c4.png">
