### PR TITLE
Whitelist European Space Agency

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12,6 +12,7 @@
     "satoshilabs.com"
   ],
   "whitelist": [
+    "open.esa.int",
     "openex.org",
     "openlead.xyz",
     "metalaska.io",


### PR DESCRIPTION
The Open Access at ESA website is legit, from the European Space Agency. Should not be blocked.

https://open.esa.int