### PR TITLE
Add metamask/members back to the config codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 *                                    @MetaMask/Members
-src/config.json @AlexHerman1 @devenblake @ethphishingmaintainer1000 @tayvano @samczsun @deshvin @tarballqc @409H
+src/config.json @AlexHerman1 @devenblake @ethphishingmaintainer1000 @tayvano @samczsun @deshvin @tarballqc @409H @MetaMask/Members


### PR DESCRIPTION
Same as #12823 

Ensures that MetaMask members are able to approve changes to the phishing config. Accidentally got removed in https://github.com/MetaMask/eth-phishing-detect/pull/12820