### PR TITLE
remove domain from blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -988,7 +988,6 @@
     "500event.top",
     "bccgxmas.com",
     "pledge-mutanthounds.com",
-    "v2-app.compound.finance",
     "optirnism.network",
     "optimism-fd.com",
     "akcbmint.com",


### PR DESCRIPTION
hello! i believe this domain was incorrectly added to the blacklist. `v2-app.compound.finance` is still the correct site running the V2 compound finance protocol. 

this can be confirmed by navigating there from `app.compound.finance`, the v3 protocol app: https://app.compound.finance/

thanks!