### PR TITLE
Remove `cryptoknitties.io` From Whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -34,7 +34,6 @@
     "walletconnect.org",
     "cryptofitties.com",
     "cryptokitties.co",
-    "cryptoknitties.io",
     "cryptotitties.fun",
     "etcerscan.com",
     "etherscan.com",


### PR DESCRIPTION
AngelFerno abuses is currently;

https://sites.google.com/view/aavee-finance/aave?gad_campaignid=23057443354

see https://cryptoknitties.io/secureproxy.php?e=ping_proxy