### PR TITLE
[URGENT] Allowlist spotonchain.ai spotonchain.com (#13565)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -510,7 +510,12 @@
     "satoshilabs.com",
     "satoshilabs.design",
     "metarisk.com",
-    "launchpad.ethereum.org"
+    "launchpad.ethereum.org",
+    "spotonchain.com",
+    "spotonchain.ai",
+    "platform.spotonchain.com",
+    "platform.spotonchain.ai",
+    "friendex.spotonchain.ai"
   ],
   "blacklist": [
     "opbnb-layer.com",

--- a/src/config.json
+++ b/src/config.json
@@ -512,10 +512,7 @@
     "metarisk.com",
     "launchpad.ethereum.org",
     "spotonchain.com",
-    "spotonchain.ai",
-    "platform.spotonchain.com",
-    "platform.spotonchain.ai",
-    "friendex.spotonchain.ai"
+    "spotonchain.ai"
   ],
   "blacklist": [
     "opbnb-layer.com",


### PR DESCRIPTION
We have just launched the beta version and some users got blocked from Metamask.

In this PR, we want to add our platform domain to the whitelist.

About spotonchain:
Spot On Chain is a pioneering platform designed to simplify on-chain data analysis and provide accessible insights for all in the cryptocurrency space. Our AI-powered platform offers easily digestible insights, intuitive visualizations, AI assistance, one-click alerts, and mobile accessibility. Our aim is to make on-chain data usable and comprehensible to a wide range of users, regardless of their technical background, ensuring confident decision-making in the cryptocurrency market.

Twitter: https://twitter.com/spotonchain
Website: https://spotonchain.ai/

Fixes: https://github.com/MetaMask/eth-phishing-detect/issues/13565

