### PR TITLE
Add return type annotation to checkDomain function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,6 @@ import config from "./config.json";
 
 const detector = new PhishingDetector(config);
 
-export default function checkDomain(domain: string) {
+export default function checkDomain(domain: string): boolean {
     return detector.check(domain).result;
 }


### PR DESCRIPTION
## Problem Background
The public function `checkDomain` in `src/index.ts` was missing a return type annotation. In TypeScript, explicit type annotations improve code readability, maintainability, and enable better type checking during development.

## Changes
- Added the return type `: boolean` to the `checkDomain` function, as it returns a boolean value from `detector.check(domain).result`. This aligns with TypeScript best practices for public API functions.

## Verification
The change is purely additive for type safety and does not alter the function's behavior or API. To verify:
1. Compile the TypeScript code to ensure no type errors are introduced.
2. Run existing tests to confirm that functionality remains unchanged.