### PR TITLE
remove FP

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -26166,7 +26166,6 @@
     "btfdairdrop.com",
     "circle-reward.claims",
     "claim-metamask.xyz",
-    "claimswap.org",
     "clippir.exchange",
     "coincups.io",
     "connect-dice99.net",


### PR DESCRIPTION
remove FP
fixes https://github.com/MetaMask/eth-phishing-detect/issues/12585

FP introduced via https://github.com/MetaMask/eth-phishing-detect/pull/12582

claimswap.org - OK LEGIT

Side note what bout those other ones?
are they legitimate as well or copycats?
```
claimswap.io
claimswap1.clamswap.org
claimswap6.clamswap.org
claimswap.co
docs.claimswap.org
www.app.claim-swap.org
www.app.claim-swap.org
www.app.claimswap.io
www.app.claimswap.co
www.app.claimswap.cm
www.app.claimswap.finance
www.app.claimswap.exchange
www.app.claimswap.net
```