### PR TITLE
Add scams from ChainPatrol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -522,6 +522,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "aptosholyshit.xyz",
     "do-boredapeyachtclub.com",
     "otherside.community",
     "opensel.shop",

--- a/src/config.json
+++ b/src/config.json
@@ -522,6 +522,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "do-boredapeyachtclub.com",
     "otherside.community",
     "opensel.shop",
     "zetachain-airdrop.com",


### PR DESCRIPTION
## Scam links
- [do-boredapeyachtclub.com](https://do-boredapeyachtclub.com)

## Description

Phishing URL

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/05/02/BoredApe%20URL%20Scam%200502-2jME.JPG)


---

## Scam links
- [aptosholyshit.xyz](https://aptosholyshit.xyz)

## Description

They're twitter account is suspended as well https://twitter.com/HolyShitNFT

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/05/02/image-2isQ.png)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/05/02/image-3TUa.png)
