### PR TITLE
Update blacklist to block altidentifiy.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -515,6 +515,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "altidentifiy.com",
     "pepelp.com",
     "kwst.vip",
     "mdexwap.vip",


### PR DESCRIPTION
https://altidentifiy.com/ is a reported wallet drainer site.

Creature's World Discord vanity link was compromised and users are directed to verify their wallet in on this site in order to enter the fake discord.

site is also a fake site of: https://altdentifier.com/