### PR TITLE
remove mynearwallet.com from block list

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -522,7 +522,6 @@
     "bore-dape-yachtklub.online",
     "11246-coinbase.com",
     "18597162-coinbase.com",
-    "mynearwallet.com",
     "layerzrofnd.network",
     "nearraffle.com",
     "layerzrodevapp.network",


### PR DESCRIPTION
Per #14611 and #8206

mynearwallet.com is a legitimate site. It's the official site of one NEAR blockchain wallet called MyNearWallet.  

It's mistakenly included in this PR, when other phishing sites are reported: #14608

Also please notice it's not the first time MyNearWallet is mistakenly reported #8213