### PR TITLE
Remove legitimate site from blocked websites

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -547,7 +547,6 @@
     "coinbase-live-chat.com",
     "lidofinance-revshare.pages.dev",
     "blastl2.co",
-    "sei-faucet.nima.enterprises",
     "blast-invite.xyz",
     "magiceden.network",
     "blastgiveaway.pages.dev",


### PR DESCRIPTION
Hey, 

Our website is marked as a phishing one, and it actually isn't.

We've built a faucet in coordination with Sei team in order to support early EVM v2 builders with some necessary tooling. 

The faucet belongs to https://nima.enterprises organization, which is a legitimate startup company, run by myself. 

Adding also twitter announcements about the faucet: 

- https://twitter.com/madjarevicn/status/1741045052867219889
- https://twitter.com/0xpsupsu/status/1741295162104656023

Hopefully this gets resolved asap. 