### PR TITLE
Moving the legitimate websites from blacklist to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -508,7 +508,9 @@
     "satoshilabs.com",
     "satoshilabs.design",
     "metarisk.com",
-    "launchpad.ethereum.org"
+    "launchpad.ethereum.org",
+    "mycoinchange.ai",
+    "mycoinchange.co"
   ],
   "blacklist": [
     "distribution-opensea.com",
@@ -871,8 +873,6 @@
     "ark-crypto.net",
     "crypto-blender.com",
     "sinbad.bio",
-    "mycoinchange.ai",
-    "mycoinchange.co",
     "sinbady.com",
     "smartmix.club",
     "hub-synthetix.com",


### PR DESCRIPTION
As per discussion in issue #14653, moved `mycoinchange.ai` and `mycoinchange.co` from block list to whitelisted.

You can find the evidence for our business below:

- ChangeNow API used for all mycoinchange.co crypto swaps [Link](https://x.com/ChangeNOW_io/status/1692250204064407964?s=20)
- [Canadian Business Registration](https://ised-isde.canada.ca/cc/lgcy/fdrlCrpDtls.html?p=0&corpId=15364035&V_TOKEN=null&crpNm=My%20Coin%20Change%20Ltd.&crpNmbr=1536403-5&bsNmbr=789253952&cProv=&cStatus=&cAct=)
- Canadian MSB application in process. 
  - FINTRAC recognizes mycoinchange.co and mycoinchange.ai as a covered [Proof](https://imgur.com/rj69OFb) 
  - _Enrollment process is proceeding as normal._
- The firm that is in charge of attaining the MSB/FINTRAC license is called Tetra Consultants [Link](https://www.tetraconsultants.com).
  - Further clarification can be provided by _hanna@tetraconsultants.com_
- Our AML and Compliance  officer Is Lester Mok _lester@tetraconsultants.com_





