### PR TITLE
Add new phishing domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,11 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "deno-guild.online",
+    "scord.gg",
+    "di.scord.gg",
+    "pandezlab.com",
+    "vulcanverify.eu",
     "cac.ubcusdt.com",
     "alfaformas.com",
     "openocean-dapp.org",

--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "oauth2-discord.com",
     "deno-guild.online",
     "scord.gg",
     "di.scord.gg",

--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,9 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "antispam-bot.com",
+    "mee6.pm",
+    "xn--scord-m4a.com",
     "d.xn--scord-m4a.com",
     "xn--iscord-v2a.com",
     "oauth2-discord.com",

--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,8 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "d.xn--scord-m4a.com",
+    "xn--iscord-v2a.com",
     "oauth2-discord.com",
     "deno-guild.online",
     "scord.gg",


### PR DESCRIPTION
Add new Vulcan phishing domain:
```
vulcanverify.eu
```

Add new Pandez phishing domain:
```
pandezlab.com
```

Add new Discord phishing domains:
```
scord.gg
di.scord.gg
deno-guild.online
oauth2-discord.com
d.xn--scord-m4a.com
xn--scord-m4a.com
xn--iscord-v2a.com
```

Add new Mee6 phishing domains:
```
antispam-bot.com
mee6.pm
```