### PR TITLE
Remove cryptoscribe.to from blocklist (false positive)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -70,7 +70,8 @@
     "satoshilabs.design",
     "storage.googleapis.com",
     "127.0.0.1",
-    "localhost"
+    "localhost",
+    "cryptoscribe.to"
   ],
   "blacklist": [
     "poly-mark.xyz",
@@ -52186,7 +52187,6 @@
     "citybitcoin.to",
     "cryptoexchange.to",
     "cashout.to",
-    "cryptoscribe.to",
     "cashing.to",
     "cryptogram.to",
     "claiming.to",


### PR DESCRIPTION
Fixes #268787 (blocklist removal request).

I am the owner and developer of **cryptoscribe.to**. CryptoScribe is a creator membership platform (Patreon-style): fans subscribe to creators and pay in USDC on Polygon via [Request Network](https://request.network) recurring payments, with Sign-in-with-Ethereum (Supabase Web3 auth). The domain was blocklisted while the site was still in pre-launch development.

It is not a phishing site: no brand or wallet impersonation, no drainer code, and it never asks for seed phrases or private keys. Wallet interactions are limited to a SIWE login signature, a standard ERC-20 `approve` for Request Network's recurring-payment proxy, and an EIP-712 permit signature for the payment schedule.

This PR removes the domain from the blocklist and adds it to the allowlist. If you prefer removal only (without the allowlist entry), happy to amend. I can also prove domain ownership via DNS TXT record or a well-known file on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only allowlist/blocklist edits with no runtime or security logic changes.
> 
> **Overview**
> **cryptoscribe.to** is moved off the phishing **blacklist** and onto the **whitelist** in `src/config.json`, addressing a false-positive block while the owner’s membership/payments site was in pre-launch.
> 
> Only list membership changes; no logic or schema updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119d8bf659eca375c233cb28c6be4c9d79d7a040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->