### PR TITLE
Adding phishing sites to blocklist [4]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,10 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "synchronizerzone.com",
+    "tradeprofitsconnect.com",
+    "aidogee.live",
+    "rewards-arkhamintelligence.net",
     "usdt-drop.info",
     "garbagefriends.club",
     "squareform.io",


### PR DESCRIPTION
addresses #13865 

1088112
1088107
1088111

    "synchronizerzone.com",
    "tradeprofitsconnect.com",
    "aidogee.live",
    "rewards-arkhamintelligence.net",