### PR TITLE
remove deform.plumenetwork.xyz from blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -158933,7 +158933,6 @@
     "getbased.info",
     "signup-linea.com",
     "connect-paramlabs.com",
-    "deform.plumenetwork.xyz",
     "whitelist-plumenetwork.xyz",
     "125194-coinbase.com",
     "16159867-coinbase.com",


### PR DESCRIPTION
Removes `deform.plumenetwork.xyz` from the blacklist. Linked issue: #62403  

I am the co-founder and CTO of Plume Network, and can verify this pull request on [LinkedIn](https://www.linkedin.com/in/eyqs/), [Twitter](https://x.com/eyqshen), [email](mailto:eyqs@plumenetwork.xyz), or any other social media platform as required.

All `*.plumenetwork.xyz` websites are the official websites of Plume Network and should not be added to the blacklist. On a somewhat related note, I tried adding plumenetwork.xyz to the allowlist but received the following error:

```
$ yarn add:allowlist plumenetwork.xyz
yarn run v1.22.22
warning package.json: License should be a valid SPDX license expression
$ node src/add-hosts.js src/config.json allowlist plumenetwork.xyz
'plumenetwork.xyz' does not require allowlisting
'phosphor.xyz' does not require allowlisting
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I could resolve this by adding plumenetwork.xyz manually to the blacklist first to ensure plumenetwork.xyz remains allowlisted even with future false positive reports. Would adding plumenetwork.xyz to the blacklist affect subdomains as well? Please let me know how I should proceed.