### PR TITLE
Update test-lists.ts

### DIFF
--- a/test/test-lists.ts
+++ b/test/test-lists.ts
@@ -73,6 +73,7 @@ const bypass = new Set([
     "25u.com", // DNS may be hijacked.
     "decentreland.live", // somehow on tranco
     "mssg.me", // hosting drainers
+    "defi2026.z13.web.core.windows.net",
 ]);
 
 export const runTests = (config: Config) => {


### PR DESCRIPTION
allowing a tranco block

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that relaxes the Tranco allowlist false-positive check by exempting one additional domain; low production risk but slightly reduces test coverage for that domain.
> 
> **Overview**
> Updates `test/test-lists.ts` to add `defi2026.z13.web.core.windows.net` to the Tranco test `bypass` set, preventing it from being flagged as a false positive in the allowlist-vs-blocklist checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb16499d8b079b91b154300d2525b603a82ae54e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->