### PR TITLE
[Block] Add cryptohopperclaim.com to the blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -79888,6 +79888,7 @@
     "filecoincrq.com",
     "zkfarzgroup.xyz",
     "metiscoin-air.com",
+    "cryptohopperclaim.com",
     "rewards-dymension.xyz"
   ]
 }


### PR DESCRIPTION
**Domain:** cryptohopperclaim.com

(Phishing website that is sent from email for fake airdrop)

- [X] I have checked to make sure that [there is not a duplicate issue](https://github.com/MetaMask/eth-phishing-detect/issues)
