### PR TITLE
add phishing mint link (mint-guttermelo.com) to blacklist 

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "mint-guttermelo.com",
     "lidonft.info",
     "insuringjewelry.com",
     "lido.cryptoinc.top",


### PR DESCRIPTION
confirmed with the legitimate team, this is a malicious mint website.