### PR TITLE
enseth.domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -966,6 +966,7 @@
     "metarisk.com"
   ],
   "blacklist": [
+    "enseth.domains",
     "chainspace.nft-premints.xyz",
     "brightmomentsnft.xyz",
     "bridgemeetis.com",


### PR DESCRIPTION
enseth.domains
Fake ENS domain phishing for funds
https://urlscan.io/result/a30bd2bc-3773-4d65-bede-722d3af5b7bd/ address: 0x4e5c564fE3DA52c1F88C6A95163A91d0FDb1898F (eth)