### PR TITLE
Add new phishing domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -961,6 +961,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "vulcan-xyz.netlify.app",
     "collab.land.wf",
     "land.wf",
     "remove-spam.net",

--- a/src/config.json
+++ b/src/config.json
@@ -961,6 +961,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "unicryptauth.com",
     "api-callab.land",
     "antibotspam.link",
     "antispambot.in",

--- a/src/config.json
+++ b/src/config.json
@@ -961,6 +961,9 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "remove-spam.net",
+    "mee6.la",
+    "dynosverify.netlify.app",
     "api4collab-land.com",
     "unicryptauth.com",
     "api-callab.land",

--- a/src/config.json
+++ b/src/config.json
@@ -961,6 +961,8 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "collab.land.wf",
+    "land.wf",
     "remove-spam.net",
     "mee6.la",
     "dynosverify.netlify.app",

--- a/src/config.json
+++ b/src/config.json
@@ -961,6 +961,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "api4collab-land.com",
     "unicryptauth.com",
     "api-callab.land",
     "antibotspam.link",

--- a/src/config.json
+++ b/src/config.json
@@ -961,6 +961,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "dashboard-asset.netlify.app",
     "collab.land.gy",
     "land.gy",
     "vulcan-xyz.netlify.app",

--- a/src/config.json
+++ b/src/config.json
@@ -961,6 +961,8 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "collab.land.gy",
+    "land.gy",
     "vulcan-xyz.netlify.app",
     "collab.land.wf",
     "land.wf",

--- a/src/config.json
+++ b/src/config.json
@@ -961,6 +961,10 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "api-callab.land",
+    "antibotspam.link",
+    "antispambot.in",
+    "coinbase.surf",
     "bot-vulcan.com",
     "api-callob.land",
     "api-connect-assets.netlify.app",

--- a/src/config.json
+++ b/src/config.json
@@ -961,6 +961,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "nospambots.xyz",
     "dashboard-asset.netlify.app",
     "collab.land.gy",
     "land.gy",


### PR DESCRIPTION
Add new Collab.Land phishing domain:
```
api-callab.land
api4collab-land.com
collab.land.wf
land.wf
collab.land.gy
land.gy
dashboard-asset.netlify.app
```

Add new Discord phishing domains:
```
antibotspam.link
antispambot.in
unicryptauth.com
remove-spam.net
mee6.la
dynosverify.netlify.app
vulcan-xyz.netlify.app
nospambots.xyz
```

Add new Coinbase phishing domain:
```
coinbase.surf
```