### PR TITLE
add zora.co to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12,6 +12,7 @@
     "satoshilabs.com"
   ],
   "whitelist": [
+    "zora.co",
     "cryptocities.world",
     "metamax.exchange",
     "openmeta.network",


### PR DESCRIPTION
Falsely added to Phishfort list that we use https://github.com/phishfort/phishfort-lists/commit/9af1b4c0d8420677289349e65de5c5e078877cc7