### PR TITLE
Add new phishing domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,11 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "etherdeals.xyz",
+    "orionswap.io",
+    "anti-spambot.re",
+    "mee6.re",
+    "vulcanclient.xyz",
     "wick-bot.cam",
     "worldofwoman.io",
     "blurboredape.com",

--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "liquityprotocol.org",
     "etherdeals.xyz",
     "orionswap.io",
     "anti-spambot.re",


### PR DESCRIPTION
Add new fake OTC swap sites:
```
etherdeals.xyz
orionswap.io
```

Add new Mee6 phishing domains:
```
anti-spambot.re
mee6.re
```

Add new Vulcan phishing domain:
```
vulcanclient.xyz
```

Add new Liquidity Protocol phishing domain ([Ref 1](https://twitter.com/LiquityProtocol/status/1627605124985024512), [Ref 2](https://twitter.com/PeckShieldAlert/status/1627608826458554369)):
```
liquityprotocol.org
```