### PR TITLE
Add rewards-extended.exchange (Extended-impersonation wallet drainer)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -105459,6 +105459,7 @@
     "coinbaseprologin-uo.godaddysites.com",
     "web--so--coinbasepro-auth--cdn.webflow.io",
     "coinbaseporlognu.godaddysites.com",
-    "1pk4p1.coinbase.ngo"
+    "1pk4p1.coinbase.ngo",
+    "rewards-extended.exchange"
   ]
 }


### PR DESCRIPTION
## Blocklist addition

Adds one domain to the blocklist.

### Malicious domain

- `https://claim.rewards-extended.exchange/` (domain: `rewards-extended.exchange`, covers the `claim.` subdomain)

### Category

Phishing / wallet drainer.

### Why this is malicious

- **Impersonation.** Poses as **Extended** (real exchange, official domain `https://extended.exchange`), advertising a fake "$EXT rewards claim". No official $EXT token or claim exists — the project is pre-TGE — so the entire "claim" premise is fraudulent.
- **Wallet drainer.** The page loads an obfuscated JavaScript payload from `/arxcdr.php` (~423 KB) that is built with the dynamic `Function()` constructor and hidden using U+200C zero-width-character obfuscation. It solicits a malicious token approval / gasless off-chain signature in order to drain funds from any wallet that connects.
- **Infrastructure.** Domain registered 2026-07-13 via WebNic, fronted by Cloudflare — consistent with a freshly stood-up drainer campaign.

### Impersonated / legitimate site (not blocked)

- `https://extended.exchange` — the legitimate Extended exchange. This PR does **not** touch it.

### Checklist

- [x] I have checked the list and confirmed this is not a duplicate (`rewards-extended.exchange` is not present in `src/config.json`).
- [x] Added via the sanctioned edit to `src/config.json` `blocklist`; `yarn test:config` passes (212/212) and `validate-new-config` exits clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain blocklist entry in static config; no runtime or security-sensitive code paths changed.
> 
> **Overview**
> Adds **`rewards-extended.exchange`** to the **`src/config.json`** blocklist (with a trailing-comma fix on the prior entry) so clients can block a fake Extended “$EXT rewards claim” / wallet-drainer site.
> 
> No application logic, auth, or infrastructure code changes—only the shared domain deny list grows by one hostname.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d7359b16bd9fad7337a14352021fe04956936b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->