### PR TITLE
Add new phishing domains circleswap[.]fi and circleswap[.]finance

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -963,6 +963,8 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "circleswap.fi",
+    "circleswap.finance",
     "circle-usdc.com",
     "claim-defybirds.com",
     "join-dimensionals.com",


### PR DESCRIPTION
The scammer uses a drainer script that is located in the /dex/io/swap/js/config.js of the base URL.