### PR TITLE
Add phishing/scams to Blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "bestmixer.pro",
+    "bestmixer.ac",
     "tbtrc.com",
     "sappyseals.click",
     "airdrop-sui.top",


### PR DESCRIPTION
Hi @AlexHerman1 ,
Following-up with commit: #12632
bestmixer.pro is now back online, and bextmixer.ac is another phishing that also copied .IO's design and domain name.

Phishing of former Bestmixer.IO:
-> https://web.archive.org/web/20221009151753/http://www.bestmixer.pro/
-> https://web.archive.org/web/20230525071335/https://bestmixer.ac/

* To see bestmixer.PRO, you might have to try different proxies or Tor relay, as they seems to have ban a wide range of IP.