### PR TITLE
Add metamask.com to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -546,7 +546,6 @@
     "myerherwallet.com",
     "myetherwalllet.com",
     "myetherwalltet.com",
-    "metamask.com",
     "opeinsea.io",
     "www.opensea.uno",
     "metamaskb.io",

--- a/src/config.json
+++ b/src/config.json
@@ -45,6 +45,7 @@
     "metacask.io",
     "metamark.lt",
     "metamask.io",
+    "metamask.com",
     "metatask.io",
     "metmask.com",
     "myetherwallet.com",

--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -38,7 +38,7 @@ export const runTests = (config: Config) => {
                 "etherscan.io",
                 // allowlist subdomains
                 "www.metamask.io",
-                    
+                "portfolio.metamask.com",
                 "faucet.metamask.io",
                 "zero.metamask.io",
                 "zero-faucet.metamask.io",

--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -20,6 +20,7 @@ export const runTests = (config: Config) => {
         testBlocklist(
             t,
             [
+                "metamask.money", // Test for fuzzylist entry
                 "tornadoeth.cash",
                 "tornadoeth.cash.", //Test for absolute fully-qualified domain name
                 "test.metamask-phishing.io",
@@ -136,6 +137,7 @@ export const runTests = (config: Config) => {
         testBlocklist(
             t,
             [
+                "metamask.money", // Test for fuzzylist entry
                 "tornadoeth.cash",
                 "tornadoeth.cash.", //Test for absolute fully-qualified domain name
                 "test.metamask-phishing.io",

--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -20,7 +20,6 @@ export const runTests = (config: Config) => {
         testBlocklist(
             t,
             [
-                "metamask.com",
                 "tornadoeth.cash",
                 "tornadoeth.cash.", //Test for absolute fully-qualified domain name
                 "test.metamask-phishing.io",
@@ -35,9 +34,11 @@ export const runTests = (config: Config) => {
             t,
             [
                 "metamask.io",
+                "metamask.com",
                 "etherscan.io",
                 // allowlist subdomains
                 "www.metamask.io",
+                    
                 "faucet.metamask.io",
                 "zero.metamask.io",
                 "zero-faucet.metamask.io",
@@ -135,7 +136,6 @@ export const runTests = (config: Config) => {
         testBlocklist(
             t,
             [
-                "metamask.com",
                 "tornadoeth.cash",
                 "tornadoeth.cash.", //Test for absolute fully-qualified domain name
                 "test.metamask-phishing.io",
@@ -150,9 +150,11 @@ export const runTests = (config: Config) => {
             t,
             [
                 "metamask.io",
+                "metamask.com",
                 "etherscan.io",
                 // allowlist subdomains
                 "www.metamask.io",
+                "portfolio.metamask.com",
                 "faucet.metamask.io",
                 "zero.metamask.io",
                 "zero-faucet.metamask.io",


### PR DESCRIPTION
Resolves #243652

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the phishing detection lists by moving `metamask.com` from the blocklist to the allowlist, which could affect end-user safety if misclassified. Scope is small and covered by updated tests, but it impacts security-sensitive configuration.
> 
> **Overview**
> Updates the domain lists to **allowlist `metamask.com`** (and thereby stop treating it as blocked), removing the previous `metamask.com` entry from the blocklist.
> 
> Adjusts config tests to reflect the new allowlist behavior (including an allowlisted subdomain like `portfolio.metamask.com`) and switches the blocklist test case to use `metamask.money` to continue exercising fuzzylist coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51201ec684787a2a646d3148e51ad6c5ac572ecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->