### PR TITLE
Adding phishing sites to blocklist [7]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,13 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "xn--fxedtfloat-68a.com",
+    "aicoinex-amm.com",
+    "reeboks.ink",
+    "fennextradingservices.com",
+    "livinglargfx.com",
+    "wildmasonfx.com",
+    "syncoiresolver.pages.dev",
     "zksync-1.com",
     "consenys.io",
     "get-liquideth.com",


### PR DESCRIPTION
all from zendesk except #14752 

    "xn--fxedtfloat-68a.com",
    "aicoinex-amm.com",
    "reeboks.ink",
    "fennextradingservices.com",
    "livinglargfx.com",
    "wildmasonfx.com",
    "syncoiresolver.pages.dev",