### PR TITLE
Adding c2 channels for revokecash sites

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -68532,6 +68532,8 @@
     "nftelamentals.com",
     "makerdaopro.info",
     "playstakebet.com",
-    "docs-opensea.io"
+    "docs-opensea.io",
+    "dsgdfgdfgdfg.oijdsfodnlkxvxcuivhxdfiukfhndx.workers.dev",
+    "kosettto-api.com"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -68533,7 +68533,6 @@
     "makerdaopro.info",
     "playstakebet.com",
     "docs-opensea.io",
-    "dsgdfgdfgdfg.oijdsfodnlkxvxcuivhxdfiukfhndx.workers.dev",
-    "kosettto-api.com"
+    "dsgdfgdfgdfg.oijdsfodnlkxvxcuivhxdfiukfhndx.workers.dev"
   ]
 }


### PR DESCRIPTION
Ran a script to run through some of the latest revokecash scam sites to deobfuscate and extract the C2 channels used:

```
Bad URLs for domain: https://revokecash.app/
-  https://kosettto-api.com
Bad URLs for domain: https://revokecash.fi/
-  https://dsgdfgdfgdfg.oijdsfodnlkxvxcuivhxdfiukfhndx.workers.dev
Bad URLs for domain: https://revokecash.services/
-  https://dsgdfgdfgdfg.oijdsfodnlkxvxcuivhxdfiukfhndx.workers.dev
```

Should at least force them to do more work since they will need to rotate these as well