### PR TITLE
Allowlist trench.express

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -70,7 +70,8 @@
     "satoshilabs.design",
     "storage.googleapis.com",
     "127.0.0.1",
-    "localhost"
+    "localhost",
+    "trench.express"
   ],
   "blacklist": [
     "poly-mark.xyz",


### PR DESCRIPTION
Adding trench.express to the allowlist ahead of launch.

We're building a gamified token launchpad on Robinhood Chain (RBC), bonding curve token creation and trading. Not live yet, still finishing things up, but "trench" is close enough to some other names that it felt worth getting ahead of the fuzzy matcher before we actually launch, rather than dealing with it after users start hitting a red page.

Site: https://trench.express
Twitter: https://x.com/trenchexpressrh

Happy to answer questions or hop on a call if that's easier. Not trying to rush review, just flagging it early since I know these take a bit to look at.