### PR TITLE
Add Piteas phishing clones to blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -102714,6 +102714,15 @@
     "exodus.credit",
     "cake-moneyfi-sdk.pages.dev",
     "sites.google.com/view/aBkR/v3/signin/",
-    "sites.google.com/view/workspace-connection/invite"
+    "sites.google.com/view/workspace-connection/invite",
+    "pitaes.io",
+    "pitaes.online",
+    "pitaes.app",
+    "pitaes.org",
+    "piteas.app",
+    "piteas.live",
+    "piteas.online",
+    "pitaes.co",
+    "piteas.finance"
   ]
 }


### PR DESCRIPTION
## Summary
Phishing clones impersonating Piteas (official site: https://piteas.io)

## Domains added to blocklist
- pitaes.io
- pitaes.online
- pitaes.app
- pitaes.org
- piteas.app
- piteas.live
- piteas.online
- pitaes.co
- piteas.finance

## Evidence
These domains use alternative TLDs and letter substitutions (pitaes vs piteas)
designed to imitate the legitimate piteas.io domain.

I am the Piteas team / brand owner reporting these impersonation sites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> List-only change with no application logic; low risk aside from ensuring none of the domains are false positives.
> 
> **Overview**
> **Extends the domain blocklist** in `src/config.json` with nine Piteas impersonation hosts (`pitaes.*` / `piteas.*` typosquats on alternate TLDs). The prior last entry (`sites.google.com/view/workspace-connection/invite`) is updated to include a trailing comma so the JSON array stays valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1018b0267ff7826b89ba5604cf9ce27b20b6e93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->