### PR TITLE
Added phishing scam to BL

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "bestmixer.pro",
     "sappyseals.click",
     "airdrop-sui.top",
     "airdrop-sui-testnet.com",


### PR DESCRIPTION
Hi @AlexHerman1 ,
Following-up with commit: #12632 
bestmixer.pro is now back online.

Phishing of Bestmixer.IO (which has been closed by Europol in 2019).
-> https://web.archive.org/web/20221009151753/http://www.bestmixer.pro/