### PR TITLE
Remove Shared Libraries as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,3 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*.js                                 @MetaMask/shared-libraries-engineers
-package.json                         @MetaMask/shared-libraries-engineers
-.github/                             @MetaMask/shared-libraries-engineers


### PR DESCRIPTION
The Shared Libraries team intended to monitor the detector by being listed as codeowners. However, having our team as codeowners has posed challenges for others who are more actively maintaining the repository. Therefore, we would like to remove our team. We are reverting it back to its previous state and will allow the more active maintainers to designate the appropriate codeowners.