### PR TITLE
Add os-event.site to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -958,6 +958,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "os-event.site",
     "blurtokens.io",
     "airdropsblur.com",
     "biur-drop.com",


### PR DESCRIPTION
OpenSea scam token (phishing)