### PR TITLE
add fake gutter cat gang site to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "guttercatgang.app",
     "aptos-evm.com",
     "join-doodles.net",
     "doodlesnft.net",


### PR DESCRIPTION
https://twitter.com/GutterCatGang compromised. This is the scam link being posted