### PR TITLE
svb-usdc.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -963,6 +963,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "svb-usdc.net",
     "xrabbits.web3-premint.xyz",
     "wonderpals.web3-premint.xyz",
     "wickensnft-mint.pdma.live",


### PR DESCRIPTION
svb-usdc.net
Fake USDC claim site phishing for funds
https://urlscan.io/result/89b94810-89c0-44e7-9280-c89d478bb996/