### PR TITLE
feat: blocklist links (Wallet Guard)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "join-renga.racing",
+    "renga.events",
     "curves-finance.org",
     "usdc-claim.xyz",
     "celiastia.org",


### PR DESCRIPTION
# Blocklist links
- `renga.events`
- `join-renga.racing`

# Reason
Impersonating `renga.app`