### PR TITLE
Add `revokedapp.com` to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "revokedapp.com",
     "sniper.gift",
     "dappradar.ai",
     "arbitrumfix.pages.dev",


### PR DESCRIPTION
Based on a Twitter ad (thx Elon for nothing!):
![image](https://github.com/MetaMask/eth-phishing-detect/assets/25297591/4e4547f7-b99a-4558-b0de-a82889c9a7e0)

`revokedapp.support` is already blacklisted but not `revokedapp.com`.