### PR TITLE
port #10499

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -7998,6 +7998,7 @@
     "whitelist-digidaigaku.com",
     "aptlabs.site",
     "etherc.net",
+    "polkastartercom.com",
     "chimpersnft.org",
     "x2y2.io.users.trade",
     "nfarcade1-free.xyz",


### PR DESCRIPTION
At c674d89e, the current base branch `main` was forked off from the previous `master`. Subsequent changes to `master` where made after this.

#10499 is one of those, and was never ported over to main, which is done here. I have not reviewed the domain as such.