### PR TITLE
Update config.json, add zksync-mint.summon.xyz to the whitelist.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -510,7 +510,8 @@
     "satoshilabs.com",
     "satoshilabs.design",
     "metarisk.com",
-    "launchpad.ethereum.org"
+    "launchpad.ethereum.org",
+    "zksync-mint.summon.xyz"
   ],
   "blacklist": [
     "earn-web3.com",


### PR DESCRIPTION
Whitelisting `zksync-mint.summon.xyz` domain. It's not in blacklist, but still having issue, users get `Deceptive site ahead` error.

It's an official mint site.