### PR TITLE
apecoin.is

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "apecoin.is",
     "sewer-pass.club",
     "register.mocaversenft.com",
     "nfarcade-pass.netlify.app",


### PR DESCRIPTION
apecoin.is
Fake ApeCoin site phishing for assets
https://urlscan.io/result/26e2559d-eb41-412d-861f-e9f9270ac984/ address: 0xb96B2EB882d599c8caCC37CDB9C73802A1BE36Ff (eth)


Sends data to //web3env.herokuapp.com/backend/connection POST `{"address":"0x000","walletBalanceInEth":"1","isMobile":false,"websiteUrl":"https://apecoin.is/claim/","websiteDomain":"apecoin.is","ipData":{"ip":"Unknown","country_name":"Unknown"}}`