### PR TITLE
Unblock non-scam artists website

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -21769,7 +21769,6 @@
     "renga-inc.com",
     "ripplegifts.live",
     "securedappbridge.com",
-    "steviep.xyz",
     "swappy.trade",
     "tarrazzor.azurewebsites.net",
     "tinyants-nft.com",


### PR DESCRIPTION
steviep.xyz is an artist website. Neither the website nor any of the subdomains contain any sort of phishing. This is the second time that this domain has been added. I'm happy to do whatever I need to do to prove that this is not a phishing website.

@dubstard seems to have added this domain the last time in https://github.com/MetaMask/eth-phishing-detect/commit/3d2de459999790d43f724442ecc10a0bcd4dbdaa