### PR TITLE
Add scams from ChainPatrol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -43142,6 +43142,8 @@
     "arbitrumbridge.zone",
     "arbjtum.com",
     "roadmap-arbitrum.com",
-    "xn--arbtrum-iza.com"
+    "xn--arbtrum-iza.com",
+    "arbitrurn.claimnow.cloud",
+    "claimnow.cloud"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -43132,6 +43132,16 @@
     "cryptopad-eth.io",
     "optimismairdrop.io",
     "optimism-lab.co",
-    "live-optimism.info"
+    "live-optimism.info",
+    "airdrops-arbitrum.net",
+    "arbietrum.foundation",
+    "arbitrum-airdrop2023.com",
+    "arbitrum-airdrop.one",
+    "arbitrum-air.net",
+    "arbitrum.at",
+    "arbitrumbridge.zone",
+    "arbjtum.com",
+    "roadmap-arbitrum.com",
+    "xn--arbtrum-iza.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -43143,7 +43143,6 @@
     "arbjtum.com",
     "roadmap-arbitrum.com",
     "xn--arbtrum-iza.com",
-    "arbitrurn.claimnow.cloud",
     "claimnow.cloud"
   ]
 }


### PR DESCRIPTION
## Scam links
- [airdrops-arbitrum.net](https://airdrops-arbitrum.net)
- [arbietrum.foundation](https://arbietrum.foundation)
- [arbitrum-airdrop2023.com](https://arbitrum-airdrop2023.com)
- [arbitrum-airdrop.one](https://arbitrum-airdrop.one)
- [arbitrum-air.net](https://arbitrum-air.net)
- [arbitrum.at](https://arbitrum.at)
- [arbitrumbridge.zone](https://arbitrumbridge.zone)
- [arbjtum.com](https://arbjtum.com)
- [roadmap-arbitrum.com](https://roadmap-arbitrum.com)
- [xn--arbtrum-iza.com](https://xn--arbtrum-iza.com)

## Description

Suspicious activity detected on these domains

## Screenshots




---

## Scam links
- [arbitrurn.claimnow.cloud](https://arbitrurn.claimnow.cloud)
- [claimnow.cloud](https://claimnow.cloud)

## Description



## Screenshots


