### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "cryptomixer.vip",
     "aeth.solutions",
     "memecoin.page",
     "metatank.app",


### PR DESCRIPTION
**Details:**
"cryptomixer.vip", a cloned website of the legitimate service "cryptomixer.io", is a fake crypto mixer and phishing platform that poses a significant risk to MetaMask users.

Added to blacklist:
    "cryptomixer.vip",