### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "bankless-claimable.net",
     "allocation-optimism.com",
     "optimism-io.tech",
     "blur-io.network",


### PR DESCRIPTION
Added 'bankless-claimable.net' to the blacklist. This domain has recently surfaced and is misleading users. Note that the official domain is 'dappradar.com'. Let's stay vigilant, friends