### PR TITLE
Add Scams to BL

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -520,6 +520,9 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "coinomize.la",
+    "ethereummixer.cc",
+    "darkmix.io",
     "altidentifer.com",
     "pancakeswap.ecproevents.com",
     "galxe.tokens-drop.com",


### PR DESCRIPTION
List of recent & identical Crypto Mixing Scams, without letter of guarantee, a design used & reused by scammers, unique deposit wallet (scam), and created by the same hacker as many of those are asking to deposit on the same wallet address. All targeting ETH users that would be happy to be protected by the best wallet ever !

https://coinomize.la/eth.html
https://ethereummixer.cc/
https://darkmix.io/eth.html