### PR TITLE
Preemptively block yearn.finance

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "yearn.finance",
     "circlest.org",
     "lp-rewards.net",
     "drop-usdt.xyz",


### PR DESCRIPTION
```
Domain Name: yearn.finance
Registry Domain ID: 4003f59832fb40bdb349122688f2d26d-DONUTS
Registrar WHOIS Server: whois.tucows.com
Registrar URL: http://www.tucows.com
Updated Date: 2023-09-02T19:35:38Z
Creation Date: 2020-01-27T20:44:58Z
Registry Expiry Date: 2028-01-27T20:44:58Z
Registrar: Tucows Domains Inc.
Registrar IANA ID: 69
Registrar Abuse Contact Email: domainabuse@tucows.com
Registrar Abuse Contact Phone: 416.535.0123x1283
```

Nameservers were unexpectedly changed and now DNS is not resolving - preemptively block per team request