### PR TITLE
allowlist: add launchpad.ethereum.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -509,7 +509,8 @@
     "boyensea.me",
     "satoshilabs.com",
     "satoshilabs.design",
-    "metarisk.com"
+    "metarisk.com",
+    "launchpad.ethereum.org"
   ],
   "blacklist": [
     "mask-tokens.io",


### PR DESCRIPTION
#12162 

This is an alternative to #12171 - only one of these should be merged.