### PR TITLE
Add fake Arbitrum token sale site arbitrum[.]bio to blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -36127,6 +36127,7 @@
     "xn--nptunmutal-z6ae49n.com",
     "xn--ptuemutual-dnb3570gea.com",
     "xn--repturemtual-ole.com",
+    "arbitrum.bio",
     "optismfnd.com",
     "aptosfoudation.org",
     "dookeydash.biz",


### PR DESCRIPTION
This domain is impersonating https://bridge.arbitrum.io (with many copied images) in an attempt to sell a fake Arbitrum token.