### PR TITLE
add: allowlist app.solidusdao.com and solidusdao.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -67,7 +67,9 @@
     "satoshilabs.design",
     "storage.googleapis.com",
     "127.0.0.1",
-    "localhost"
+    "localhost",
+    "solidusdao.com",
+    "app.solidusdao.com"
   ],
   "blacklist": [
     "poly-mark.xyz",


### PR DESCRIPTION
Please allow app.solidusdao.com (subdomain) and solidusdao.com on the allowlist. Thank you.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just expands the allowlist. Impact is limited to permitting these two domains where allowlist checks are enforced.
> 
> **Overview**
> Updates `src/config.json` to allowlist **`solidusdao.com`** and **`app.solidusdao.com`**, expanding the set of permitted domains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8523f3c23e57b67f418226da7d1849a1cfd2169c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->