### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "bestmixer.pro",
     "bitmixersonline.com",
     "balticasopot.pl",
     "bitmix.cc",


### PR DESCRIPTION
Fishing Scam of: bestmixer.IO ("bestmixer.io has been seized and shut down by European police for reportedly laundering over $200 million in cryptocurrency"). You can see in their footer the domain pretend to be open since 2017 (which was the case for the real .IO website), but this fishing domain has been registered in 2020. They also kept the Github link in their footer for showing: bestmixer.IO github page. You can also see in their footer that the links have been badly copied... "Partnership Program (/en/) | Terms of Use (/de/)" while this scam copy doesn't offer multiple language.

This scam is targeting crypto users in general, including USDT/ETH which can impact MM users.

* Sorry for not grouping this pull with my previous one, I just realized my previous pull request for this domain didn't go through as I didn't join any explanation to it.