### PR TITLE
Add fake otherside site to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -522,6 +522,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "otherside.community",
     "opensel.shop",
     "zetachain-airdrop.com",
     "labs.zetachain.one",


### PR DESCRIPTION
Yuga CEO twitter hacked. This is the linked malicious site in twitter post.