### PR TITLE
Adding phishing sites to blocklist [8]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -502,6 +502,14 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "opensae-claim.web.app",
+    "mint-openseapro.web.app",
+    "solana-hold.web.app",
+    "paperhands-solana.web.app",
+    "portal-coin.web.app",
+    "openseanftmint.web.app",
+    "connect-collabs.land",
+    "earsndrop.org",
     "sleeplessailab.net",
     "manta-networks.org",
     "clestia.org",


### PR DESCRIPTION
fixes #14913
fixes #14916 

    "opensae-claim.web.app",
    "mint-openseapro.web.app",
    "solana-hold.web.app",
    "paperhands-solana.web.app",
    "portal-coin.web.app",
    "openseanftmint.web.app",
    "connect-collabs.land",
    "earsndrop.org",