### PR TITLE
Expanded Allowlist Check

### DIFF
--- a/src/validate-new-config.js
+++ b/src/validate-new-config.js
@@ -70,7 +70,7 @@ if (process.argv.length !== 4) {
         const data = await response.json();
         if (data.status === "ALLOWED") {
           exitWithFail(
-            `new blocklist entry "${blocklistAddition}" is in the allowlist`
+            `new blocklist entry "${blocklistAddition}" is in the chainpatrol allowlist`
           );
         }
       }

--- a/src/validate-new-config.js
+++ b/src/validate-new-config.js
@@ -25,7 +25,6 @@ if (process.argv.length !== 4) {
 
 (async () => {
   try {
-    console.log("starting validate-new-config");
     const [baseConfig, newConfig] = process.argv
       .slice(2)
       .map((p) => JSON.parse(readFileSync(p)));
@@ -55,20 +54,15 @@ if (process.argv.length !== 4) {
         (h) => !baseConfig.blacklist.includes(h)
       );
 
-      const chainpatrolAPIoptions = {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: '{"content":"<string>"}',
-      };
-
-      console.log(
-        "Running blocklist additions against ChainPatrol Allowlist API",
-        blocklistAdditions
-      );
-
       // Check that they are not in the allowlist
       for (const blocklistAddition of blocklistAdditions) {
         //call chainpatrol api asset-check
+        const chainpatrolAPIoptions = {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: blocklistAddition }),
+        };
+
         const response = await fetch(
           "https://app.chainpatrol.io/api/v2/asset/check",
           chainpatrolAPIoptions

--- a/src/validate-new-config.js
+++ b/src/validate-new-config.js
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
-const { readFileSync } = require('fs');
+const { readFileSync } = require("fs");
 
 const exitWithUsage = (exitCode) => {
-  console.error(`Usage: ${
-    process.argv.slice(0,2).join(' ')
-  } baseconfig.json newconfig.json`);
-  console.error('Compares diff between base and new config, validating invariants');
+  console.error(
+    `Usage: ${process.argv
+      .slice(0, 2)
+      .join(" ")} baseconfig.json newconfig.json`
+  );
+  console.error(
+    "Compares diff between base and new config, validating invariants"
+  );
   process.exit(exitCode);
 };
 
@@ -19,25 +23,68 @@ if (process.argv.length !== 4) {
   exitWithUsage(1);
 }
 
-try {
-  const [baseConfig, newConfig] = process.argv.slice(2).map(p => JSON.parse(readFileSync(p)));
-  {
-    // 1. Fuzzylist is remove-only
-    let result;
-    if (result = newConfig.fuzzylist.find(h => !baseConfig.fuzzylist.includes(h))) {
-      exitWithFail(`unexpected fuzzylist entry "${result}"`);
+(async () => {
+  try {
+    console.log("starting validate-new-config");
+    const [baseConfig, newConfig] = process.argv
+      .slice(2)
+      .map((p) => JSON.parse(readFileSync(p)));
+    {
+      // 1. Fuzzylist is remove-only
+      let result;
+      if (
+        (result = newConfig.fuzzylist.find(
+          (h) => !baseConfig.fuzzylist.includes(h)
+        ))
+      ) {
+        exitWithFail(`unexpected fuzzylist entry "${result}"`);
+      }
     }
-  }
-  {
-    // 2. Fuzzy-tolerance is strictly bounded to not grow
-    if (!(newConfig.tolerance <= baseConfig.tolerance)) {
-      exitWithFail(`new tolerance ${newConfig.tolerance} must be <= old tolerance ${oldConfig.tolerance}`);
+    {
+      // 2. Fuzzy-tolerance is strictly bounded to not grow
+      if (!(newConfig.tolerance <= baseConfig.tolerance)) {
+        exitWithFail(
+          `new tolerance ${newConfig.tolerance} must be <= old tolerance ${oldConfig.tolerance}`
+        );
+      }
     }
-  }
-  // TODO: enable once lists are sorted in `config.json`
-  /*
+    {
+      // Check against ChainPatrol Allowlist API
+      // Get only the blocklist additions in newConfig
+      const blocklistAdditions = newConfig.blacklist.filter(
+        (h) => !baseConfig.blacklist.includes(h)
+      );
+
+      const chainpatrolAPIoptions = {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: '{"content":"<string>"}',
+      };
+
+      console.log(
+        "Running blocklist additions against ChainPatrol Allowlist API",
+        blocklistAdditions
+      );
+
+      // Check that they are not in the allowlist
+      for (const blocklistAddition of blocklistAdditions) {
+        //call chainpatrol api asset-check
+        const response = await fetch(
+          "https://app.chainpatrol.io/api/v2/asset/check",
+          chainpatrolAPIoptions
+        );
+        const data = await response.json();
+        if (data.status === "ALLOWED") {
+          exitWithFail(
+            `new blocklist entry "${blocklistAddition}" is in the allowlist`
+          );
+        }
+      }
+    }
+    // TODO: enable once lists are sorted in `config.json`
+    /*
   {
-    // 3. Entries are sorted alphabetically
+    // 4. Entries are sorted alphabetically
     ['fuzzylist','blacklist','whitelist'].forEach(listName => {
       if(!deepEqual(newConfig[listName], [...newConfig[listName]].sort())) {
         exitWithFail(`${listName} not sorted`);
@@ -45,6 +92,7 @@ try {
     });
   }
   */
-} catch (err) {
-  exitWithFail(err.message || err);
-}
+  } catch (err) {
+    exitWithFail(err.message || err);
+  }
+})();


### PR DESCRIPTION
This PR aims to reduce false positives in the blocklist by checking against ChainPatrol's allowlist of legitimate domains.

ChainPatrol regularly verifies companies in the Web3 space and adds their domains to our own allowlist. The allowlist is always open for use.

Here we add a check in `validate-new-config.js` to check the new blocklist additions against the ChainPatrol Asset-Check API.

If the API returns `ALLOWED` for any blocklist addition then `validate-new-config` will throw an error.

Full Documentation on the API can be found here https://chainpatrol.io/docs/external-api/asset-check