### PR TITLE
add phishing sites to blocklist [4]

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -107619,6 +107619,10 @@
     "live-desktop-us.hashnode.dev",
     "plasma-cove.pages.dev",
     "parstaking.com",
-    "privnotse.com"
+    "privnotse.com",
+    "startledgersso.ghost.io",
+    "safepol.com.co",
+    "safepal.com.co",
+    "tronlink.com.co"
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk data-only change that only affects which domains are flagged by the `PhishingDetector`.
> 
> **Overview**
> Adds four new domains (including lookalikes for `safepal` and `tronlink`) to `src/config.json`’s phishing blocklist, expanding what `checkDomain()` will flag as blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f00bd5766dd766efc83ec7e5e34bedd650918228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->