### PR TITLE
Add one phishing/scam mixer

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -963,6 +963,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "bitmixing.net",
     "xn--strgate-qwa.com",
     "xn--layerzro-60a.network",
     "spambotdetection.click",


### PR DESCRIPTION
Another Scam that copied the old bitcoinmix.org's design.
( Targeting ETH users https://bitmixing.net/eth.html )