### PR TITLE
Add Ambient Finance phishing site

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -133341,6 +133341,7 @@
     "allocation-arkm.com",
     "qoin-bes-login.pages.dev",
     "xn--cnbscmdwnladwllet-u4nk4g6igcd00dz5254adai.colnbas.us.com",
-    "unswp.org"
+    "unswp.org",
+    "amblent.com"
   ]
 }


### PR DESCRIPTION
`amblent.com` is impersonating `ambient.finance` with its favicon and metadata.

<img width="751" height="192" alt="amblent" src="https://github.com/user-attachments/assets/c416b9c0-b2b3-4d2c-b056-78e4a0d558ca" />
