### PR TITLE
Remove FP

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -33937,7 +33937,6 @@
     "pepenfts.ink",
     "pepes.top",
     "pepesnfts.ink",
-    "pepefarmers.com",
     "rnetarnask-co.tech",
     "seabums.cc",
     "web3nb.tk",


### PR DESCRIPTION
fixes https://github.com/MetaMask/eth-phishing-detect/issues/12526

remove FP
https://www.linkedin.com/pulse/nicenicnet-2nd-most-abused-domain-registrar-sure-one-first-dema/ 

https://twitter.com/Cryptolinkscom/status/1654411447110180865 

https://crypto.news/peckshield-pepe-coins-rise-inspired-a-series-of-scam-tokens

https://www.binance.com/en-IN/feed/post/512823

https://cointelegraph.com/news/pepe-memecoin-frenzy-gets-unwanted-attention-from-scammers

red flag - Nice NIC + the recent influx of fake pepe sites caused the FP

many pepe, few not scams
(i only knew of pepe.vip - and considered any other "pepes" to be of scammy nature)