### PR TITLE
Add auto-lp-swap.com and autoswap.tech to allowlist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -66,6 +66,8 @@
     "satoshilabs.com",
     "satoshilabs.design",
     "storage.googleapis.com",
+    "auto-lp-swap.com",
+    "autoswap.tech",
     "127.0.0.1",
     "localhost"
   ],


### PR DESCRIPTION
### Domains

- `auto-lp-swap.com` — Production Uniswap V3 LP automation platform on Base + Arbitrum
- `autoswap.tech` — Production Uniswap V3 LP automation platform on Base + Arbitrum

### Rationale

Both domains are legitimate, operator-owned DeFi LP automation platforms in production with real users and TVL. Submitting a proactive allowlist entry to prevent any future false-positive blocks (cf. coinpool.app recent misclassification).

Both sites:
- Display their own original branding
- Connect only to their own audited smart contracts (Uniswap V3 LP vault proxies on Base and Arbitrum)
- Do not impersonate any other brand
- Have non-custodial contracts (admin cannot drain user funds)

### Checks

- ✅ Local clone of upstream verified neither domain is currently in blacklist / whitelist / fuzzylist
- ✅ \`npm run clean:allowlist\` ran without changes
- ✅ \`npm run test:config\` passes (212/212)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-domain whitelist additions with no logic or security-sensitive code changes.
> 
> **Overview**
> Adds **`auto-lp-swap.com`** and **`autoswap.tech`** to the **`whitelist`** in `src/config.json` so MetaMask’s phishing detector treats them as trusted origins instead of potential impersonation sites.
> 
> No other lists or detector settings change—only these two production DeFi LP automation domains are allowlisted proactively.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08db4d0ab43188f20ab0c5cdec0735fe396f88fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->