### PR TITLE
Add nature-makerdao.com to the blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "nature-makerdao.com",
     "lives-airdrop.com",
     "claim-web3.com",
     "milady-platform.app",


### PR DESCRIPTION
`nature-makerdao.com` is a scam, claiming to be related to MarkerDAO.