### PR TITLE
Add ZeroLend Phishing Site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -97503,6 +97503,7 @@
     "trollheim.io",
     "node-access.xyz",
     "pandora.zh1y.top",
-    "pandora.b5qlb.top"
+    "pandora.b5qlb.top",
+    "zero-land.site"
   ]
 }


### PR DESCRIPTION
Ola ola,
The attached PR includes "Zero-land[dot]site" which is a phishing site pretending to be ZeroLend. 

