### PR TITLE
Add fake revoke.cash to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1281,6 +1281,7 @@
     "metamask-flask.zendesk.com"
   ],
   "blacklist": [
+    "revoken.cash",
     "polkastartercom.com",
     "chimpersnft.org",
     "metamask-toolset.onrender.com",


### PR DESCRIPTION
Fake Pranksy account is directing users to revoke access to OpenSea due to a (false) contract exploit.

Tweet: https://twitter.com/caseystubbs/status/1619044633933385729?s=20&t=nxF_0zErCBh8DOoaQkWoVQ

Twitter redirects to: beacon.ai/pranksy which hosts malicious link to fake revoke.cash