### PR TITLE
Add phishing sites to blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,17 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "layerzero.com.co",
+    "sandboxclaim.org",
+    "okcoindexchange.asia",
+    "celestiaportal.vip",
+    "okx-b.com",
+    "layerzerodrop.fun",
+    "okcoindex.xyz",
+    "okx.markets",
+    "blurmagicsedenlooksrareinu.com",
+    "chalkbored.xyz",
+    "layerzerowebnetwork.com",
     "curves-fi.org",
     "usdc.sadw.top",
     "case-usdc.com",


### PR DESCRIPTION
```
    "layerzero.com.co",
    "sandboxclaim.org",
    "okcoindexchange.asia",
    "celestiaportal.vip",
    "okx-b.com",
    "layerzerodrop.fun",
    "okcoindex.xyz",
    "okx.markets",
    "blurmagicsedenlooksrareinu.com",
    "chalkbored.xyz",
    "layerzerowebnetwork.com",
```