### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "gravixguard.github.io",
     "doge-qr-code.su",
     "ltc-qr-code.ru",
     "usdrewards.io",


### PR DESCRIPTION
https://gravixguard.github.io/discord/?id=YmVja2hhbW1hcmxvdw==&token=2459281-887f-4d83-8568-2675b9f82c34

The domain itself - yes, it doesn't open and shows a 404 error, but such a full link from above is provided on the Discord scam server and it works fine. Please blacklist the domain.

    "gravixguard.github.io",
