### PR TITLE
Add new phishing domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -901,6 +901,7 @@
     "ethberlin.org"
   ],
   "blacklist": [
+    "chirulabs.net",
     "azuki.ws",
     "whitelisted-doodles.com",
     "genesis-doodles.app",


### PR DESCRIPTION
Add new Azuki NFT phishing domain:
```
chirulabs.net
```