### PR TITLE
Update path-enabled-domains.ts

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -68,7 +68,6 @@
     "revoke.cash",
     "satoshilabs.com",
     "satoshilabs.design",
-    "storage.googleapis.com",
     "127.0.0.1",
     "localhost"
   ],

--- a/test/path-enabled-domains.ts
+++ b/test/path-enabled-domains.ts
@@ -8,4 +8,5 @@ export const PATH_REQUIRED_DOMAINS = [
   'arweave.mainnet.irys.xyz',
   'script.google.com',
   'itch.io',
+  'storage.googleapis.com',
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small config/test policy change for one host; may affect false-positive checks and which GCS URLs can be blocked without a path.
> 
> **Overview**
> **`storage.googleapis.com` is no longer on the global allowlist** and is now treated like other shared hosts (e.g. `sites.google.com`, `itch.io`) where blocklist entries must include a path.
> 
> The hostname was removed from `config.json` whitelist and added to `PATH_REQUIRED_DOMAINS` in `path-enabled-domains.ts`, so CI rejects bare-domain blocklist rows and only path-specific GCS URLs can be listed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb9ef2861a17b7d7ae889222ae049de9f1707f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->