### PR TITLE
Update path-enabled-domains.ts to inlcude `uploader.irys.xyz`

### DIFF
--- a/test/path-enabled-domains.ts
+++ b/test/path-enabled-domains.ts
@@ -3,5 +3,6 @@ export const PATH_REQUIRED_DOMAINS = [
   'cdpn.io',
   'sites.google.com',
   'twitter.com',
-  'x.com'
+  'x.com',
+  'uploader.irys.xyz'
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new hostname that requires a path in the blocklist.
> 
> - Extends `PATH_REQUIRED_DOMAINS` in `test/path-enabled-domains.ts` to include `uploader.irys.xyz`
> - Minor formatting: adds trailing comma after `x.com`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be221697a4ca16bd9837938884cdf219529f279c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->