### PR TITLE
Added zerolend to the whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -494,7 +494,6 @@
     "everscan.io",
     "boyensea.me",
     "satoshilabs.com",
-    "zerolend.xyz",
     "satoshilabs.design",
     "metarisk.com",
     "launchpad.ethereum.org"

--- a/src/config.json
+++ b/src/config.json
@@ -494,6 +494,7 @@
     "everscan.io",
     "boyensea.me",
     "satoshilabs.com",
+    "zerolend.xyz",
     "satoshilabs.design",
     "metarisk.com",
     "launchpad.ethereum.org"
@@ -509,7 +510,6 @@
     "mtc-network.xyz",
     "metacoin-wallets.org",
     "apis-colnbase.com",
-    "zerolend.xyz",
     "redeemjito.org",
     "www-coinbase-cb.com",
     "identity-colnbase.help",


### PR DESCRIPTION
ZeroLend.xyz is the real website. All the others are fakes. It was accidently added into the blacklist.