### PR TITLE
Remove beta.usdcswap.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -85010,7 +85010,6 @@
     "secureassets-kraken.com",
     "slashchat.dev",
     "spcxmeme.sale",
-    "beta.usdcswap.com",
     "coinase-sso-logi.created.app",
     "36.azamad.com",
     "upheld-trouble.created.app",


### PR DESCRIPTION
Fixes #264299

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line list maintenance with no logic or security behavior changes beyond dropping one blocked domain.
> 
> **Overview**
> Removes **`beta.usdcswap.com`** from the domain list in `src/config.json` (fixes #264299).
> 
> No other references to that host remain in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e406a398beb4d5a7adffc66a338507d1680854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->