### PR TITLE
add fake genkai mint sites to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "genkai.xyz",
+    "genkai-mint.com",
     "1chef.io",
     "xen-crypto.xyz",
     "earn-drops.io",


### PR DESCRIPTION
OpenSea users were being directed to these two malicious sites by wash-traded collections