### PR TITLE
Add scams from ChainPatrol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "starknet.cryptoshares.online",
     "grt.etructpad.top",
     "thegraph.fi",
     "wquryq.me",


### PR DESCRIPTION
## Scam links
- [starknet.cryptoshares.online](https://starknet.cryptoshares.online)

## Description

Matched keywords: starknet is

## Screenshots


