### PR TITLE
Adding phishing sites to blocklist [3]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,9 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "wallsstmeme.pages.dev",
+    "apyeth.net",
+    "bitsgapmis.net",
     "claim-zetachain.online",
     "ethereummixer.org",
     "shibarm.com",


### PR DESCRIPTION
1088104, 1088073, 1088106

    "wallsstmeme.pages.dev",
    "apyeth.net",
    "bitsgapmis.net",