### PR TITLE
Add sites to blocklist [3]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "ammtron.info",
+    "btcbscio.live",
     "artbelleza.org",
     "beb2050.com",
     "bsco2o.cc",

--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "able-nft.top",
     "ammtron.info",
     "btcbscio.live",
     "artbelleza.org",


### PR DESCRIPTION
| domain | report | vector |
| ------ | ------ | ------ |
ammtron.info | 1082524 | mining voucher
btcbscio.live | 1082645 | srp phish
able-nft.top | 1082771 | fake NFT platform