### PR TITLE
add drop.block-sec.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -45,6 +45,7 @@
     "satoshilabs.design"
   ],
   "blacklist": [
+    "drop.block-sec.com",
     "arbitrum-token-bridge-6l0svbyos-offchain-labs.vercel.app",
     "arbitrum-token-bridge-git-fix-event-logs-w-3bc88f-offchain-labs.vercel.app",
     "arbitrum-token-bridge-git-new-tx-history-s-a94206-offchain-labs.vercel.app",


### PR DESCRIPTION
Kindly include drop.block-sec.com in the blacklist. 
It's a counterfeit phishing site mimicking BlockSec. 
Appreciate your vigilance!