### PR TITLE
Add fake linea site to blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -514,6 +514,7 @@
   ],
   "blacklist": [
     "nature-makerdao.com",
+    "lineabuild-airdrop.com",
     "lives-airdrop.com",
     "claim-web3.com",
     "milady-platform.app",


### PR DESCRIPTION
Site impersonates linea and attempts to scam user. 

https://lineabuild-airdrop.com/claim.html

<img width="1981" alt="Screenshot 2023-06-01 at 11 31 08 AM" src="https://github.com/MetaMask/eth-phishing-detect/assets/15018469/92c4dbc4-7826-47ef-aeed-37a5faff8ec0">
