### PR TITLE
add more irys blocking capabilities

### DIFF
--- a/test/custom-tlds.ts
+++ b/test/custom-tlds.ts
@@ -250,6 +250,5 @@ export const customTlds = [
   "ct.ws",
   "freecluster.eu",
   "page.gd",
-  "mssg.me",
-  "irys.xyz"
+  "mssg.me"
 ];

--- a/test/path-enabled-domains.ts
+++ b/test/path-enabled-domains.ts
@@ -4,5 +4,6 @@ export const PATH_REQUIRED_DOMAINS = [
   'sites.google.com',
   'twitter.com',
   'x.com',
-  'uploader.irys.xyz'
+  'uploader.irys.xyz',
+  'arweave.mainnet.irys.xyz',
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes blocklist validation and domain parsing behavior around `irys.xyz`, which can affect what URLs are accepted or flagged. Scope is small and limited to configuration/test lists.
> 
> **Overview**
> Adds a specific `arweave.mainnet.irys.xyz/.../index.html` entry to the blacklist and updates the path-required domain allowlist to require paths for `arweave.mainnet.irys.xyz` (and normalizes the `uploader.irys.xyz` entry).
> 
> Removes `irys.xyz` from the custom public-suffix list, tightening how `irys.xyz` subdomains are parsed/treated in tests and related validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76155a7643229fb0a064d379fb062d7f9c8a3d40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->