### PR TITLE
Add scams targeting Eth Denver

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -36169,6 +36169,7 @@
     "optismfounds.com",
     "optimism.connect-web3.app",
     "connect-web3.app",
-    "blurdrop.art"
+    "blurdrop.art",
+    "go-ethdenver.com"
   ]
 }


### PR DESCRIPTION
## Scam links
- [go-ethdenver.com](https://go-ethdenver.com)

## Description

Google search ad for eth Denver. Organizer posted a warning about it on Discord server: https://discord.com/channels/541487144884240436/644214191019786251/1077040271742742618

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/02/20/Screenshot_20230219-203728-3VH4.png)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/02/20/Screenshot_20230219-203820-18b1.png)
