### PR TITLE
Remove Domains From Fuzzylist [7]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -2,20 +2,13 @@
   "version": 2,
   "tolerance": 2,
   "fuzzylist": [
-    "auctus.org",
     "cryptokitties.co",
     "launchpad.ethereum.org",
     "etherscan.io",
-    "fulcrum.trade",
-    "hederahashgraph.com",
-    "localcryptos.com",
-    "localethereum.com",
     "makerfoundation.com",
-    "maskmeta.org",
     "metamask.io",
     "myetherwallet.com",
     "opensea.io",
-    "originprotocol.com",
     "satoshilabs.com"
   ],
   "whitelist": [


### PR DESCRIPTION
Removing domains from the fuzzylist. The presence of these domains in the fuzzylist generate far too many allowlist requests. Some may have been active projects at the time but are no longer popular or inactive domains.

"auctus.org",
"fulcrum.trade",
"hederahashgraph.com",
"localcryptos.com",
"localethereum.com",
"maskmeta.org",
"originprotocol.com",