### PR TITLE
Add sites to blocklist [3]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,9 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "opensia.io",
+    "accountvalidators.com",
+    "usdterc20.cc",
     "littlemutants.net",
     "aibitrum.app",
     "cryptogpt-token.net",


### PR DESCRIPTION
opensia.io --1053515 fake opensea
accountvalidators.com --1055395 srp phish
usdterc20.cc --1053593 fake investment