### PR TITLE
evilkongs.art remove from black list

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -510,6 +510,7 @@
     "satoshilabs.com",
     "satoshilabs.design",
     "metarisk.com",
+    "evilkongs.art",
     "launchpad.ethereum.org"
   ],
   "blacklist": [
@@ -53678,7 +53679,6 @@
     "easyexr.com",
     "easyexs.com",
     "eigenlayeir.xyz",
-    "evilkongs.art",
     "exdouseds.azurewebsites.net",
     "exdousrr.azurewebsites.net",
     "exodufs.azurewebsites.net",


### PR DESCRIPTION
Evil Kongs project was added to black list with out any reason, the project have more than 1 year working, now a lot users have problems on the website, you should check this kind of request or merges...

Remove from blacklist
"evilkongs.art",