### PR TITLE
UPDATE config with originals-adidas.store

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -45,6 +45,7 @@
     "satoshilabs.design"
   ],
   "blacklist": [
+    "originals-adidas.store",
     "zrxdao.com",
     "fuelnetwork-registerlivei.vercel.app",
     "dappsradar.markets",


### PR DESCRIPTION
https://www.originals-adidas.store is a malicious site that hasn't been added to eth phishing detect yet

Proof
<img width="315" alt="image" src="https://github.com/MetaMask/eth-phishing-detect/assets/40729327/fea4a561-a86f-4eea-ab4e-19733a1864d7">
