### PR TITLE
Added logic to explicitly skip an allowlist redundancy check

### DIFF
--- a/src/add-hosts.js
+++ b/src/add-hosts.js
@@ -13,6 +13,12 @@ const LISTNAME_KEYS = {
   whitelist: 'allowlist',
 };
 
+// We explicitly want these domains on the allowlist
+// but redundancy check will fail if we don't ignore
+const IGNORE_ALLOWLIST_CHECK = [
+  "revoke.cash"
+];
+
 /**
   * Adds new host to config and writes result to destination path on filesystem.
   * @param {PhishingDetectorConfiguration} config - Input config
@@ -76,6 +82,12 @@ const validateHostRedundancy = (detector, listName, host) => {
       return true;
     }
     case 'allowlist': {
+
+      const skipHostRedundancyCheck = new Set(IGNORE_ALLOWLIST_CHECK);
+      if(skipHostRedundancyCheck.has(host)) {
+        return true;
+      }
+
       const r = detector.check(host);
       if (!r.result) {
         console.error(`'${host}' does not require allowlisting`);


### PR DESCRIPTION
Allows us to explicitly add to the allowlist domains that are blocked in third party lists but not our own, overruling the third party decision