### PR TITLE
Add ethereum-creditor.club to the blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -926,6 +926,7 @@
     "reward-drop.foundation",
     "provider-web3.foundation",
     "reutersbuild.com",
+    "ethereum-creditor.club",
     "ethereum-creditor.com",
     "squid2.network",
     "ethzab.com",


### PR DESCRIPTION
`ethereum-creditor.club` seems to be the same site as `ethereum-creditor.com`, which has already been added to this list. It claims to have been jointly created by a bunch of orgs, including MakerDAO, which I can confirm is false, so I'm assuming it's definitely a scam.