### PR TITLE
Adding phishing sites to blocklist [6]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,12 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "web3box.io",
+    "staker.vip",
+    "dldecred.top",
+    "ethmixer.io",
+    "eth-mixing.com",
+    "eanrdrops.io",
     "journeymantle.xyz",
     "dexcurve.net",
     "b-drop.top",


### PR DESCRIPTION
addresses #13641 #13658 #13662 and zd

    "web3box.io",
    "staker.vip",
    "dldecred.top",
    "ethmixer.io",
    "eth-mixing.com",
    "eanrdrops.io",