### PR TITLE
Updated blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "cac.ubcusdt.com",
     "alfaformas.com",
     "openocean-dapp.org",
     "diemjoinwallet.com",


### PR DESCRIPTION
Fake minting website reported through Zendesk support - http://cac[dot]ubcusdt[dot]com