### PR TITLE
Update config.json to block pudgy-tanks.xyz 

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1281,6 +1281,7 @@
     "metamask-flask.zendesk.com"
   ],
   "blacklist": [
+    "pudgy-tanks.xyz",
     "revoken.cash",
     "polkastartercom.com",
     "chimpersnft.org",


### PR DESCRIPTION
Drainer site found in the description of a collection being wash traded on OpenSea. Impersonation of Pudgy Penguins.