### PR TITLE
Add claim-dai2.com to blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -15164,6 +15164,7 @@
     "claim-azuki.live",
     "claim-bayc.com",
     "claim-coolcatsnft.com",
+    "claim-dai2.com",
     "claim-moonbirds.xyz",
     "claim-worldofwomen.art",
     "cryptopunks-claim.app",


### PR DESCRIPTION
`claim-dai2.com` is a scam targeting DAI holders. Their site is a copy of `makerdao.com`.