### PR TITLE
Remove bnbminer.finance from blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -600,7 +600,6 @@
     "drop-usd.com",
     "usdc-check.com",
     "shibainun.com",
-    "bnbminer.finance",
     "gmxechange.com",
     "xn--niswap-9lb.org",
     "blog-celestia.org",


### PR DESCRIPTION
Successfully operating for nearly 3 years, bnbminer.finance is a legitimate site that has been erroneously blocked.

As the developer and maintainer of the official bnbminer.finance website, I can confirm that bnbminer.finance has never engaged, and will never engage, in harmful activities such as creating fake versions of MetaMask, stealing Secret Recovery Phrases or passwords, initiating malicious transactions resulting in asset theft, phishing, or any other form of malicious activity. As we explained when our website was flagged nearly two years ago, we also do not claim to actually mine BNB; our name is merely a concept, and our contract is fully explained on our website, in our litepaper, and other documents.

Like MetaMask and many other successful projects, we are consistent victims of impersonators and scammers targeting both us and our users. We continuously do everything within our power to warn and protect our current and potential users to the fullest. Our website and documents are filled with tips and warnings.

The warning message from MetaMask that is currently being displayed to our users is erroneous and unfairly damaging to our community. I have removed bnbminer.finance from the blacklist in this branch and hope you will strongly consider accepting its removal. Thank you!