### PR TITLE
remove false positive: mystic

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -56890,7 +56890,6 @@
     "masseducationweapon.com",
     "metamask-api.apps.openxcell.dev",
     "metamask-group.io",
-    "metamask.mysticlabs.xyz",
     "metamaskex.vip",
     "metamaskv.com",
     "metis.events",


### PR DESCRIPTION
@AlexHerman1 You guys added metamask.mysticlabs.xyz again (https://github.com/MetaMask/eth-phishing-detect/issues/13554). We are a Metamask Snap (https://snaps.metamask.io/snap/npm/cosmsnap/snap/).

How can we avoid this happening again cause this is the second time and disrupts users? Please advise.

Thanks!