### PR TITLE
Update blocklist – remove retrofunding.optimism.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -95,7 +95,6 @@
     "portal-zksync.network",
     "web-zksync.network",
     "airdroper.app",
-    "retrofunding.optimism.io",
     "airdrop.fueleproject.network",
     "auroria.explorer-api.zksync.stratisplatform.com",
     "zksync.guru",


### PR DESCRIPTION
Removes `retrofunding.optimism.io` from the blocklist.

This is a legitimate Optimism website added as a false positive.

Issues: #62004 #61985 