### PR TITLE
Phishing/scam mixer Added to BL

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "bestmixer.pro",
     "metatoken.gift",
     "gpt-ai.io",
     "garbageuniverse.com",


### PR DESCRIPTION
bestmixer.pro is a fake mixer (phishing/scam) that pretend to be the now closed: BESTMIXER.IO (They copied both design and domain name)

**The genuine website bestmixer.io was shutdown by authorities in 2019:**
* https://www.zdnet.com/article/bestmixer-seized-by-eu-police-over-laundering-of-200-million-in-cryptocurrency/
* https://www.europol.europa.eu/media-press/newsroom/news/multi-million-euro-cryptocurrency-laundering-service-bestmixerio-taken-down
* https://www.mcafee.com/blogs/other-blogs/mcafee-labs/crypto-currency-laundering-service-bestmixer-io-taken-down-by-law-enforcement/

This scam is targeting multiple coins (ETH,BNB,ERC20, ...) that are used by MetaMask users, and it now appear on google 1st page for many keywords, it is urgent to put an end to it.

You can see the website has "many broken links" as the website has been copied with a ripper, for instance:
* When you use the contact form it performs an HTTP request to https://bestmixer.pro/int/spcr/ returning a 404 Error, but still showing a message saying "Your message has been send thank you."
* If you try to register as a partner: https://bestmixer.pro/en/partner.html it will failed as it tries to send data to "partner.php" but ripper renamed it as "partner.html", so: 404) ...

*I originally created this pull with a proof of mixing transaction not being executed and money being kept by the mixer, but they already deleted the mixing order, and obviously, this scam doesn't provide "Letter of Guarantee"...
