### PR TITLE
Adding phishing sites to blocklist [4]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,10 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "revokecash.services",
+    "revokecash.it",
+    "synkswallet.square.site",
+    "idlabsinternational.space",
     "zksync-trade.com",
     "500usd.promogift.top",
     "curve-finance.org",


### PR DESCRIPTION
zd, fixes #14182 

    "revokecash.services",
    "revokecash.it",
    "synkswallet.square.site",
    "idlabsinternational.space",