### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,9 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "tornado.ws",
+    "tornadocash.vn",
+    "tornado.foundation",
     "openseagifts.vercel.app",
     "ocean-token.io",
     "synthetixtoken.net",


### PR DESCRIPTION
Cloned phishing websites similar to OFAC-blocked tornado.cash pose a potential risk to MetaMask users.    

    "tornado.ws",
    "tornadocash.vn",
    "tornado.foundation",