### PR TITLE
apesdrop.org

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "apesdrop.org",
     "lidodrop.live",
     "synthetixreward.com",
     "solanacoin.online",


### PR DESCRIPTION
Fake ApeCoin site phishing for assets - backend: //cmeptb.bio/ 
https://urlscan.io/result/9a51cb62-50a0-45f6-83a5-062702d1a465/ 
address: 0x5fe140c36c4b3abab550b3b600ed469c2441826d (polygon) 
address: 0x000042B3537ea7055cCb37817b451c3ECd9d0000 (eth)


NFT Metadata: https://bafybeib4ogy33faosp5kmgkisvj4nailwfmo5epwoubrdv756xgv3ejdxe.ipfs.dweb.link/

![image](https://github.com/MetaMask/eth-phishing-detect/assets/2313704/991aab9d-763b-447f-99a6-92edd57ed8df)
