### PR TITLE
Remove balancer and beets FPs

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -41245,8 +41245,6 @@
     "arbdogeairdrops.org",
     "argenthq.org",
     "azpp-egeelayerr-p.zoholandingpage.com",
-    "beta-app-v2-git-feat-pools-from-beets-api-balancer.vercel.app",
-    "beta-app-v2-git-hotfix-swap-input-scaling-balancer.vercel.app",
     "bitcoinbsc-verify.onrender.com",
     "bitcoinbscclaim.online",
     "bitcoinminetrix.live",


### PR DESCRIPTION
```
beta-app-v2-git-hotfix-swap-input-scaling-balancer.vercel.app
beta-app-v2-git-feat-pools-from-beets-api-balancer.vercel.app
```

Fixes https://github.com/MetaMask/eth-phishing-detect/issues/13792
Amazingly those turned out to be legit, despite being flagged in GSB and elsewhere, which threw me off as well.
Reference: https://github.com/balancer/frontend-v2/pull/4068#issuecomment-1727878027


![image](https://github.com/MetaMask/eth-phishing-detect/assets/49607867/61866da5-10b2-447d-90c8-966be7bb479f)
![sss](https://github.com/MetaMask/eth-phishing-detect/assets/49607867/0d771d35-49ce-42f6-a796-50f9aa1764b0)
