### PR TITLE
Add `irys.xyz` to `custom-tlds.ts`

### DIFF
--- a/test/custom-tlds.ts
+++ b/test/custom-tlds.ts
@@ -250,5 +250,6 @@ export const customTlds = [
   "ct.ws",
   "freecluster.eu",
   "page.gd",
-  "mssg.me"
+  "mssg.me",
+  "irys.xyz"
 ];


### PR DESCRIPTION
Just a few examples over the lates 24hrs:
- https://arweave.mainnet.irys.xyz/RD2PdPuRs0fewtjYdlmp0fLYT4yvvH4BatjefQ72LqE/index.html
- https://arweave.mainnet.irys.xyz/l_3_DPaEeaLw4rrm4yf4wK-hpfc7ZchEkO1kYuU3PS8/index.html
- https://arweave.mainnet.irys.xyz/rjFYwgy_QRaasz5aE_oMOvnF9MIK8-udeVJFEnjqBRs/index.html
- https://arweave.mainnet.irys.xyz/J3SxgwgG2ia-SW0RXn_WsFnvR9i5kbqdvgbS0ns6pis/index.html
- https://arweave.mainnet.irys.xyz/rjFYwgy_QRaasz5aE_oMOvnF9MIK8-udeVJFEnjqBRs/index.html
- https://arweave.mainnet.irys.xyz/2XoI2KGVff4GrJ5xIvN5QQMuytMkg4ZICrNrRpEg_o0/index.html

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single-list update that only broadens domain matching/classification behavior for one additional suffix.
> 
> **Overview**
> Updates `test/custom-tlds.ts` to include **`irys.xyz`** in the `customTlds` allowlist (and fixes the trailing comma on the preceding entry) so subdomains under this suffix are treated as user-generated-content hosts for public-suffix matching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f61b55f5f1950628f6bcb5b768498ec2ea90d8e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->