### PR TITLE
Add scams targetting Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -40052,6 +40052,8 @@
     "airdrops-optimism.com",
     "optimismlab.net",
     "arbitrun.io",
-    "arbitrum.press"
+    "arbitrum.press",
+    "claim-arbitrum.cx",
+    "arbitrum.digital"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -40050,6 +40050,8 @@
     "arbitrumtechnologies.com",
     "collabdapp.surge.sh",
     "airdrops-optimism.com",
-    "optimismlab.net"
+    "optimismlab.net",
+    "arbitrun.io",
+    "arbitrum.press"
   ]
 }


### PR DESCRIPTION
## Scam links
- [arbitrun.io](https://arbitrun.io)
- [arbitrum.press](https://arbitrum.press)
- claim-arbitrum.cx
- arbitrum.digital

## Description

<img width="1454" alt="image" src="https://user-images.githubusercontent.com/10101970/226066148-d7352bb5-f7d8-4c64-a054-20146102828d.png">



## Screenshots


