### PR TITLE
[Block Domain] Block phishing website ceramic.gift impersonating as Ceramic network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -57694,6 +57694,6 @@
     "worldcoin.si",
     "blurcrypto.io",
     "appgmx.io",
-    "aavev3lp.com"
+    "ceramic.gift",
   ]
 }


### PR DESCRIPTION
**Domain:**
- `ceramic.gift`

- [x] I have checked to make sure that [there is not a duplicate issue](https://github.com/MetaMask/eth-phishing-detect/issues)

Fixes #13297