### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "tornado.cat",
     "chaineyes.tools",
     "abcmeta.io",
     "airdrop-vaults.com",


### PR DESCRIPTION
**Details:**
Phishing website "tornado.cat" which is a fake copy of "tornado.cash". The site claims to launder Ethereum, but it is a scam that steals and drains Ethereum wallets and is a risk for MetaMask users.

Added to blacklist:
"tornado.cat",