### PR TITLE
blacklist lido-xyz.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -22845,6 +22845,7 @@
     "myethdex.com",
     "ethcombo.com",
     "locaibitcoins.net",
+    "lido-xyz.com",
     "giveaway-transfer.com",
     "decentralized-exchange.info",
     "mcafeenow.net",


### PR DESCRIPTION
- impersonating lido
- use of `eth_sign`
- obfuscated source