### PR TITLE
adds airddrop hunter to whitelist upon request of the team

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -510,7 +510,8 @@
     "satoshilabs.com",
     "satoshilabs.design",
     "metarisk.com",
-    "launchpad.ethereum.org"
+    "launchpad.ethereum.org",
+    "airdrop-hunter.site"
   ],
   "blacklist": [
     "curverewards.org",


### PR DESCRIPTION
issue and details provided here https://github.com/MetaMask/eth-phishing-detect/issues/13555

it looks like the site is being blocked via fuzzy list, adding to whitelist will override the fuzzylist blocking.

the site is not delivering malware or outwardly phishing private keys or engaging in approval/permit phishing. whether the information on the site is true and whether they are offering a valuable product is left to the judgement of the individual user.

<img width="1800" alt="Screenshot 2023-09-15 at 1 07 16 AM" src="https://github.com/MetaMask/eth-phishing-detect/assets/7924827/13c2c518-7172-4979-aa6d-4add90e9499e">

