### PR TITLE
Whitelist: tedcrypto.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -499,7 +499,8 @@
     "satoshilabs.com",
     "satoshilabs.design",
     "metarisk.com",
-    "launchpad.ethereum.org"
+    "launchpad.ethereum.org",
+    "tedcrypto.io"
   ],
   "blacklist": [
     "dappradar.land",
@@ -52300,7 +52301,6 @@
     "solbitbridge.io",
     "starsatlas.io",
     "swap-jup.ag",
-    "tedcrypto.io",
     "token-claiming.xyz",
     "toncrypto.io",
     "trplnft.net",


### PR DESCRIPTION
As requested here: https://github.com/MetaMask/eth-phishing-detect/issues/15015 this adds tedcrypto.io to the whitelisted domains. 

Many thanks