### PR TITLE
Add scams from ChainPatrol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "airdrop.arbitruinm.foundation",
     "celestiantia.com",
     "app.claims-celestia.org",
     "celestia.genesiss.info",


### PR DESCRIPTION
## Scam links
- [airdrop.arbitruinm.foundation](https://airdrop.arbitruinm.foundation)

## Description

SCAM

## Screenshots


