### PR TITLE
Remove false positive: decen-masters.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,4 +1,4 @@
-{
+    {
   "version": 2,
   "tolerance": 1,
   "fuzzylist": [
@@ -132853,7 +132853,6 @@
     "opensea-wallet-log-io.pages.dev",
     "highwaymigration.com",
     "malgo.finance",
-    "decen-masters.com",
     "web-metamask-digi-wallet.pages.dev",
     "coinboses.com",
     "metamask-login-cloud.pages.dev",


### PR DESCRIPTION
 Removing incorrectly flagged legitimate ecommerce site.
 See Issue ##186556 for full details.
 Site has no Web3/crypto functionality and was falsely reported.
 This is causing active business damage.