### PR TITLE
Add scams from ChainPatrol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "arbitrum-cnnct-clk.online",
     "airdrop-arbitrum.club",
     "arbitrum-drops.pro",
     "arbitrumairdrop.pro",

--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,10 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "airdrop-arbitrum.club",
+    "arbitrum-drops.pro",
+    "arbitrumairdrop.pro",
+    "arbitrumswap.io",
     "kbonus.xyz",
     "seniorassistantsupportservices.com",
     "pepe-drops.top",


### PR DESCRIPTION
## Scam links
- [airdrop-arbitrum.club](https://airdrop-arbitrum.club)
- [arbitrum-drops.pro](https://arbitrum-drops.pro)
- [arbitrumswap.io](https://arbitrumswap.io)
- [arbitrumairdrop.pro](https://arbitrumairdrop.pro)

## Description

Phishing URLs

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/05/22/Arbitrum%20URL%20Scam%200522-2hYi.JPG)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/05/22/Arbitrum%20URL%20Scam2%200522-Md2x.JPG)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/05/22/Arbitrum%20URL%20Scam3%200522-73fq.JPG)
![](https://upcdn.io/kW15b1u/raw/uploads/2023/05/22/Arbitrum%20URL%20Scam4%200522-wyzH.JPG)


---

## Scam links
- [arbitrum-cnnct-clk.online](https://arbitrum-cnnct-clk.online)

## Description

Phishing URL

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/05/17/Arbitrum%20URL%20Scam%200517-4qM8.JPG)
