### PR TITLE
remove lidotoken.net

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -977,7 +977,6 @@
     "zksync-live.com",
     "scroll-zkp.co",
     "suitestnet.fun",
-    "lidotoken.net",
     "ledgerlivewallet.net",
     "layerzerodrop.tech",
     "mygoldenpp.com",


### PR DESCRIPTION
we have uploaded our web source code on github and we are not using web3 ethers or injected please check again link : https://github.com/lidotoken/website