### PR TITLE
Blacklist a scam site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "gravixguard.github.io",
     "celestialgroup.lol",
     "layerzroxapp.network",
     "celesti.tech",


### PR DESCRIPTION
gravixguard.github.io is a scam site that steals crypto from a MetaMask wallet once it is connected to the site. Please blacklist the site.
<img width="960" alt="Scam Website" src="https://github.com/MetaMask/eth-phishing-detect/assets/110564738/5894225d-4ae1-4ce6-a2a6-0fcb34f7aba2">
<img width="960" alt="MetaMask Connection To A Scam Website" src="https://github.com/MetaMask/eth-phishing-detect/assets/110564738/3c926258-f253-4cfa-9425-7b1da29dff30">
