### PR TITLE
Add scams from ChainPatrol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "decryptmedia.legal",
     "avadrop.org",
     "opensae-io.online",
     "io-assets.in",


### PR DESCRIPTION
## Scam links
- [decryptmedia.legal](https://decryptmedia.legal)

## Description

This fake page was used to hack the insurace.io discord server.

## Screenshots

![](https://upcdn.io/kW15b1u/raw/uploads/2023/08/02/image-764f.png)
