### PR TITLE
fix: tranco bypass

### DIFF
--- a/test/test-lists.ts
+++ b/test/test-lists.ts
@@ -80,6 +80,7 @@ const bypass = new Set([
     "eth.limo", // https://x.com/eth_limo/status/2045413512986411467
     "startledgersso.ghost.io",
     "uni-swap.jimdofree.com",
+    "coinbasesupportdisk.forumotion.com",
 ]);
 
 export const runTests = (config: Config) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change to an explicit bypass list; no runtime blocklist or production behavior is modified.
> 
> **Overview**
> Adds **`coinbasesupportdisk.forumotion.com`** to the Tranco allowlist test **`bypass`** set in `test/test-lists.ts`.
> 
> That domain is treated as a known bad entry that still appears on Tranco (high reputation), so the bypass keeps the “no allowlist domains blocked” check from failing while the domain stays on the blocklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6eb8db9be64a93bdb926cda1cefd82e5660d78d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->