### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 *.js                                 @kumavis @409H @FrederikBolding @MetaMask/product-safety
 *.sh                                 @kumavis @409H @FrederikBolding
 package.json                         @kumavis @409H @FrederikBolding
-.github/                             @kumavis @409H @FrederikBolding @MetaMask/application-security
+.github/                             @kumavis @409H @FrederikBolding @MetaMask/product-safety
 test/                                @kumavis @409H @FrederikBolding

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*.js                                 @kumavis @409H @FrederikBolding @0xOhm @augmentedmode
+*.js                                 @kumavis @409H @FrederikBolding @MetaMask/product-safety
 *.sh                                 @kumavis @409H @FrederikBolding
 package.json                         @kumavis @409H @FrederikBolding
 .github/                             @kumavis @409H @FrederikBolding @MetaMask/application-security


### PR DESCRIPTION
Add team `product-safety` to own .js changes (mostly for tests going forward as detector.js logic is moved elsewhere)