### PR TITLE
Add paradigmdefi.com to blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -101191,6 +101191,7 @@
     "sso-uphuld-x-auth.created.app",
     "phantomweb.wixstudio.com",
     "trustwalletsupport.nsmll.info",
-    "phantomomwwallleett.godaddysites.com"
+    "phantomomwwallleett.godaddysites.com",
+    "paradigmdefi.com"
   ]
 }


### PR DESCRIPTION
## Description

This site impersonated us

<img width="1020" height="1762" alt="image" src="https://github.com/user-attachments/assets/a63cdadc-c7c0-4bbb-aeb4-b145687af535" />

gained access to a discord admin account and posted a spam link

<img width="942" height="2048" alt="image" src="https://github.com/user-attachments/assets/c97a743f-9437-4f82-ad99-c6de17ddf403" />
