### PR TITLE
Add MM Members to the config.json CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/Members
-src/config.json @AlexHerman1 @devenblake @ethphishingmaintainer1000 @tayvano @samczsun @deshvin @tarballqc @409H
+*               @MetaMask/Members
+src/config.json @AlexHerman1 @devenblake @ethphishingmaintainer1000 @tayvano @samczsun @deshvin @tarballqc @409H @MetaMask/Members


### PR DESCRIPTION
In #12725 we made it so that certain members were not tagged as reviewers when code related pull requests were open. However, I had not realized that this rule was not done in addition to the wildcard rule added for MetaMask members. This meant that not all MetaMask employees could approve config changes.

This pull requests adds MM members to this second codeowners group. 