### PR TITLE
Swap out test phishing domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -520,6 +520,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "test.metamask-phishing.io",
     "service-lido.com",
     "arbitrumeth.com",
     "arbitlrum.net",
@@ -45634,7 +45635,6 @@
     "web3-zone.com",
     "hugosale.com",
     "zetachain.web3-bridging.foundation",
-    "phishing-test.ellul.dev",
     "optimism-claim.org",
     "zks-allocation.com",
     "zksync-bridge.network",


### PR DESCRIPTION
In #12346 I added phishing-test.ellul.dev as a phishing test domain to use for testing.  However, we now have access to test.metamask-phishing.io (Managed corperately) instead to replace this.

This PR simply swaps the two.