### PR TITLE
remove compound.cash from blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -25373,7 +25373,6 @@
     "compound-claim.com",
     "compound-esi.pages.dev",
     "compound-labs.net",
-    "compound.cash",
     "compoundclaim.com",
     "compoundfilayer.com",
     "compoundfinance.cx",


### PR DESCRIPTION
Following up from @kevincheng96 's PR #13021 

There is one additional legit Compound-related site that is currently on the blacklist: compound.cash.

That's the official site for Compound Gateway project. You can see the site linked to on the [Compound Gateway Github repo](https://github.com/compound-finance/gateway):

![image](https://github.com/MetaMask/eth-phishing-detect/assets/2570291/bbebd89a-d69e-4215-9cfd-6b4656071b49)
