### PR TITLE
Added urls based on automatic detections for drainer scripts

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -35545,6 +35545,12 @@
     "xn--neptnernutual-6yc.com",
     "lido-airdrop.com",
     "op-reward.xyz",
-    "xn--ptimsm-zva7b.net"
+    "xn--ptimsm-zva7b.net",
+    "tridentdao1-free.xyz",
+    "ens.credit",
+    "kitsumintu.com",
+    "beanz.app",
+    "arbitrum-one.net",
+    "mountvitruvious.art"
   ]
 }


### PR DESCRIPTION
I won't disclose the methods we used in our detections publicly, as this would make evasion by the attacker trivial. However, I have sent this information to the Slack channel if you need to verify/confirm.

All of these are drainers, with a few of them live as of only 20 minutes prior to my PR.