### PR TITLE
Add scams targetting Aztec

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -29464,6 +29464,7 @@
     "optimism-airdrop.live",
     "mdmvn.xyz",
     "mmvmd.io",
-    "pudgypenguens.com"
+    "pudgypenguens.com",
+    "multiwallet-connects.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -29469,4 +29469,5 @@
     "multiwallet-connects.com",
     "pudgypinguins.com",
     "pudgypenguins-nft.com"
+  ]
 }


### PR DESCRIPTION
## Scam links
- [multiwallet-connects.com](https://multiwallet-connects.com)

## Description

Full scam URL is https://www.multiwallet-connects.com/0x/ 

More details in this report by Discord User https://app.chainpatrol.io/admin/aztec/reports/179?reportIds=179 

From Discord User:

"""
I asked in the group how to transfer from L2 to L1. A person who claimed to be the administrator of Aztec Network added me as a friend, said that he could help, and then guided me to another website: https://www.multiwallet-connects.com/0x /, where zkwa2WETH
Convert to zkETH
, I also need to ask my Aztec Account Address and metamask address, let me transfer 0.018ETH at https://www.multiwallet-connects.com/0x/"
"""



## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/01/18/image-31GU.png)
