### PR TITLE
Adding additional renga pages and c2

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -68650,6 +68650,8 @@
     "makerdaopro.info",
     "playstakebet.com",
     "docs-opensea.io",
-    "dsgdfgdfgdfg.oijdsfodnlkxvxcuivhxdfiukfhndx.workers.dev"
+    "dsgdfgdfgdfg.oijdsfodnlkxvxcuivhxdfiukfhndx.workers.dev",
+    "car-cra.sh",
+    "claim-renga.racing"
   ]
 }


### PR DESCRIPTION
Looks like the c2 is car-cra.sh and `claim-renga[.]racing` was another one that used it
<img width="534" alt="image" src="https://github.com/MetaMask/eth-phishing-detect/assets/1465995/498c18f4-f0f1-4567-9c77-6e813de485d6">

    "car-cra.sh",
    "claim-renga.racing"