### PR TITLE
Make add-hosts add new domains to end of lists

### DIFF
--- a/src/add-hosts.js
+++ b/src/add-hosts.js
@@ -34,14 +34,17 @@ const addHosts = (config, section, domains, dest) => {
 
   let didFilter = false;
 
+  const filteredHosts = [];
   for (const host of config[section]) {
     if (!validateHostRedundancy(detector, LISTNAME_KEYS[section], host)) {
       console.error(`existing entry '${host}' removed due to now covered by '${r.match}' in '${r.type}'.`);
       didFilter = true;
       continue;
     }
-    hosts.push(host);
+    filteredHosts.push(host);
   }
+  // make sure the new added domains are at end of list
+  hosts.unshift(...filteredHosts);
 
   const cfg = {
     ...config,


### PR DESCRIPTION
@danfinlay pointed out adding domains to the end of the list would help reduce merge conflicts, which would save everyone time and enable phishing requests to get processed faster

https://github.com/MetaMask/eth-phishing-detect/pull/13087#issuecomment-1644769354