### PR TITLE
Adding zora.fun to the blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -932,6 +932,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "zora.fun",
     "devdappsengine.pages.dev",
     "staking-ipor.com",
     "anyswap-start.org",


### PR DESCRIPTION
seaport farming to steal NFTs