### PR TITLE
Block "supranfts.com",

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -954,6 +954,7 @@
   ],
   "blacklist": [
     "apecoin.is",
+    "supranfts.com",
     "sewer-pass.club",
     "register.mocaversenft.com",
     "nfarcade-pass.netlify.app",


### PR DESCRIPTION
Part of campaign using the dumped emails from OpenSea So legitimate OS users get baited with scams on their OS registered emails....
![image](https://user-images.githubusercontent.com/49607867/220424317-9e9706bf-60f9-4b4d-8698-07a207fd04df.png)
Scam registered yesterday
![image](https://user-images.githubusercontent.com/49607867/220424429-15f0030f-08ca-47f6-931a-8dcdf5835720.png)
![image](https://user-images.githubusercontent.com/49607867/220424577-b8aa6088-f02e-45e5-965a-84f146e27a9d.png)

```
"supranfts.com",
```

everything on bitcoin-dns.com is a scam, no exceptions
