### PR TITLE
Add scams targetting Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -40050,6 +40050,8 @@
     "arbitrumtechnologies.com",
     "collabdapp.surge.sh",
     "airdrops-optimism.com",
-    "optimismlab.net"
+    "optimismlab.net",
+    "arbitrun.io",
+    "arbitrum.press"
   ]
 }


### PR DESCRIPTION
## Scam links
- [arbitrun.io](https://arbitrun.io)
- [arbitrum.press](https://arbitrum.press)

## Description



## Screenshots


