### PR TITLE
remove fp feedback.gandalf.network

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -107729,7 +107729,6 @@
     "migrate-alienform.live",
     "fedex.safety-orders.site",
     "schwcryptovipclubusa.com",
-    "feedback.gandalf.network",
     "jitro.network",
     "airdropfinderhelp-bot.laag.site",
     "bungeeexchange.top",


### PR DESCRIPTION
I know the founders personally and they reported feedback.gandalf.network as being owned by them but currently on blocklist