### PR TITLE
fix: remove error log referencing non-existent variables

### DIFF
--- a/src/add-hosts.js
+++ b/src/add-hosts.js
@@ -42,7 +42,6 @@ const addHosts = (config, section, domains, dest) => {
 
   for (const host of config[section]) {
     if (!validateHostRedundancy(detector, LISTNAME_KEYS[section], host)) {
-      console.error(`existing entry '${host}' removed due to now covered by '${r.match}' in '${r.type}'.`);
       didFilter = true;
       continue;
     }


### PR DESCRIPTION
- This console.error() statement seems to have been accidentally left behind by this commit: https://github.com/MetaMask/eth-phishing-detect/commit/047be1fde1808356a65e9e873fb55650667cf3e4#diff-3fcd5e03cd2019c80afc743dfff70f45ee2aeb58c83ca5994f55949b3af02d6bL30-L32
- To reproduce the bug, run `yarn add:blocklist ticket.universalprotocoldapp.io universalprotocoldapp.io`

```
yarn add:blocklist ticket.universalprotocoldapp.io universalprotocoldapp.io
yarn run v1.22.21
warning package.json: License should be a valid SPDX license expression
warning ../package.json: License should be a valid SPDX license expression
$ node src/add-hosts.js src/config.json blocklist ticket.universalprotocoldapp.io universalprotocoldapp.i
o                                                                                                        'ticket.universalprotocoldapp.io' already covered by 'ticket.universalprotocoldapp.io' in 'blacklist'.
'ticket.universalprotocoldapp.io' already covered by 'universalprotocoldapp.io' in 'blacklist'.
ReferenceError: r is not defined
    at addHosts (/Users/umar/Projects/chainpatrol/eth-phishing-detect/eth-phishing-detect/src/add-hosts.j
s:45:80)                                                                                                     at Object.<anonymous> (/Users/umar/Projects/chainpatrol/eth-phishing-detect/eth-phishing-detect/src/a
dd-hosts.js:153:23)                                                                                          at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```