### PR TITLE
Update and correct DBAD license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 # DON'T BE A DICK PUBLIC LICENSE
 
-> Version 1.1, December 2016
+[Source](https://github.com/philsturgeon/dbad)
+
+> Version 1.2, February 2021
 
 > Copyright (C) 2018 kumavis
 
@@ -10,17 +12,19 @@ copies of this license document.
 > DON'T BE A DICK PUBLIC LICENSE
 > TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-1. Do whatever you like with the original work, just don't be a dick.
+ 1. Do whatever you like with the original work, just don't be a dick.
 
-   Being a dick includes - but is not limited to - the following instances:
+     Being a dick includes - but is not limited to - the following instances:
 
- 1a. Outright copyright infringement - Don't just copy this and change the name.
- 1b. Selling the unmodified original with no work done what-so-ever, that's REALLY being a dick.
- 1c. Modifying the original work to contain hidden harmful content. That would make you a PROPER dick.
+	 1a. Outright copyright infringement - Don't just copy the original work/works and change the name.  
+	 1b. Selling the unmodified original with no work done what-so-ever, that's REALLY being a dick.  
+	 1c. Modifying the original work to contain hidden harmful content. That would make you a PROPER dick.  
 
-2. If you become rich through modifications, related works/services, or supporting the original work,
-share the love. Only a dick would make loads off this work and not buy the original work's
-creator(s) a pint.
+ 2. If you become rich through modifications, related works/services, or supporting the original work,
+ share the love. Only a dick would make loads off this work and not buy the original work's 
+ creator(s) a pint.
+ 
+ 3. Code is provided with no warranty. Using somebody else's code and bitching when it goes wrong makes 
+ you a DONKEY dick. Fix the problem yourself. A non-dick would submit the fix back or submit a [bug report](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html).
 
-3. Code is provided with no warranty. Using somebody else's code and bitching when it goes wrong makes
-you a DONKEY dick. Fix the problem yourself. A non-dick would submit the fix back.
+ 4. If you use code, calling it your own would make you a ROYAL dick. [How to cite a repo](https://academia.stackexchange.com/questions/14010/how-do-you-cite-a-github-repository). Alternatively, even just a comment giving attribution to where you found the code would be OK.


### PR DESCRIPTION
### Updates:

- The DBAD license was updated a few years ago, including a fairly substantive fourth clause. That's included here.
- Small formatting changes that make it more readable (taken from current DBAD license)

### Additions: 

- Added attribution link at the top. Citing the source seems to be in line with the spirit of the license.