### PR TITLE
namecheap/sendgrid phishing email domain bip-portal.info

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -957,6 +957,7 @@
     "metamaskw.cc",
     "myetherwalleten.cc",
     "apecoin-info.com",
+    "bip-portal.info",
     "alchemixfiprotocol.com",
     "alchemist-official.xyz",
     "whitelist-premint.com",


### PR DESCRIPTION
https://www.bleepingcomputer.com/news/security/namecheaps-email-hacked-to-send-metamask-dhl-phishing-emails/