### PR TITLE
Remove balancer.fi

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -531,7 +531,6 @@
     "btc20web.site",
     "dexnfts.io",
     "enradrops.io",
-    "balancer.fi",
     "layeron.network",
     "layery.network",
     "layero.network",


### PR DESCRIPTION
Balancer.fi has been regained and they are reporting it as safe: https://twitter.com/Balancer/status/1704552285395894422