### PR TITLE
Fake Uniswap/RevokeCash site phishing for assets

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "revoke-uniswap.org",
     "rewards-uniswapx.org",
     "bounty-uniswap.com",
     "lifeparallel.app",


### PR DESCRIPTION
revoke-uniswap.org
Fake RevokeCash site phishing for assets
https://urlscan.io/result/7e84e568-0b9b-4005-b577-22d39a1b1a0e/
address: 0xdd6CF6483FE5d948E0aEee94D94b8C98f055d1b0 (eth)

Calls to hxxps://sss.renga-inc.com/api/spawn/telegram

<img width="593" alt="Screenshot 2023-07-20 at 21 44 53" src="https://github.com/MetaMask/eth-phishing-detect/assets/2313704/1dd2a733-8871-434c-97da-053e497d8c35">

