### PR TITLE
Add Scams to BL

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,11 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "bitmixersonline.com",
+    "balticasopot.pl",
+    "bitmix.cc",
+    "coinpal.eu",
+    "bitcoinmixer.ru",
     "art-blocks.xyz",
     "artnblocks.io",
     "artblocks-claim.com",

--- a/src/config.json
+++ b/src/config.json
@@ -958,7 +958,6 @@
     "bitmix.cc",
     "coinpal.eu",
     "bitcoinmixer.ru",
-    "etherc.net",
     "art-blocks.xyz",
     "artnblocks.io",
     "artblocks-claim.com",


### PR DESCRIPTION
--- Domains Used By Cloaking Redirection ---
bitmixersonline.com: subdomains blender.bitmixersonline.com (blender.io) and eth.bitmixersonline.com ----------
balticasopot.pl: Search "balticasopot.pl mixer" on google and see the cloaking, redirecting to bitmixersonline.com ethereum-mixer-eth-mixer.com (already BL and well referenced) also redirects to the above scam.
bitmix.cc / coinpal.eu / bitcoinmixer.ru Scams with the same design as previous scam mentioned promoted by a fake youtube channel: https://www.youtube.com/@TechInstantHelp/videos