### PR TITLE
add sites to blocklist [5]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,11 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "kaykagallery.com",
+    "mannaz.pro",
+    "dapps-claim.ive",
+    "app-cyberpoints.xyz",
+    "britbexxtradingltd.com",    
     "app-injective.org",
     "tornado3.com",
     "bitcoinlaundry.net",


### PR DESCRIPTION
| domain | report | vector |
| ------ | ------ | ------ |
kaykagallery.com | 1094629 | job offer scam
mannaz.pro | 1094002 | investment scam
dapps-claim.ive | 1094815 | SRP phish
app-cyberpoints.xyz | 1096065 | fake airdrop
britbexxtradingltd.com | 1096084 | investment scam