### PR TITLE
Add scams from ChainPatrol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "arbitrum.bitcontinuity.com",
     "coinmixer1.com",
     "bitcoinmixer.io",
     "unijoin.plus",


### PR DESCRIPTION
## Scam links
- [arbitrum.bitcontinuity.com](https://arbitrum.bitcontinuity.com)

## Description

Suspicious activity detected on these domains

## Screenshots


