### PR TITLE
add back openmeta.network to allowlist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12,6 +12,7 @@
     "satoshilabs.com"
   ],
   "whitelist": [
+    "openmeta.network",
     "open.esa.int",
     "openex.org",
     "openlead.xyz",


### PR DESCRIPTION
Originally added in 8cb956610

Incorrectly removed in ece46e415