### PR TITLE
Add fake revoke.cash to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -901,6 +901,7 @@
     "ethberlin.org"
   ],
   "blacklist": [
+    "revoken.cash",
     "world-hilumia.com",
     "erdefimining.com",
     "allblockchaindapp.godaddysites.com",


### PR DESCRIPTION
Fake Pranksy account is directing users to revoke access to OpenSea due to a (false) contract exploit.

Tweet: https://twitter.com/caseystubbs/status/1619044633933385729?s=20&t=nxF_0zErCBh8DOoaQkWoVQ

Twitter redirects to: beacon.ai/pranksy which hosts malicious link to fake revoke.cash (revoken[.]cash)