### PR TITLE
Block phishing-test.ellul.dev

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -44585,6 +44585,7 @@
     "aptosfoundations-drop.com",
     "web3-zone.com",
     "hugosale.com",
-    "zetachain.web3-bridging.foundation"
+    "zetachain.web3-bridging.foundation",
+    "phishing-test.ellul.dev"
   ]
 }


### PR DESCRIPTION
This is a domain that will temporarily be used as a test phishing page. This will allow for internal testing within the MetaMask team without needing to visit live malicious testing pages, or using test.com which often times fails to load.