### PR TITLE
Add scams targetting Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -41115,6 +41115,7 @@
     "arbitrum-drop.info",
     "foundation-arbitrum.app",
     "foundation-arbitrum.net",
-    "claim-arbitrum.cc"
+    "claim-arbitrum.cc",
+    "abi-reward.xyz"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -41102,6 +41102,19 @@
     "arditrum.foundation",
     "arbitrum-drop.net",
     "join-arbitrum.com",
-    "whitelist-arbtrum.com"
+    "whitelist-arbtrum.com",
+    "arbitrumbot.com",
+    "arbitrum-arb.tech",
+    "airdroparbitrum.net",
+    "airdroparbitrum.org",
+    "arbitrumlive.foundation",
+    "arbitruml.foundation",
+    "arbtruim.foundation",
+    "arbitrumtoken.org",
+    "arbitrumtoken.foundation",
+    "arbitrum-drop.info",
+    "foundation-arbitrum.app",
+    "foundation-arbitrum.net",
+    "claim-arbitrum.cc"
   ]
 }


### PR DESCRIPTION
## Scam links
- [arbitrumbot.com](https://arbitrumbot.com)
- [arbitrum-arb.tech](https://arbitrum-arb.tech)
- [airdroparbitrum.net](https://airdroparbitrum.net)
- [airdroparbitrum.org](https://airdroparbitrum.org)
- [arbitrumlive.foundation](https://arbitrumlive.foundation)
- [arbitruml.foundation](https://arbitruml.foundation)
- [arbtruim.foundation](https://arbtruim.foundation)
- [arbitrumtoken.org](https://arbitrumtoken.org)
- [arbitrumtoken.foundation](https://arbitrumtoken.foundation)
- [arbitrum-drop.info](https://arbitrum-drop.info)
- [foundation-arbitrum.app](https://foundation-arbitrum.app)
- [foundation-arbitrum.net](https://foundation-arbitrum.net)
- [claim-arbitrum.cc](https://claim-arbitrum.cc)

## Description



## Screenshots


