### PR TITLE
fix: add phishing site to blocklist [1]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -68526,6 +68526,7 @@
     "apyeth.eu",
     "revokecash.app",
     "nftelamentals.com",
-    "makerdaopro.info"
+    "makerdaopro.info",
+    "playstakebet.com"
   ]
 }


### PR DESCRIPTION
Adds `playstakebet.com` to blocklist