### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "lndry.xyz",
+    "btcmixer.grabgame.cash",
     "metacoin.page",
     "earndrop.world",
     "tornadoeth.cash",


### PR DESCRIPTION
**Details:**
Both "lndry.xyz" and "btcmixer.grabgame.cash" are fake crypto mixer phishing websites that pose a significant risk to unsuspecting individuals.

Added to blacklist:
    "lndry.xyz",
    "btcmixer.grabgame.cash",