### PR TITLE
Add 'eth[.]limo' to the tranco bypass list

### DIFF
--- a/test/test-lists.ts
+++ b/test/test-lists.ts
@@ -77,6 +77,7 @@ const bypass = new Set([
     "samouraiwallet.com", // https://x.com/econoalchemist/status/2035735206691315848
     "chainge.finance",
     "cow.fi", // https://x.com/CoWSwap/status/2044078590514327888
+    "eth.limo", // https://x.com/eth_limo/status/2045413512986411467
 ]);
 
 export const runTests = (config: Config) => {


### PR DESCRIPTION
`eth[.]limo` is currently having a DNS compromise. This adds it to the Tranco bypass list so that it can be blocked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a test bypass list used to exclude known-bad/high-reputation domains from false-positive checks, with no runtime logic changes.
> 
> **Overview**
> Updates the Tranco false-positive test bypass set to include `eth.limo` (noted as having a DNS compromise), preventing list-validation tests from treating it as an allowlisted domain that must not be blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaae5735353acf1feb48aca9ca0f8c2c924d09cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->