### PR TITLE
Add scams targetting Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -40042,6 +40042,10 @@
     "arbitrurn.foundation",
     "arbitrun.foundation",
     "aribitrum.foundation",
-    "arbtrum.foundation"
+    "arbtrum.foundation",
+    "arbitrum.cliamdrop.net",
+    "cliamdrop.net",
+    "arbitrums.web3-prmint.xyz",
+    "web3-prmint.xyz"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -40048,6 +40048,7 @@
     "arbitrums.web3-prmint.xyz",
     "web3-prmint.xyz",
     "arbitrumtechnologies.com",
-    "collabdapp.surge.sh"
+    "collabdapp.surge.sh",
+    "airdrops-optimism.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -40049,6 +40049,7 @@
     "web3-prmint.xyz",
     "arbitrumtechnologies.com",
     "collabdapp.surge.sh",
-    "airdrops-optimism.com"
+    "airdrops-optimism.com",
+    "optimismlab.net"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -40034,6 +40034,8 @@
     "wen-arbitrum.com",
     "arbitrum-eth.com",
     "wl-airdrop.xyz",
-    "wldrops.xyz"
+    "wldrops.xyz",
+    "arbitrumfoundations.com",
+    "arbtrum-wen.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -40036,6 +40036,7 @@
     "wl-airdrop.xyz",
     "wldrops.xyz",
     "arbitrumfoundations.com",
-    "arbtrum-wen.com"
+    "arbtrum-wen.com",
+    "arbittrum-foundation.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -40037,6 +40037,11 @@
     "wldrops.xyz",
     "arbitrumfoundations.com",
     "arbtrum-wen.com",
-    "arbittrum-foundation.com"
+    "arbittrum-foundation.com",
+    "arbitrums.foundation",
+    "arbitrurn.foundation",
+    "arbitrun.foundation",
+    "aribitrum.foundation",
+    "arbtrum.foundation"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -40046,6 +40046,8 @@
     "arbitrum.cliamdrop.net",
     "cliamdrop.net",
     "arbitrums.web3-prmint.xyz",
-    "web3-prmint.xyz"
+    "web3-prmint.xyz",
+    "arbitrumtechnologies.com",
+    "collabdapp.surge.sh"
   ]
 }


### PR DESCRIPTION
## Scam links
- [arbitrumfoundations.com](https://arbitrumfoundations.com)
- [arbtrum-wen.com](https://arbtrum-wen.com)
- "arbittrum-foundation.com",
- "arbitrums.foundation",
- "arbitrurn.foundation",
- "arbitrun.foundation",
- "aribitrum.foundation",
- "arbtrum.foundation"
- "web3-prmint.xyz",
- "arbitrumtechnologies.com",
- "collabdapp.surge.sh",
- "airdrops-optimism.com",
- "optimismlab.net"

## Description



## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/03/17/Screenshot_20230317-002713_Firefox-5r9r.jpg)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/03/17/Screenshot_20230317-002719_Firefox-5b5P.jpg)
