### PR TITLE
Add strata.markets to allowlist (false positive)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -67,7 +67,9 @@
     "satoshilabs.design",
     "storage.googleapis.com",
     "127.0.0.1",
-    "localhost"
+    "localhost",
+    "app.strata.markets",
+    "strata.markets"
   ],
   "blacklist": [
     "poly-mark.xyz",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only whitelist additions with no logic or security behavior changes beyond exempting two domains from detection.
> 
> **Overview**
> Adds **`app.strata.markets`** and **`strata.markets`** to the phishing detector **whitelist** in `config.json` so those hosts are no longer flagged as suspicious (false positive).
> 
> Also fixes JSON formatting by adding a trailing comma after **`localhost`** before the new entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ccebae3fb8008debf80515297e40057e7c85834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->