### PR TITLE
Remove balancer.fi from blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -585,7 +585,7 @@
     "graph.claims",
     "thegraph.band",
     "linea-app.bridges-web3-claim.online",
-    "balancer.fi",
+    "web.balancer.fi",
     "bonus-requests-web3.online",
     "coinbase-gift.online",
     "coinbasegift.online",


### PR DESCRIPTION
Balancer has recovered control of balancer.fi after a social engineering attack at our registrar allowed hackers to take over the account.

We have confirmed that correct IPs have propigated.  If possible, please leave web.balancer.fi on the blocklist as we do not use it, and it seems like this name was used as part of the recent attack.

We have a war room open that we contacted via the seal-911 chat and I have been speaking to Tay.  You can find me that way if you have questions. 

Thank you