### PR TITLE
Remove false positive polymarket-il.com from blocklist (+ allowlist)

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12,6 +12,7 @@
     "satoshilabs.com"
   ],
   "whitelist": [
+    "polymarket-il.com",
     "pcswap.org",
     "sophon.xyz",
     "opensea.pro",
@@ -106969,7 +106970,6 @@
     "stack-tw.com",
     "metsxmasklognux.gitbook.io",
     "metamasklusf.gitbook.io",
-    "polymarket-il.com",
     "exchange.rayduim.ink",
     "virtuals-2026.xyz",
     "access-flarefoundation.live",


### PR DESCRIPTION
## Summary

Removal of a false positive, filed by the domain owner. Companion to removal request #269126.

`polymarket-il.com` is a Hebrew-language **education & community site about Polymarket for Israeli users** (a course and a free market-analytics dashboard on a subdomain). It links out to the real `polymarket.com` via Polymarket's public referral program — it does not imitate Polymarket's interface and operates no wallet flows.

## Why it cannot be phishing by the mechanics this list blocks for

- **Zero wallet interaction anywhere on the site**: no `window.ethereum` access, no WalletConnect / wagmi / ethers, no transaction prompts.
- **Never requests a Secret Recovery Phrase or private key.** Authentication is email/password + email OTP (Supabase) only.
- **Google Safe Browsing: clean** (both apex and subdomains).
- Not a typosquat: not a fuzzylist match; "polymarket-il" is a clear regional-community name, and the site prominently identifies itself as an independent Israeli community.

## How the entry got here

The domain was added to the hotlist on **2026-07-19 11:22 UTC** (`eth_phishing_detect_config.blocklist`, per the diffsSince API) via an automated feed import — apparently a brand-keyword match on "polymarket". The site's content did not change; it has operated as an education site since launch.

## Change

Removes `polymarket-il.com` from the blocklist and adds it to the allowlist to prevent automated re-listing by the same feed.

Happy to verify domain ownership however you prefer (DNS TXT record / file upload / email from an @polymarket-il.com address). A ChainPatrol dispute for the same listing was filed on 2026-07-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSwsA8crooq2vUhUqXCvms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain list maintenance in config only; no runtime logic, auth, or data-path changes.
> 
> **Overview**
> Removes **`polymarket-il.com`** from the phishing **blocklist** and adds it to the **whitelist** so MetaMask (and related consumers of this list) stop treating it as malicious and automated feeds are less likely to re-block it.
> 
> This is a false-positive remediation for a regional Polymarket education/community site, not a code or detection-logic change—only `src/config.json` is touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c578f53811e132d8deae8bcd788cf7338c5b52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->