### PR TITLE
Add domains to blocklist [2]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "gaixe.ink",
+    "mantle-airdrop.com",
     "freend.xyz",
     "openeea.top",
     "uniswapstaking.com",


### PR DESCRIPTION
| domain | report | vector |
| ------ | ------ | ------ |
gaixe.ink | #13630 | fake galxe
mantle-airdrop.com | ^ | drainer