### PR TITLE
Add aotrust.link domains to whitelist (false-positive EIP-3009 heuristic)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -68,7 +68,12 @@
     "satoshilabs.design",
     "storage.googleapis.com",
     "127.0.0.1",
-    "localhost"
+    "localhost",
+    "aotrust.link",
+    "shield.aotrust.link",
+    "verify.aotrust.link",
+    "api.aotrust.link",
+    "docs.aotrust.link"
   ],
   "blacklist": [
     "poly-mark.xyz",


### PR DESCRIPTION
## False Positive Whitelisting Request — aotrust.link

**Domains affected:**
- `aotrust.link` (root domain)
- `shield.aotrust.link` (FreelanceShield dApp interface)
- `verify.aotrust.link` (PDR verification UI)
- `api.aotrust.link` (REST API + MCP server)
- `docs.aotrust.link` (documentation)

**Type of flag:** Suspected heuristic false-positive (`.link` TLD + EIP-3009 off-chain signature request on a recently registered domain).

---

### Project Description

**AOTrust / Shield** is an open-source, non-custodial cryptographic notary and payment attestation protocol operating on Base L2 (EVM) and NEAR Protocol. The project implements the x402 payment standard using EIP-3009 `transferWithAuthorization` for gasless USDC transfers on Base mainnet.

- **Open-source repository:** https://github.com/GitSerge-crypto/agent-notary-service
- **SDKs & skills:** https://github.com/GitSerge-crypto/aotrust-skills
- **Documentation:** https://docs.aotrust.link
- **Payment-receiver wallet (Base):** `0x97E9af6B4d8a49f509DA99afaB954429Ab8Cc800`
- **Architecture:** Non-custodial. The protocol never holds user funds. All transfers are peer-to-peer, authorized directly by the user's wallet via EIP-3009. No drainer patterns, no unlimited approvals, no upgrade proxy admin keys.

---

### Why This Is a False Positive

1. **`.link` TLD heuristic:** The `.link` TLD has elevated abuse statistics, which likely triggered an automated heuristic. However, `aotrust.link` has valid TLS certificates, consistent DNS history, and operates exclusively via standard HTTPS.

2. **EIP-3009 signature pattern:** The `transferWithAuthorization` typed-data signature (EIP-3009) may superficially resemble a drainer's permit signature. However, EIP-3009 is a standard approved by Circle (USDC issuer) and used in production by Coinbase and Uniswap. The signed parameters include `validAfter`/`validBefore` expiry window and a `nonce`, making replay attacks cryptographically impossible.

3. **No custodial risk:** The destination address (`0x97E9af6B4d8a49f509DA99afaB954429Ab8Cc800` on Base) is a standard non-custodial project wallet, not a mixer, bridge, or exchange deposit address. It has transparent transaction history on Basescan with no flagged counterparties.

---

### Evidence Package

- **Basescan:** https://basescan.org/address/0x97E9af6B4d8a49f509DA99afaB954429Ab8Cc800
- **GitHub (open source):** https://github.com/GitSerge-crypto/agent-notary-service
- **Documentation:** https://docs.aotrust.link
- **Blockaid verification filed:** https://report.blockaid.io/verifiedProject
- **Contact:** legal@aotrust.link

---

### Request

Please add the `aotrust.link` domains to the **allowlist** in `src/config.json` to prevent false-positive security warnings for our users. We are available to provide any additional technical evidence.

**Contact:** legal@aotrust.link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only allowlist expansion with no runtime logic changes; incorrect entries could reduce warnings for those hosts only.
> 
> **Overview**
> Adds **five AOTrust-related domains** to the phishing detector **allowlist** in `src/config.json`: `aotrust.link` plus `shield`, `verify`, `api`, and `docs` subdomains.
> 
> This is intended to stop **false-positive** security warnings tied to `.link` TLD heuristics and legitimate **EIP-3009** `transferWithAuthorization` flows on the project’s dApps and API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b9f22b120746b09fabbbf36f3e7e7d63a38464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->