### PR TITLE
Add scams targetting Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,4 +1,3 @@
-
 {
   "version": 2,
   "tolerance": 2,
@@ -42420,6 +42419,29 @@
     "arbitrum-io.live",
     "arbitrum.tw",
     "gifts-arbitrum.org",
-    "claim-arbitrum.at"
+    "claim-arbitrum.at",
+    "arb-claims.xyz",
+    "air-arbitrum.com",
+    "2nd-arbitrum.foundation",
+    "airbitrum.org",
+    "arbirtrums.com",
+    "arbitrium.pages.dev",
+    "arbitruim.space",
+    "arbirutm.foundation",
+    "arbitrum-arb.us",
+    "arbitrumclaimconnect.areth.live",
+    "areth.live",
+    "arbitrumcrypt.com",
+    "arbitrum-company.com",
+    "arbitrum.eu.com",
+    "arbitrum-drop.site",
+    "arbitrum-crypto.top",
+    "arbitrum-drop.icu",
+    "arbitrum-labs.info",
+    "arbltrum.de",
+    "arbltrum-foundatlon.com",
+    "bridge-arbitruom.com",
+    "claimsarbitrum.com",
+    "dao-arbitrum.com"
   ]
 }


### PR DESCRIPTION
## Scam links
- [arb-claims.xyz](https://arb-claims.xyz)
- [air-arbitrum.com](https://air-arbitrum.com)
- [2nd-arbitrum.foundation](https://2nd-arbitrum.foundation)
- [airbitrum.org](https://airbitrum.org)
- [arbirtrums.com](https://arbirtrums.com)
- [arbitrium.pages.dev](https://arbitrium.pages.dev)
- [arbitruim.space](https://arbitruim.space)
- [arbirutm.foundation](https://arbirutm.foundation)
- [arbitrum-arb.us](https://arbitrum-arb.us)
- [arbitrumclaimconnect.areth.live](https://arbitrumclaimconnect.areth.live)
- [areth.live](https://areth.live)
- [arbitrumcrypt.com](https://arbitrumcrypt.com)
- [arbitrum-company.com](https://arbitrum-company.com)
- [arbitrum.eu.com](https://arbitrum.eu.com)
- [arbitrum-drop.site](https://arbitrum-drop.site)
- [arbitrum-crypto.top](https://arbitrum-crypto.top)
- [arbitrum-drop.icu](https://arbitrum-drop.icu)
- [arbitrum-labs.info](https://arbitrum-labs.info)
- [arbltrum.de](https://arbltrum.de)
- [arbltrum-foundatlon.com](https://arbltrum-foundatlon.com)
- [bridge-arbitruom.com](https://bridge-arbitruom.com)
- [claimsarbitrum.com](https://claimsarbitrum.com)
- [dao-arbitrum.com](https://dao-arbitrum.com)

## Description



## Screenshots


