### PR TITLE
removing site from blocklist [1] and adding sites to blocklist [4]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -957,6 +957,7 @@
     "metaflipmarket.com",
     "liveverse.world",
     "dappreader.static.app",
+    "magicalworld.cool",
     "connect-land.netlify.app",
     "vulcanverify.us",
     "vulcam.xyz",

--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,10 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "cosmo-pads.web.app",
+    "metaflipmarket.com",
+    "liveverse.world",
+    "dappreader.static.app",
     "connect-land.netlify.app",
     "vulcanverify.us",
     "vulcam.xyz",
@@ -1265,7 +1269,6 @@
     "vww-opensea.com",
     "syn-dpps.web.app",
     "eth-kan.com",
-    "geodoge.com",
     "bakery-woo.org",
     "digidaigdaku.com",
     "ethmz1.xyz",


### PR DESCRIPTION
geodoge.com not malicious

blocklist:
cosmo-pads.web.app 1000113
metaflipmarket.com 1000073
liveverse.world 1000223
dappreader.static.app 1000227