### PR TITLE
Add claims-digidaigaku.com to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -962,6 +962,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "claims-digidaigaku.com",
     "api1collab-land.com",
     "captcha-bot.guild-assist.click",
     "guild-assist.click",


### PR DESCRIPTION
scam minting site (phishing)