### PR TITLE
Add `velodrome.finance` to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "velodrome.finance",
     "stakeflip.fi",
     "worldcoinv2.com",
     "distribute-aave.com",


### PR DESCRIPTION
This is a temporary blacklist as the UI is currently compromised: https://twitter.com/VelodromeFi/status/1729771762752135463.