### PR TITLE
Update path-enabled-domains.ts

### DIFF
--- a/test/path-enabled-domains.ts
+++ b/test/path-enabled-domains.ts
@@ -7,4 +7,5 @@ export const PATH_REQUIRED_DOMAINS = [
   'uploader.irys.xyz',
   'arweave.mainnet.irys.xyz',
   'script.google.com',
+  'itch.io',
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single test/config allowlist entry with no runtime or security logic changes.
> 
> **Overview**
> Adds **`itch.io`** to `PATH_REQUIRED_DOMAINS` in `test/path-enabled-domains.ts`, so blocklist entries for that host must include a path (same rule as `twitter.com`, `x.com`, etc.). CI fails if someone adds a path-less `itch.io` blocklist entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92893225b9374fcf5bd38de6d22abdc534539cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->