### PR TITLE
Add Phishing Sites to Blocklist [8]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -965,6 +965,14 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "rarible-giftcard-promo.premintweb3.com",
+    "walletsbugfix.pages.dev",
+    "garbage-friend.in",
+    "web.coiresolveapps.live",
+    "bridge-zksync.com",
+    "zksync-cryptodrop.com",
+    "launchpads.network",
+    "consensystrade.online",
     "dynocaptcha.netlify.app",
     "collab.land.fail",
     "land.fail",


### PR DESCRIPTION
1016174, 1016373, 1016555, 1017627, 1016211, 1014796 548b83dc-3c01-44fc-b577-72c14bc81ab4

--
"rarible-giftcard-promo.premintweb3.com",
"walletsbugfix.pages.dev",
"garbage-friend.in",
"web.coiresolveapps.live",
"bridge-zksync.com",
"zksync-cryptodrop.com",
"launchpads.network",
"consensystrade.online",