### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -499,6 +499,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "dappradar.run",
+    "dappradar-token.com",
     "fees-etherscan.com",
     "nfts-altlayer.io",
     "zerolend.app",


### PR DESCRIPTION
Added 2 phishing links to the blacklist.

Official domain is dappradar.com