### PR TITLE
Unblocking reclaimprotocol.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1246,7 +1246,6 @@
     "rainbowpad.top",
     "raudiymc.com",
     "real-money.vip",
-    "reclaimprotocol.org",
     "recovery-phrase-metamask.com",
     "rewards-layerzero.com",
     "splendorous-kringle-27ac38.netlify.app",


### PR DESCRIPTION
I'm the founder of Reclaim Protocol and the owner of reclaimprotocol.org ; proof in dns txt record
![image](https://user-images.githubusercontent.com/2111253/230695880-37d38dee-0041-4e89-9531-dfa8a5785029.png)

It is a recently launched website and protocol. We do not require users to connect their metamask or download an app that mimics metamask. However we do have a protocol app called the Reclaim Wallet that users are prompted to install. 

This is an error to include reclaimprotocol.org as a phishing website. 

Happy to answer any questions here. 