### PR TITLE
add guardiansmeta com (redline / malware)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "guardiansmeta.com",
     "app-mintable.app",
     "arkham.trade",
     "arkhamintelilgence.net",

--- a/src/config.json
+++ b/src/config.json
@@ -514,6 +514,7 @@
   ],
   "blacklist": [
     "guardiansmeta.com",
+    "arkhaminletigence.com",
     "app-mintable.app",
     "arkham.trade",
     "arkhamintelilgence.net",


### PR DESCRIPTION
report in eth security tg channel. also mentioned in ticket 1061808.

> Can anyone tell me if they have heard of any scam attempts by projects that look like DAOs but require you to install their PvE "Game"?

> they were able to get in my wallets after I put in referral game that they have called guardiansmeta com



plus 

<img width="621" alt="Screenshot 2023-07-21 at 2 25 45 PM" src="https://github.com/MetaMask/eth-phishing-detect/assets/7924827/e9366aec-af1c-4a41-b8f0-1e69d61eb0a8">
