### PR TITLE
add phishing site to blocklist [1]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -502,6 +502,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "waves-opensea.com",
     "coins-rocketpool.net",
     "fuelcoin.click",
     "bigbang-blast.io",


### PR DESCRIPTION
fixes #15083 

    "waves-opensea.com",
