### PR TITLE
Add scams targetting Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -40067,6 +40067,7 @@
     "arbitrun.io",
     "arbitrum.press",
     "claim-arbitrum.cx",
-    "arbitrum.digital"
+    "arbitrum.digital",
+    "abritum.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -40068,6 +40068,9 @@
     "arbitrum.press",
     "claim-arbitrum.cx",
     "arbitrum.digital",
-    "abritum.com"
+    "abritum.com",
+    "airbirturm-foundation.com",
+    "aerbitrum.foundation",
+    "arbitum-foundation.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -40071,6 +40071,9 @@
     "abritum.com",
     "airbirturm-foundation.com",
     "aerbitrum.foundation",
-    "arbitum-foundation.com"
+    "arbitum-foundation.com",
+    "arbittrum.com",
+    "arbirtum.com",
+    "arbiturm.com"
   ]
 }


### PR DESCRIPTION
## Scam links
- [abritum.com](https://abritum.com)
- "airbirturm-foundation.com",
- "aerbitrum.foundation",
- "arbitum-foundation.com",
- "arbittrum.com",
- "arbirtum.com",
- "arbiturm.com"

## Description

<img width="1463" alt="image" src="https://user-images.githubusercontent.com/10101970/226087202-fc870e94-3ce7-48f6-b971-c8d296f069bf.png">


## Screenshots


