### PR TITLE
allowlist: openseo.so

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -58,6 +58,7 @@
     "openseam.co",
     "openseas.gr",
     "opensee.io",
+    "openseo.so",
     "openset.co",
     "openspa.info",
     "phosphor.xyz",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-domain allowlist addition with no logic or security-rule changes.
> 
> **Overview**
> Adds **`openseo.so`** to the phishing detector **`whitelist`** in `config.json`, alongside other OpenSea-related domains so it is not treated as a fuzzy/typosquat match.
> 
> No other config fields or lists are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f17839b4f114e15d112f999ece219fbd3f673090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->