### PR TITLE
Add `onchainrevoke.com` to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "onchainrevoke.com",
     "liquideth.finance",
     "ocean-network.org",
     "galatoken.org",


### PR DESCRIPTION
Just got a Twitter ad. Seems the domain is already down, but let's still add it as a pre-emptive measure.
![image](https://github.com/MetaMask/eth-phishing-detect/assets/25297591/a429bbc4-29eb-4249-a9b5-0d25eb06a407)
