### PR TITLE
fix: add 2 custom tlds

### DIFF
--- a/test/custom-tlds.ts
+++ b/test/custom-tlds.ts
@@ -1,6 +1,7 @@
 /* 
   Extend public suffix list by adding to this list.
   This can include any website that allows user-generated content such as medium.com, wordpress.com, gitbook.io, etc.
+  Example: scam1.gitbook.io, scam2.gitbook.io is when you SHOULD add a domain to this website.
   Do not add real businesses that are using subdomains that are created by the company itself. You will enable false positives. 
   If you see a website that is not a hosting provider on this list, please remove it.
   If too many obscure hosting providers become a problem, we should reduce the tranco threshold from 200,000 to help filter these out.
@@ -255,4 +256,6 @@ export const customTlds = [
   "arweave.net",
   "se.net",
   "trendmicro.com", // attackers are using trendmicro subdomains
+  "zapier.app",
+  "hashnode.dev",
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates a test data list used to extend the public suffix/custom TLD set, with no logic changes.
> 
> **Overview**
> Updates `test/custom-tlds.ts` by clarifying contribution guidance in the header comment and extending the `customTlds` allowlist with **two additional user-content hosting suffixes**: `zapier.app` and `hashnode.dev`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4fc1fd39982db28d9d3bdbaf5c08a26fa26311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->