### PR TITLE
Add scams targetting Azuki

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1322,7 +1322,7 @@
     "uniswaape-app.com",
     "ussf-67.com",
     "www-polkastarler.com",
-    "ioratoken.com",    
+    "ioratoken.com",
     "winselfhelplinejgjkjk-hfjh9878009.online",
     "lab-arbitrum.com",
     "lab-adidas.com",
@@ -31297,6 +31297,8 @@
     "boredsjobs.com",
     "ethgiftx.com",
     "memes6529.xyz",
-    "suite.trezor.io.zeptunion.com"
+    "suite.trezor.io.zeptunion.com",
+    "azukigardens.net",
+    "azukico.xyz"
   ]
 }


### PR DESCRIPTION
## Scam links
- [azukigardens.net](https://azukigardens.net)
- [azukico.xyz](https://azukico.xyz)

## Description

Scams targeting azuki

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/01/27/Screenshot_20230127-150736_Firefox-SCs9.jpg)
