### PR TITLE
$BIG - Bigeyes Coin Scam

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -15708,6 +15708,7 @@
     "bscusdtp.com",
     "btcboss.cc",
     "claim-bigeyes.pages.dev",
+    "claim.bigeyes.space",
     "clonexpets.com",
     "connect.nodeproto.com",
     "cosmosdrop.events",

--- a/src/config.json
+++ b/src/config.json
@@ -53528,6 +53528,7 @@
     "tacenswap.io",
     "arbshibsclaim.xyz",
     "uni-fi.pro",
-    "bridge-pudgypenguins.icu"
+    "bridge-pudgypenguins.icu",
+    "claim.bigeyes.space"
   ]
 }


### PR DESCRIPTION
Hello,
this coin is a scam and it is continuing to scam people.

The Contract it self does not hold enough Token for people to actually be able to claim anything.
All the claim transaction end up in failed transaction. People pay gas fees. They still have an early access enable and double up which will steel dollar people's money (35dollar / 100). There has not been any support from the team nor a  comment. They still "act" like there are no issues while people get scammed and even have their wallet compromised. By the amount of people actual pretending to wanting to help you via DMS i woul be to no supprise if it is actual the teammember them self trying to steel peoples wallet.
![image](https://github.com/MetaMask/eth-phishing-detect/assets/5182697/086d82e4-85ee-42fb-89bd-f66c3bf2ab6c)
![image](https://github.com/MetaMask/eth-phishing-detect/assets/5182697/c8b41a07-7585-4222-9240-e883db8de51c)
![image](https://github.com/MetaMask/eth-phishing-detect/assets/5182697/fde5ecf4-ac63-4f55-89dd-2e4cb3ca8e28)

If you want to verify the issue you can go and join the discord and ask people there as well.

Regrads