### PR TITLE
Add `aerodrome.finance` to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "aerodrome.finance",
     "velodrome.finance",
     "stakeflip.fi",
     "worldcoinv2.com",


### PR DESCRIPTION
This is a temporary blacklisting as the UI is compromised: https://twitter.com/aerodromefi/status/1729771968717541711