### PR TITLE
Add sites to blocklist [2]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "bittrex-omniagentsolutions.com",
+    "riscorp.de",
     "revokecash.services",
     "revokecash.it",
     "synkswallet.square.site",


### PR DESCRIPTION
| domain | report | vector |
| ------ | ------ | ------ |
bittrex-omniagentsolutions.com | 1093995 | approval farming
riscorp.de | 1094028 | approval farming fake etherscan