### PR TITLE
fix(whitelist): ipfs.io breaks OpenSea projects

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -898,7 +898,8 @@
     "razor.network",
     "satoshilabs.design",
     "goerli.net",
-    "ethberlin.org"
+    "ethberlin.org",
+    "ipfs.io"
   ],
   "blacklist": [
     "revoken.cash",


### PR DESCRIPTION
ipfs.io domain should be whitelisted. OpenSea is using ipfs.io as IPFS gateway, hence many generative projects (or projects with animated scripts) that are hosted on IPFS do not work. [OpenSea problem](https://opensea.io/assets/ethereum/0x708f94690076b08fa24e60c01a85054350dbcfc2/850566621)

<img width="1627" alt="image" src="https://user-images.githubusercontent.com/5672094/215337257-548176c4-d31f-42d8-b428-0ccb21f53ce8.png">
