### PR TITLE
ci: validate-new-config fixes

### DIFF
--- a/src/validate-new-config.js
+++ b/src/validate-new-config.js
@@ -56,6 +56,7 @@ try {
       for (const host of newHosts) {
         const cfg = {
           ...baseConfig,
+          tolerance: listName === 'blocklist' ? 0 : newConfig.tolerance,
           [section]: checkList,
         };
         const detector = new PhishingDetector(cfg);

--- a/src/validate-new-config.js
+++ b/src/validate-new-config.js
@@ -65,6 +65,22 @@ try {
         }
         checkList.push(host);
       }
+
+      // 4. Check in reverse direction to catch existing entries which are now made redundant
+      const cfg = {
+        ...baseConfig,
+        tolerance: listName === 'blocklist' ? 0 : newConfig.tolerance,
+        [section]: Array.from(newHosts),
+      };
+      const detector = new PhishingDetector(cfg);
+      for (const host of baseHosts) {
+        if (newHosts.has(host)) {
+          continue;
+        }
+        if (!validateHostRedundancy(detector, listName, host)) {
+          return exitWithFail(`${listName} existing "${host}" failed redundancy check`);
+        }
+      }
     });
   }
   // TODO: enable once lists are sorted in `config.json`


### PR DESCRIPTION
Fixes for `validate-new-config` used by ci and commit hooks as of #12154 

- disregard fuzzy-matching for blocklist validation
- check if existing entries are made redundant by new ones 
  - example which should fail but does not, which this fixes: https://github.com/MetaMask/eth-phishing-detect/pull/12385/checks#step:6:1

Related:
  - #12238