### PR TITLE
Create sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,19 +9,19 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout eth-phishing-detect
       uses: actions/checkout@v4
       with:
         path: eth-phishing-detect
-        
+
     - name: Checkout blocklists
       uses: actions/checkout@v4
       with:
         repository: security-alliance/blocklists
         path: blocklists
-        
+
     - name: Sync
       run: |
         cd $GITHUB_WORKSPACE/eth-phishing-detect
@@ -33,11 +33,18 @@ jobs:
           > temp.json
 
         mv temp.json src/config.json
-        
+
+        git add .
+
+        if git diff-index --quiet HEAD; then
+          echo "no changes to commit"
+          exit 0
+        fi
+
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         
-        git commit -am "sync blocklist"
+        git commit -m "sync blocklist"
         
         git push
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,40 @@
+name: Sync with SEAL blocklists
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout eth-phishing-detect
+      uses: actions/checkout@v4
+      with:
+        path: eth-phishing-detect
+        
+    - name: Checkout blocklists
+      uses: actions/checkout@v4
+      with:
+        repository: security-alliance/blocklists
+        path: blocklists
+        
+    - name: Sync
+      run: |
+        cd $GITHUB_WORKSPACE/eth-phishing-detect
+
+        cat $GITHUB_WORKSPACE/blocklists/domain.txt $GITHUB_WORKSPACE/blocklists/ip.txt $GITHUB_WORKSPACE/blocklists/ipfs.txt \
+          | grep -v '^$' \
+          | jq --raw-input . \
+          | jq --slurpfile newBlacklist /dev/stdin '. + {blacklist: $newBlacklist}' src/config.json \
+          > temp.json
+
+        mv temp.json src/config.json
+        
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        
+        git commit -am "sync blocklist"
+        
+        git push
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,7 +1,10 @@
 name: Sync with SEAL blocklists
 
-on:
-  workflow_dispatch:
+on: workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   sync:


### PR DESCRIPTION
CI keeps failing in various fun ways, probably because of our (ab)use of pull requests and actions to [checkout, install node, run a bunch of javascript] every few minutes. SEAL is already importing any remaining manual changes being made to this repository, and we just implemented a new filter on our end to replicate the Tranco checks being performed here. Let's try using an action to merge in the changes instead of flooding the repo with PRs.