### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "cryptomixer.club",
+    "crypto-mixer.co",
     "wsm.gift",
     "nft-derace.com",
     "hub-synthetix.io",

--- a/src/config.json
+++ b/src/config.json
@@ -513,6 +513,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "tornadocash.pro",
     "cryptomixer.club",
     "crypto-mixer.co",
     "wsm.gift",


### PR DESCRIPTION
**Details:**
Two phishing websites cloned from CryptoMixer.io that falsely offer bitcoin mixing services and may pose a risk to MetaMask users by adding other cryptocurrency options like Ethereum.

Added to blacklist:
    "cryptomixer.club",
    "crypto-mixer.co",