### PR TITLE
Add scams from ChainPatrol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -44349,6 +44349,7 @@
     "zksyncswap.party",
     "arbitrum-foundation.biz",
     "lido.fans",
-    "l2-optimism.info"
+    "l2-optimism.info",
+    "manlte.xyz"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -44350,6 +44350,9 @@
     "arbitrum-foundation.biz",
     "lido.fans",
     "l2-optimism.info",
-    "manlte.xyz"
+    "manlte.xyz",
+    "rewards-sui.xyz",
+    "api3.fund",
+    "sui-token.net"
   ]
 }


### PR DESCRIPTION
## Scam links
- [manlte.xyz](https://manlte.xyz)

## Description

A fake website that asks users to connect their wallets.


## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/04/18/Screen%20Shot%202023-04-18%20at%2011.11.57%20AM-71ho.png)


---

## Scam links
- [rewards-sui.xyz](https://rewards-sui.xyz)
- [api3.fund](https://api3.fund)
- [sui-token.net](https://sui-token.net)

## Description

Phishing URLs

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/04/17/SUI%20URL%20Scam%200417-5TuW.JPG)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/04/17/SUI%20URL%20Scam2%200417-26cd.JPG)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/04/17/SUI%20URL%20Scam3%200417-2wZG.JPG)
