### PR TITLE
fix: keep mm test phishing page blocked

### DIFF
--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -23,6 +23,7 @@ export const runTests = (config: Config) => {
                 "metamask.com",
                 "tornadoeth.cash",
                 "tornadoeth.cash.", //Test for absolute fully-qualified domain name
+                "test.metamask-phishing.io",
             ],
             config,
         );
@@ -136,6 +137,7 @@ export const runTests = (config: Config) => {
                 "metamask.com",
                 "tornadoeth.cash",
                 "tornadoeth.cash.", //Test for absolute fully-qualified domain name
+                "test.metamask-phishing.io",
             ],
             currentConfig,
         );


### PR DESCRIPTION
Prevents a regression on a QA test by ensuring that this URL remains blocked. This unit test will now fail whenever it attempts to be unblocked

![image](https://github.com/user-attachments/assets/b54966fa-d0da-45fb-90b1-ff498678aefd)
![image](https://github.com/user-attachments/assets/51a9cc72-ca02-41ba-add0-9b761db42336)
