### PR TITLE
Update one BL entry

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -953,7 +953,7 @@
     "ipfs.io"
   ],
   "blacklist": [
-    "bitmixersonline.com",
+    "bitcoin7577.com",
     "balticasopot.pl",
     "bitmix.cc",
     "coinpal.eu",


### PR DESCRIPTION
bitmixersonline.com has just been eactivated by registrar, and scammers now redirect to new domain: eth.bitcoin7577.com (same scam).