### PR TITLE
test: verify that every fuzzylist entry is also in allowlist

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1196,6 +1196,11 @@ function startTests () {
     t.end()
   })
 
+  test("all fuzzylist entries are present in allowlist", (t) => {
+    testListIsContained(t, config.fuzzylist, config.whitelist)
+    t.end()
+  })
+
   test("config does not contain redundant entries", (t) => {
     testListNoBlocklistRedundancies(t, config)
     testListNoAllowlistRedundancies(t, config)
@@ -1254,6 +1259,14 @@ function testListIsPunycode (t, list) {
   list.forEach((domain) => {
     t.equals(domain, punycode.toASCII(domain), `domain "${domain}" is encoded in punycode`)
   })
+}
+
+function testListIsContained (t, needles, stack) {
+  needles.forEach((domain) => {
+    if (!stack.includes(domain)) {
+      t.fail(`${domain} in fuzzylist but not present in allowlist`, domain)
+    }
+  });
 }
 
 function testListDoesntContainRepeats (t, list) {


### PR DESCRIPTION
As the fuzzylist is exclusively used to protect against impersonations, this adds a tests that verifies that the fuzzylist is contained in the allowlist.

This should prevent future incidents like #12162 