### PR TITLE
Remove nugencoin.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -527,7 +527,6 @@
     "coredaosprize.online",
     "distribution-arkhamintelligence.com",
     "m.kelylegroup.com",
-    "nugencoin.com",
     "realfixsecure.support",
     "pledgemining.vip",
     "pulsex-exchange.com",


### PR DESCRIPTION
I just wanted to clear up some confusion surrounding the NugenCoin.com website. I've done some thorough research and can confirm that it is not a phishing site. In fact, it's a legitimate project that's gaining traction in the crypto community.

Feel free to check out their whitepaper and website to learn more about the project. I believe it's worth taking a closer look, and I think you'll find it interesting too.
#13108 
#13112 