### PR TITLE
Update path-enabled-domains.ts to support `script.google.com`

### DIFF
--- a/test/path-enabled-domains.ts
+++ b/test/path-enabled-domains.ts
@@ -6,4 +6,5 @@ export const PATH_REQUIRED_DOMAINS = [
   'x.com',
   'uploader.irys.xyz',
   'arweave.mainnet.irys.xyz',
+  'script.google.com',
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single hostname added to a test/config allowlist with no auth, data, or runtime logic changes.
> 
> **Overview**
> Adds **`script.google.com`** to **`PATH_REQUIRED_DOMAINS`**, so blocklist entries for that host must include a path (same rule as `sites.google.com`, `twitter.com`, etc.); CI enforces this list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0683785187e76060d24c97f639905ec69be3720b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->