### PR TITLE
add metamask phishing test page to blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -991,6 +991,7 @@
     "www.collablandverify.org",
     "verify.connectkava.xyz",
     "jup.airdrop.llc",
+    "test.metamask-phishing.io",
     "u6u.mining123.com",
     "ethenvironment.pro",
     "remix-console.net",


### PR DESCRIPTION
## Summary

This pull request adds the MetaMask phishing test page to the blocklist. We use this for internal blocklist testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `test.metamask-phishing.io` to the blocked domains list in `src/config.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b43d0a9fa03e15973d0b94fc6102cbde9dc788a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->