### PR TITLE
Add fake Liquity airdrop

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -36170,6 +36170,7 @@
     "optimism.connect-web3.app",
     "connect-web3.app",
     "blurdrop.art",
-    "go-ethdenver.com"
+    "go-ethdenver.com",
+    "liquityprotocol.org"
   ]
 }


### PR DESCRIPTION
Someone just posted a link to this page on the Liquity Discord, through a compromised account.