### PR TITLE
[scripts/add-hosts,validate-new-config] Fix redundancy validation

### DIFF
--- a/src/validate-new-config.js
+++ b/src/validate-new-config.js
@@ -73,8 +73,9 @@ try {
         [section]: Array.from(newHosts),
       };
       const detector = new PhishingDetector(cfg);
+      const allNewHosts = new Set(newConfig[section]);
       for (const host of baseHosts) {
-        if (newHosts.has(host)) {
+        if (newHosts.has(host) || !allNewHosts.has(host)) {
           continue;
         }
         if (!validateHostRedundancy(detector, listName, host)) {


### PR DESCRIPTION
Currently, when adding multiple entries, the `add:blocklist` and `add:allowlist` scripts will assume input is consistent, and accept internally inconsistent additions.

Examples:

```
$ yarn add:blocklist foo.example.com example.com
$ yarn add:blocklist example.com foo.example.com
```

This adds checks for that, only adding a consistent set of entries.

~#12234 complements this in that it allows the process to complete and write a new config even in face of invalid blocklist entries.~


Related:
  - #12391
  - #12392

Also contains fix where `validate-new-config` would incorrectly throw on removed entries. [Example](https://github.com/MetaMask/eth-phishing-detect/actions/runs/4822878408/jobs/8590655639)