### PR TITLE
Allowlist cyberdyne-os.xyz

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -67,7 +67,8 @@
     "satoshilabs.design",
     "storage.googleapis.com",
     "127.0.0.1",
-    "localhost"
+    "localhost",
+    "cyberdyne-os.xyz"
   ],
   "blacklist": [
     "poly-mark.xyz",


### PR DESCRIPTION
## Allowlist cyberdyne-os.xyz

Proactive allowlist request for `cyberdyne-os.xyz` (covers `app.cyberdyne-os.xyz`).

**What it is:** CYBERDYNE is an agent-native marketplace where AI agents pay verified humans for real-world tasks. The web app at `app.cyberdyne-os.xyz` is a wallet-connected dapp (SIWE login, USDC payments on Base via the audited Coinbase Commerce-Payments escrow contract).

**Why:** the domain is young and crypto-facing (wallet connect + payment prompts), so we'd like it on the allowlist to prevent fuzzy-match false positives. It is not currently flagged.

**Verifiable references:**
- Live site: https://cyberdyne-os.xyz · app: https://app.cyberdyne-os.xyz
- Open-source MCP gateway: https://github.com/Cyberdyne-OS/cyberdyne-mcp (npm: `cyberdyne-mcp`)
- X: https://x.com/CyberdyneOS

`yarn test:config` passes (212/212).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain whitelist entry with no logic or security behavior changes beyond that list.
> 
> **Overview**
> Adds **`cyberdyne-os.xyz`** to the phishing-detector **`whitelist`** in `src/config.json`, so the root domain and subdomains (e.g. `app.cyberdyne-os.xyz`) are treated as legitimate and avoid fuzzy-match false positives. Also adds a trailing comma after `localhost` in the same array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d0bd70c1b37cb1e682f14c889950417b4ea65fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->