### PR TITLE
Remove from phishing sites

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -854,7 +854,6 @@
     "opensea-extended.com", 
     "opensea.cash", 
     "withkoji.com",
-    "tofunft.com", 
     "oddities.fhnfts.com", 
     "oddities.now-minting.xyz",
     "deviatorsnft.xyz",   


### PR DESCRIPTION
We cannot determine that tofunft.com that is a marketplace with a proven track record. is applicable.