### PR TITLE
Update test-lists.ts to allow for `irys.xyz` domains to be blocked

### DIFF
--- a/test/test-lists.ts
+++ b/test/test-lists.ts
@@ -69,6 +69,7 @@ const bypass = new Set([
     "kuroro.com", // FE Compromise?
     "maxidogetoken.com",
     "bondex.app", // XSS
+    "irys.xyz", // Drainer frontends being hosted on IPFS
 ]);
 
 export const runTests = (config: Config) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the test bypass list to avoid false-positive failures when `irys.xyz` is blocked.
> 
> - Adds `irys.xyz` to the `bypass` set in `test/test-lists.ts` (noted as drainer frontends on IPFS) so allowlist tests pass while it remains blocklisted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5b7cec670918fcf17af15a471594ee5e70ac7c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->