### PR TITLE
Adding fake phishing domain for opensea

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -68527,6 +68527,7 @@
     "revokecash.app",
     "nftelamentals.com",
     "makerdaopro.info",
-    "playstakebet.com"
+    "playstakebet.com",
+    "docs-opensea.io"
   ]
 }


### PR DESCRIPTION
Added domain faking opensea docs attempting to trick users based on an email claiming API keys were leaked:

![image](https://github.com/MetaMask/eth-phishing-detect/assets/1465995/ac8235fd-d86e-4dfc-b09e-f2128d9ad9ac)
