### PR TITLE
Adding phishing sites to blocklist [6]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,12 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "eanrsdrop.io",
+    "binacy.market",
+    "crypto-mixers.com",
+    "anonymousmixer.eth.limo",
+    "coinspal.io",
+    "thebestbitcoinmixers.com",
     "drops-usd.xyz",
     "geteurc.com",
     "usd-drops.com",


### PR DESCRIPTION
#13680 
#13697
#13698
#13699
#13700
#13702 

    "eanrsdrop.io",
    "binacy.market",
    "crypto-mixers.com",
    "anonymousmixer.eth.limo",
    "coinspal.io",
    "thebestbitcoinmixers.com",