### PR TITLE
Update config.json - fake blender site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "blender.pw",
     "blockscape.org",
     "blockchainrepairprotocols.com",
     "dappsresolver.com",


### PR DESCRIPTION
**Details:** The Fake Crypto Mixer website has successfully phished users by mimicking the former legitimate service "Blender.io".

Added to blacklist:
    "blender.pw",