### PR TITLE
Add parstaking.com (active drainer impersonating Paradigm, targeting $ATWO TGE community)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -107622,6 +107622,7 @@
     "ruko-rewards.top",
     "tibbs-allocation.info",
     "donna-allocation.info",
-    "herzog-allocation.info"
+    "herzog-allocation.info",
+    "parstaking.com"
   ]
 }


### PR DESCRIPTION
## Domain
`parstaking.com` — wallet-drainer phishing site.

## Pattern
Impersonates Paradigm (the VC firm) as a "staking platform". Paradigm does not run a staking product; their only domain is paradigm.xyz. The site advertises "94% APR" on a mixed pool of $ATWO + $ETH + $USDT + $USDC, with an "exclusive 100 spots / Cypher Punk NFT" urgency hook.

## Distribution vector
A Telegram group ("Arena Two X Paradigm", created 2026-05-22) seeded by two impersonator accounts using homoglyph handles:
- `@lmran85` (lowercase L spoofing capital I in `@Imran85`)
- `@impossibIe_rio` (capital I spoofing lowercase L in `@impossible_rio`)

They impersonate real Arena Two partner contacts (Impossible Finance), and explicitly press the Arena Two CTO to amplify `parstaking.com/ATWO` on the official Arena Two X/Telegram channels — i.e. trying to weaponize an official account into driving traffic to the drainer. Timed to day 2 of the ATWO TGE.

## WHOIS / hosting
- Created: 2026-03-16 (~2 months old)
- Registrar: NICENIC INTERNATIONAL GROUP CO., LIMITED (IANA 3765)
- Nameservers: jillian.ns.cloudflare.com, yevgen.ns.cloudflare.com (Cloudflare-fronted)

Also reported to Cloudflare phishing abuse, NiceNIC registrar abuse, and Chainabuse.

I'm the CTO of Arena Two and one of the explicit targets of this campaign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that adds a single domain entry; main risk is potential false-positive blocking if misclassified.
> 
> **Overview**
> Adds `parstaking.com` to the domain list in `src/config.json` (alongside a trailing-comma adjustment) so it is treated as a blocked/suspicious site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c73cecf7aa630c11e23d64deb5a89f329973066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->