### PR TITLE
removed unlock-protocol.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -816,7 +816,6 @@
     "uniswap.launch-v2.org",
     "uniswapcoin.net",
     "uniswaps.net",
-    "unlock-protocol.com",
     "vulcan.to",
     "whitelist-dogecoin.com",
     "www-1nch.com.trustpadx.org",


### PR DESCRIPTION
I am not sure how https://unlock-protocol.com/ ended up on that list...
Please let us know if there is something we should fix on our end.
Thanks