### PR TITLE
Add scams targetting Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -40066,6 +40066,9 @@
     "arbitrun.io",
     "arbitrum.press",
     "claim-arbitrum.cx",
-    "arbitrum.digital"
+    "arbitrum.digital",
+    "arbitrumofficial.com",
+    "arbitrum.rip",
+    "thearbitrum.com"
   ]
 }


### PR DESCRIPTION
## Scam links
- [arbitrumofficial.com](https://arbitrumofficial.com)
- [arbitrum.rip](https://arbitrum.rip)
- [thearbitrum.com](https://thearbitrum.com)

## Description

These sites are imitating bridge.arbitrum.io and arbitrum.foundation

## Screenshots


