### PR TITLE
Add scams targetting Optimism

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -36329,6 +36329,7 @@
     "blurdrop.art",
     "xn--trzor-csa.net",
     "go-ethdenver.com",
-    "taikoalpha.com"
+    "taikoalpha.com",
+    "xn--ptimism-00a.net"
   ]
 }


### PR DESCRIPTION
## Scam links
- [xn--ptimism-00a.net](https://xn--ptimism-00a.net)

## Description

From scam twitter https://twitter.com/fnd_optimism/status/1628036418562924544

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/02/21/image-4Ujc.png)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/02/21/image-7Qda.png)
