### PR TITLE
Xaman.app = legitimate #1 used wallet in XRPL/Xahau ecosystem

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -107598,7 +107598,6 @@
     "treasurys-flare.foundation",
     "enter-ena.xyz",
     "increase-firelight.com",
-    "xaman.app",
     "sites.google.com/view/relaylink",
     "dashboard-flare.co",
     "dai-lgns-origindefi.io",


### PR DESCRIPTION
See title.

https://xaman.app/

Legitimate no 1 crypto wallet in the XRPL / Ripple / Xahau ecosystem, domain also used for help center and "sign requests", massive service disruption with Xaman.app on the blacklist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the domain blacklist used for blocking/flagging sites; incorrect removals could reduce protection against phishing, but the change is a single-entry adjustment.
> 
> **Overview**
> Removes `xaman.app` from the `blacklist` in `src/config.json`, allowing the root domain to no longer be treated as blocked while leaving other listed (sub)domains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a78702a4240873609ccb878a40e8b1834f27d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->