### PR TITLE
Add one new scam to BL

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+	"bestmix.io",
     "xbet.cash",
     "spawnart.org",
     "tokenswaphub.online",


### PR DESCRIPTION
Following #12665 and #12934
Here is ine more domains hosting the same scam:
 - bestmix[dot]io
It belongs to the same team of scammer, as the already blacklisted best-mixer[dot]pro is now being redirected to this bestmix[dot]io