### PR TITLE
Update config.json 

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -498,6 +498,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "anonymousmixer.eth.link",
     "web3-infinityfx.com",
     "illuviumtoken.com",
     "swellnetworketn.com",


### PR DESCRIPTION
Details:
"Anonymousmixer.eth.link" is a fraudulent crypto mixer website that poses a risk to MetaMask users. This site is a continuation of the previous phishing domain, "anonymousmixers.com," which was already suspended for abusing its services. The fraudster behind this site is using a Medium account to promote their new phishing website, as seen on https://anonymousmixers.medium.com/ (Backup: https://web.archive.org/web/20240206164226/https://anonymousmixers.medium.com/).

The former Ethereum mixer scam website known as "Anonymousmixers" (anonymousmixers.com) had also been promoted on their Medium account, as seen on https://ethereum-mixer.medium.com/anonymous-mixer-cdb805f616cf (Backup: https://web.archive.org/web/20240206165204/https://ethereum-mixer.medium.com/anonymous-mixer-cdb805f616cf). When their previous domain was suspended, they created the new phishing domain, "anonymousmixer.eth.link," along with another Medium account, to conduct social engineering and psyop attacks. They fabricated a fake story to explain why their previous domain was suspended, which can be read here: https://anonymousmixers.medium.com/anonymous-mixer-decentralized-domain-name-5a1767ca4227 (Backup: https://web.archive.org/web/20240206164337/https://anonymousmixers.medium.com/anonymous-mixer-decentralized-domain-name-5a1767ca4227).

Added to blacklist:
"anonymousmixer.eth.link",