### PR TITLE
scripts/add-hosts: fix dangling async file write

### DIFF
--- a/src/add-hosts.js
+++ b/src/add-hosts.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const fs = require('fs');
+const { writeFileSync } = require('fs');
 const config = require('./config.json');
 const PhishingDetector = require('./detector')
 
@@ -17,7 +17,7 @@ const addHosts = (section, domains, dest) => {
 
   const output = JSON.stringify(cfg, null, 2) + '\n';
 
-  fs.writeFile(dest, output, (err) => {
+  writeFileSync(dest, output, (err) => {
     if (err) {
       return console.log(err);
     }


### PR DESCRIPTION
This replaces an orphaned async `fs.writeFile` with a sync `fs.writeFileSync`. This ensures that the file gets consistently written before continuing.