### PR TITLE
Remove theresidency.ro (false positive)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -106545,7 +106545,6 @@
     "rhino-bridge.com",
     "unitrans.cloud",
     "worldcupcoins.live",
-    "theresidency.ro",
     "yaecoin.lat",
     "hyperx-pool.com",
     "makina-finance.net",


### PR DESCRIPTION
Domain owner here. theresidency.ro is the marketing site for The Residency, a builder program by humans.ai. Registered 2026-05-11, hosted on Vercel under our team account. Static Next.js page — no wallet-connect, no seed-phrase prompts, no token claim, no on-chain interaction.

Added by `security-alliance-bot` in #247570 (auto-merged 2026-05-17). Also reaching out to SEAL via Telegram to delist from the upstream source so the bot doesn't re-sync it.

Happy to verify ownership via DNS TXT or any other check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a single domain from the `config.json` blocklist, slightly reducing phishing detection coverage for that specific hostname.
> 
> **Overview**
> Removes `theresidency.ro` from `src/config.json`, so `checkDomain`/`PhishingDetector` will no longer flag that domain as blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5532d51b4c194e7642dc337faa3515e2fefb49a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->