### PR TITLE
Remove Legit from BL

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1435,7 +1435,6 @@
     "the-bitcointrendapp.algostage.com",
     "the-bitsoft360app-com.algostage.com",
     "the-crypto-methodapp.algostage.com",
-    "the-crypto-mixer.com",
     "the-ethereum-codeapp.algostage.com",
     "the-ethereum-profit.algostage.com",
     "the-ethereum-trader-app.net",


### PR DESCRIPTION
I believe this is a mistake,
The-crypto-mixer.COM is a legit mixer that provides a signed Letter of Guarantee, I already used it once and it worked okay. Can you provide your letter of guarantee to prove that it is a scam/fake mixer ?
* The phishing scam was the-crypto-mixer.ORG (a copy of the .COM that has already been banned).