### PR TITLE
Adding phishing sites to blocklist [2]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "earndrop.org",
+    "eorndrop.io",
     "enter-mantle.xyz",
     "events-arbitrum.com",
     "bonus-lido.fi",


### PR DESCRIPTION
addresses #13070 and #13117 