### PR TITLE
Remove FP revolut.codes

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -50319,7 +50319,6 @@
     "pancakeswapclean.pages.dev",
     "paxosreward.net",
     "poly-claims.xyz",
-    "revolut.codes",
     "rewards-monthly.com",
     "scrroll.io",
     "secured-apps-mainnet.onrender.com",


### PR DESCRIPTION
Remove FP revolut.codes
Blocked Nov 7, 2023 via [#14086](https://github.com/MetaMask/eth-phishing-detect/pull/14086)