### PR TITLE
Update test-lists.ts to block `https://Decentreland.live`

### DIFF
--- a/test/test-lists.ts
+++ b/test/test-lists.ts
@@ -71,6 +71,7 @@ const bypass = new Set([
     "bondex.app", // XSS
     "irys.xyz", // Drainer frontends being hosted on IPFS
     "25u.com", // DNS may be hijacked.
+    "decentreland.live", // somehow on tranco
 ]);
 
 export const runTests = (config: Config) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `decentreland.live` to the test `bypass` set to prevent it from being flagged in allowlist checks (e.g., Tranco). This only affects test validation logic.
> 
> - Extend `bypass` domains in `test/test-lists.ts` with `decentreland.live`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de89cd4536f19fd12226d771418242c0d8614139. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->