### PR TITLE
Add mint.lostutopias.xyz to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -58,6 +58,7 @@
     "qactus.fr",
     "fulcrumpd.com",
     "metamax.work",
+    "mint.lostutopias.xyz",
     "ahotus.com",
     "openbeta.io",
     "betterscan.io",


### PR DESCRIPTION
Domain: mint.lostutopias.xyz

Details: *
Main domain is https://lostutopias.xyz/
You can check it. It is not a phishing site.
https://mint.lostutopias.xyz/ is our free mint page, it didn't charge any token, it was a charity program.

"https://metamask.github.io/eth-phishing-detect/" and "https://cryptoscamdb.org/search" also returned [This domain is not blocked! No problem here.]*

 I have checked to make sure that [there is not a duplicate issue](https://github.com/MetaMask/eth-phishing-detect/issues)