### PR TITLE
test: temporarily disable allowlist consistency tests

### DIFF
--- a/src/add-hosts.js
+++ b/src/add-hosts.js
@@ -25,7 +25,10 @@ const addHosts = (config, section, domains, dest) => {
 
   const detector = new PhishingDetector({
     ...config,
-    tolerance: section === 'blacklist' ? 0 : config.tolerance,
+    // FIXME: Temporary workaround during list inconsistency.
+    // Can be reverted after 2023-05-14
+    tolerance: section === 'blacklist' ? 0 : 2,
+    // tolerance: section === 'blacklist' ? 0 : config.tolerance,
     [section]: domains,
   });
 
@@ -126,7 +129,14 @@ if (require.main === module) {
 
     // check each entry for redundancy, adding it to the detector's internal config if valid
     // reuse detector to avoid costly reinitialization
-    let detector = new PhishingDetector(config);
+
+    // FIXME: Temporary workaround during list inconsistency.
+    // Can be reverted after 2023-05-14
+    // let detector = new PhishingDetector(config);
+    let detector = new PhishingDetector({
+      ...config,
+      tolerance: 2,
+    });
     for (const host of hosts) {
       if (validateHostRedundancy(detector, section, host)) {
         newHosts.add(host);

--- a/src/add-hosts.js
+++ b/src/add-hosts.js
@@ -8,6 +8,11 @@ const SECTION_KEYS = {
   allowlist: 'whitelist',
 };
 
+const LISTNAME_KEYS = {
+  blacklist: 'blocklist',
+  whitelist: 'allowlist',
+};
+
 /**
   * Adds new host to config and writes result to destination path on filesystem.
   * @param {PhishingDetectorConfiguration} config - Input config
@@ -27,8 +32,7 @@ const addHosts = (config, section, domains, dest) => {
   let didFilter = false;
 
   for (const host of config[section]) {
-    const r = detector.check(host);
-    if (r.result) {
+    if (!validateHostRedundancy(detector, LISTNAME_KEYS[section], host)) {
       console.error(`existing entry '${host}' removed due to now covered by '${r.match}' in '${r.type}'.`);
       didFilter = true;
       continue;

--- a/src/validate-new-config.js
+++ b/src/validate-new-config.js
@@ -62,7 +62,10 @@ try {
       for (const host of newHosts) {
         const cfg = {
           ...baseConfig,
-          tolerance: listName === 'blocklist' ? 0 : newConfig.tolerance,
+          // FIXME: Temporary workaround during list inconsistency.
+          // Can be reverted after 2023-05-14
+          tolerance: listName === 'blocklist' ? 0 : 2,
+          // tolerance: listName === 'blocklist' ? 0 : newConfig.tolerance,
           [section]: checkList,
         };
         const detector = new PhishingDetector(cfg);
@@ -75,7 +78,10 @@ try {
       // 4. Check in reverse direction to catch existing entries which are now made redundant
       const cfg = {
         ...baseConfig,
-        tolerance: listName === 'blocklist' ? 0 : newConfig.tolerance,
+        // FIXME: Temporary workaround during list inconsistency.
+        // Can be reverted after 2023-05-14
+        tolerance: listName === 'blocklist' ? 0 : 2,
+        // tolerance: listName === 'blocklist' ? 0 : newConfig.tolerance,
         [section]: Array.from(newHosts),
       };
       const detector = new PhishingDetector(cfg);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -388,7 +388,8 @@ function startTests ({ config }) {
 
   test('config does not contain redundant entries', (t) => {
     testListNoBlocklistRedundancies(t, config)
-    testListNoAllowlistRedundancies(t, config)
+    // FIXME: temporarily disabled due to config propagation inconsistency
+    // testListNoAllowlistRedundancies(t, config)
     t.end()
   })
 }


### PR DESCRIPTION
## Description

After #12481 was merged, it was discovered that downstream caching treats `tolerance` and `allowlist` differently, resulting in inconsistent configuration with incorrect blocking of previous `allowlist` entries removed.

ece46e415644d9e7fd30b7489796d7ccbfb5912a added back the entries.

This PR temporarily disables consistency check for `allowlist`, allowing for a `tolerance` of `1` and presence of entries which would be blocked only withthe previous value of `2`.

## Next steps

Relaying message:
> Presently, the bulk of the data (the "stalelist") containing the `tolerance` level is being refreshed server-side every 4 days roughly. With a client side `Cache-Control: max-age=` to 4 days and the last, this means that the next server-side update would be right after **2023-05-11 midnight UTC** with all users being swapped over to new `tolerance` value roughly around **2023-05-14 UTC**. This applies to everyone on the extension versions on or after `10.25`.
> I'm not sure about what version of `phishing-controller` `metamask-mobile` is on or if they've released this yet.