### PR TITLE
Add heymint.pm to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -953,6 +953,7 @@
     "ipfs.io"
   ],
   "blacklist": [
+    "heymint.pm",
     "airdrops-apecoin.com",
     "anatanft.freemiting.cyou",
     "animetaverses.club",


### PR DESCRIPTION
Full URL for OpenSea impersonator scam is:

heymint.pm/openseapro