### PR TITLE
Adding phishing sites to blocklist [5]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,11 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "ecoinchanger.com",
+    "instantexchange.net",
+    "boomchange.com",
+    "binacy.com",
+    "ai-moveworks.info",
     "potrfoliometamosk.com",
     "portal.zksyenc.com",
     "syncswap.shop",


### PR DESCRIPTION
addresses #13714
addresses #13716
addresses #13719
addresses #13720 
ZD 1085684

    "ecoinchanger.com",
    "instantexchange.net",
    "boomchange.com",
    "binacy.com",
    "ai-moveworks.info",