### PR TITLE
Add scams from ChainPatrol

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "blockscape.org",
     "blockchainrepairprotocols.com",
     "dappsresolver.com",
     "dappswebe3.com",


### PR DESCRIPTION
## Scam links
- [blockscape.org](https://blockscape.org)
- [stake.blockscape.org](https://stake.blockscape.org)
- [bridge.blockscape.org](https://bridge.blockscape.org)
