### PR TITLE
Block metamaskw.cc and myetherwalleten.cc

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -954,6 +954,8 @@
   ],
   "blacklist": [
     "vulcan.pm",
+    "metamaskw.cc",
+    "myetherwalleten.cc",
     "apecoin-info.com",
     "alchemixfiprotocol.com",
     "alchemist-official.xyz",


### PR DESCRIPTION
Block `metamaskw.cc` and `myetherwalleten.cc`
The [same IP](https://www.virustotal.com/gui/ip-address/103.164.62.38/relations) also hosts `metamaskv.cc` (already blocked)

![image](https://user-images.githubusercontent.com/49607867/218298411-7843dbb3-8687-4bac-8a58-ec9f6bc8e445.png)
![image](https://user-images.githubusercontent.com/49607867/218298413-c205c033-4581-4617-99d1-b6efb77c2231.png)
![image](https://user-images.githubusercontent.com/49607867/218298417-f8de2877-c539-4bdc-b8b6-d0fab4579d4b.png)

hat tip / discovered by [@harugasumi](https://twitter.com/harugasumi)