### PR TITLE
Add Scams to BL

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,14 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "wasabi-mixer.pw",
+    "criptomixer.com",
+    "coinmixer.cc",
+    "bitcoinsmix.pro",
+    "helixmixer.co",
+    "helixmixer.io",
+    "mixm.cc",
+    "ethereummixing.com",
     "web-3drop.xyz",
     "opensea-pro.io",
     "zyberswap-join.com",


### PR DESCRIPTION
List of recent & identical Crypto Mixing Scams, without letter of guarantee, a design used & reused by scammers, unique deposit wallet (scam), and created by the same hacker as many of those are asking to deposit on the same wallet address.
All targeting ETH users that would be happy to be protected by the best wallet ever !

https://wasabi-mixer.pw/eth.html
https://www.criptomixer.com/eth.html
https://coinmixer.cc/eth.html
https://bitcoinsmix.pro/eth/
https://helixmixer.co/eth.html
https://helixmixer.io/eth.html
https://mixm.cc/eth.html
https://ethereummixing.com