### PR TITLE
Remove unneccessary allowlist entry [1]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12,7 +12,6 @@
     "satoshilabs.com"
   ],
   "whitelist": [
-    "zora.co",
     "cryptocities.world",
     "metamax.exchange",
     "openmeta.network",


### PR DESCRIPTION
zora.co is added to allowlist and causing all Pull Requests to fail.