### PR TITLE
block cow.fi for frontend comp

### DIFF
--- a/test/test-lists.ts
+++ b/test/test-lists.ts
@@ -76,6 +76,7 @@ const bypass = new Set([
     "defi2026.z13.web.core.windows.net",
     "samouraiwallet.com", // https://x.com/econoalchemist/status/2035735206691315848
     "chainge.finance",
+    "cow.fi",
 ]);
 
 export const runTests = (config: Config) => {

--- a/test/test-lists.ts
+++ b/test/test-lists.ts
@@ -76,7 +76,7 @@ const bypass = new Set([
     "defi2026.z13.web.core.windows.net",
     "samouraiwallet.com", // https://x.com/econoalchemist/status/2035735206691315848
     "chainge.finance",
-    "cow.fi",
+    "cow.fi", // https://x.com/CoWSwap/status/2044078590514327888
 ]);
 
 export const runTests = (config: Config) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a high-profile domain to the phishing `blacklist`, which could cause user-facing false positives if the incident assessment is wrong. Test coverage is adjusted to avoid CI failures due to Tranco allowlist checks.
> 
> **Overview**
> Blocks `cow.fi` by adding it to `src/config.json`’s `blacklist`.
> 
> Updates the Tranco false-positive bypass set in `test/test-lists.ts` to include `cow.fi`, preventing the allowlist-vs-blocklist test from failing while the domain is blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739660f76ddba71c6ead2c9aadade89f069d94fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->