### PR TITLE
Add new phishing domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -963,6 +963,13 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "verifydyno.xyz",
+    "guild.security-assist.co.uk",
+    "security-assist.co.uk",
+    "guild-captcha.com",
+    "zcm.deno.dev",
+    "guildassist.re",
+    "token-holdings.netlify.app",
     "xrabbits.web3-premint.xyz",
     "wonderpals.web3-premint.xyz",
     "wickensnft-mint.pdma.live",


### PR DESCRIPTION
Add new misc Discord phishing domains:
```
verifydyno.xyz
guild.security-assist.co.uk
security-assist.co.uk
guild-captcha.com
zcm.deno.dev
guildassist.re
```

Add new Collab.Land phishing domain:
```
token-holdings.netlify.app
```