### PR TITLE
add: blacklist librertyswap and zkxwallets

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -108427,6 +108427,11 @@
     "treasury-flare.finance",
     "vote-flarenetwork.live",
     "degens.stakingreward.cloud",
-    "scrolls.stakingreward.cloud"
+    "scrolls.stakingreward.cloud",
+    "librertyswap.finance",
+    "liberty-swap.finance",
+    "zkxwallets.com",
+    "zk-xwallet.com",
+    "zkx-wallet.com"
   ]
 }


### PR DESCRIPTION
Requesting to add the related domains (libertyswap & zkxwallets) to the phishing blacklist due to scam/phishing activity reports.

These domains appear to impersonate legitimate DeFi/wallet services and may pose a risk to users interacting with MetaMask.

Please consider adding them to the blocklist repository for user protection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only extends a static blacklist list and does not change runtime logic, though incorrect entries could cause unintended blocking.
> 
> **Overview**
> Adds new domains to `src/config.json`’s phishing/blocked-domain list, including `librertyswap.finance`/`liberty-swap.finance` and multiple `zkxwallets` variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e697e3e392809d224f591b7ffa24891954b3c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->