### PR TITLE
remove gt from blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -47758,7 +47758,6 @@
     "rewards-monad.xyz",
     "treasury-manta.xyz",
     "event-monad.xyz",
-    "gt-protocol.io",
     "dapp-pyth.network",
     "giveaway-manta.network",
     "whitelist-pyth.network",


### PR DESCRIPTION
The team behind this project reached out requesting to be removed from the blocklist

Obliging as I personally did not see the site stealing private keys or approval phishing

I did not verify every subdomain, nor did I look for potentially malicious activity beyond private key phishing / approval phishing

Removal from the blocklist is not an indication that the site, project, or team is legitimate.

Further, the site should be immediately re-blocked if anyone does find any indication that the site is phishing.

