### PR TITLE
Block fake UMA domain

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -29465,6 +29465,7 @@
     "optimism-airdrop.live",
     "mdmvn.xyz",
     "mmvmd.io",
-    "pudgypenguens.com"
+    "pudgypenguens.com",
+    "uma-coin.xyz"
   ]
 }


### PR DESCRIPTION
Discord users are being DM-spammed with this link, offering a fake airdrop.

![image](https://user-images.githubusercontent.com/108695806/213328987-b5d595a2-0596-45a9-b1a3-5132630b36e5.png)