### PR TITLE
add sites to blocklist [10]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,16 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "extserum.bio",
+    "fastauthewalletconnect.xyz",
+    "fath-hub.com",
+    "insightconsultinggroup.io",
+    "linken-fxgured.top",
+    "linkenfx.com",
+    "multidappconnect.on.fleek.co",
+    "mysofinance.xyz",
+    "nodeauthenticate.com",
+    "tradings.host",
     "eigen-layer.net",
     "eigenlayer.tech",
     "event-eigenlayer.xyz",


### PR DESCRIPTION

| domain | report | vector |
| ------ | ------ | ------ |
extserum.bio|1080674|fake investment platform
fastauthewalletconnect.xyz|51112908-3042-4dca-b6e1-d2da5e73a6d9|srp phish
fath-hub.com|1081390|mining voucher
insightconsultinggroup.io|0a233d67-6a6a-48ae-8ee8-9b27946ef61b|fake investment platform
linken-fxgured.top|c7790015-7f6a-4a3a-8abb-5c86e4357f7e|fake investment platform
linkenfx.com|c7790015-7f6a-4a3a-8abb-5c86e4357f7e|fake investment platform
multidappconnect.on.fleek.co|dd2a5eba-03ea-4f4d-9d9d-d2e1285f562e|srp phish
mysofinance.xyz|4120a56d-bf02-4bd2-bd29-d6e3e1960762|drainer
nodeauthenticate.com|46478dfd-e6fd-4b7c-a3f7-3393f1a2e337|srp phish
tradings.host|62a18126-a070-4fa2-9209-e5020eff28e1|fake investment platform