### PR TITLE
Add scams targetting Arbitrum

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -42465,6 +42465,15 @@
     "arbrltrum.foundation",
     "arbitrum-reward.io",
     "arbitrum-foundawtion.site",
-    "arbitrum-give.us"
+    "arbitrum-give.us",
+    "airbitrum.app",
+    "arbirtium.com",
+    "arbitrium.icu",
+    "arbitrtum.com",
+    "arbitrium.ink",
+    "arbitirum.net",
+    "arbitrumcrypto.live",
+    "arbitrum-network.space",
+    "drops-arbitrum.com"
   ]
 }


### PR DESCRIPTION
## Scam links
- [airbitrum.app](https://airbitrum.app)
- [arbirtium.com](https://arbirtium.com)
- [arbitrium.icu](https://arbitrium.icu)
- [arbitrtum.com](https://arbitrtum.com)
- [arbitrium.ink](https://arbitrium.ink)
- [arbitirum.net](https://arbitirum.net)
- [arbitrumcrypto.live](https://arbitrumcrypto.live)
- [arbitrum-network.space](https://arbitrum-network.space)
- [drops-arbitrum.com](https://drops-arbitrum.com)

## Description



## Screenshots


