### PR TITLE
synthetixreward.com + lidodrop.live

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "lidodrop.live",
     "synthetixreward.com",
     "earnsdrops.com",
     "cryptocurrency-qr-code.com",

--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "synthetixreward.com",
     "earnsdrops.com",
     "cryptocurrency-qr-code.com",
     "earndrops.io",


### PR DESCRIPTION
Fake Synthetix site phishing for assets
https://urlscan.io/result/b378a53c-1da7-4fc8-b31d-363f54e03b0a/ 
address: 0xa21a09fa426c1016f5aecda02ac48e201456db5c (polygon) 
address: 0x000011387Eb24F199e875B1325E4805EfD3b0000 (eth)

Sending out NFTs on Polygon to scam users

```json
{
	"name": "Synthetix Airdrop #1",
	"description": "For providing a reliant liquidity pool and holding Synthetix Tokens, we are rewarding your kind efforts with a Synthetix NFT. You can swap your NFT for 500 Synthetix or stake your NFT and earn daily rewards. https://tinyurl.com/synthetixreward #1",
	"attributes": [],
	"creators": [],
	"collection": {
		"name": "Synthetix Airdrop",
		"family": "Synthetix Airdrop"
	},
	"symbol": "NFT",
	"seller_fee_basis_points": 0,
	"image": "https://bafybeid6jyielf7wib73oharbn37pwoya6sk4avd7jz4bxiy3whmoh5e5e.ipfs.w3s.link/1.png"
}
```

![image](https://github.com/MetaMask/eth-phishing-detect/assets/2313704/14ca8f81-9448-4a42-9054-d5188c1bb82e)

<img width="966" alt="Screenshot 2023-08-01 at 00 42 52" src="https://github.com/MetaMask/eth-phishing-detect/assets/2313704/26b28aa1-35a5-40cc-bf77-2b808b190756">
