### PR TITLE
Update test-lists.ts

### DIFF
--- a/test/test-lists.ts
+++ b/test/test-lists.ts
@@ -79,6 +79,7 @@ const bypass = new Set([
     "cow.fi", // https://x.com/CoWSwap/status/2044078590514327888
     "eth.limo", // https://x.com/eth_limo/status/2045413512986411467
     "startledgersso.ghost.io",
+    "uni-swap.jimdofree.com",
 ]);
 
 export const runTests = (config: Config) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line test configuration change with no effect on production blocklist behavior or security policy.
> 
> **Overview**
> Adds **`uni-swap.jimdofree.com`** to the `bypass` set in `test/test-lists.ts` so list overlap tests (`ensure no domains on allowlist are blocked`) do not treat it as a false positive when it appears alongside Tranco-related allowlist entries (parent host **`jimdofree.com`** is on Tranco).
> 
> This is test harness only: the domain can remain on the blocklist while CI keeps passing the allowlist-vs-blacklist checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa57bc3a5a6626bea9344643db97540225e129d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->