### PR TITLE
Adding phishing sites to blocklist [9]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -499,6 +499,15 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "dropsearcher.com",
+    "searchdrop.app",
+    "dropcheckerx.com",
+    "dmail.events",
+    "check-defi.com",
+    "reg-de.fi",
+    "sign-defi.com",
+    "season1-defi.xyz",
+    "list-defi.com",
     "mixertumbler.com",
     "bitcoin2litecoin.com",
     "karatdao.fi",


### PR DESCRIPTION
from Issues list

    "dropsearcher.com",
    "searchdrop.app",
    "dropcheckerx.com",
    "dmail.events",
    "check-defi.com",
    "reg-de.fi",
    "sign-defi.com",
    "season1-defi.xyz",
    "list-defi.com",