### PR TITLE
add mainnet.irys.xyz

### DIFF
--- a/test/path-enabled-domains.ts
+++ b/test/path-enabled-domains.ts
@@ -6,4 +6,5 @@ export const PATH_REQUIRED_DOMAINS = [
   'x.com',
   'uploader.irys.xyz',
   'arweave.mainnet.irys.xyz',
+  'mainnet.irys.xyz',
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line change to a test/config allowlist; low risk with minimal behavioral impact beyond permitting this hostname when a path is present.
> 
> **Overview**
> Adds `mainnet.irys.xyz` to the `PATH_REQUIRED_DOMAINS` list so this hostname can be added to the blocklist *only when a path is included*, preventing CI/CD failures for pathless entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7afa5faf0901693a444a58f3fdd6481075f64f66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->