### PR TITLE
Add scams targetting Taiko

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -36224,7 +36224,6 @@
     "blurdrop.art",
     "xn--trzor-csa.net",
     "go-ethdenver.com",
-    "taikoalpha.com",
-    "loopring.gg"
+    "taikoalpha.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -36215,6 +36215,8 @@
     "connect-web3.app",
     "blurdrop.art",
     "xn--trzor-csa.net",
-    "go-ethdenver.com"
+    "go-ethdenver.com",
+    "taikoalpha.com",
+    "loopring.gg"
   ]
 }


### PR DESCRIPTION
## Scam links
- [taikoalpha.com](https://taikoalpha.com)
- [loopring.gg](https://loopring.gg)

## Description

We saw an announcement appear in the Taiko discord leading to a scam site.

We saw the same thing happen in Looping discord and others, this could be a mass bot compromise targeting many servers.

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/02/20/Screenshot_20230220-185343_Firefox-4v1E.jpg)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/02/20/Screenshot_20230220-185347_Firefox-6uZb.jpg)
