### PR TITLE
Add viralonchain.com to allowlist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -69,6 +69,7 @@
     "satoshilabs.com",
     "satoshilabs.design",
     "storage.googleapis.com",
+    "viralonchain.com",
     "127.0.0.1",
     "localhost"
   ],


### PR DESCRIPTION
### What

Adds `viralonchain.com` to the `whitelist` (allowlist) in `src/config.json`.

### Why

`viralonchain.com` is the official website for **VIRAL ($VIRAL)**, a legitimate on-chain referral dApp on Robinhood Chain (chainId 4663). The site is a standard wallet-connect + token-buy flow that routes buys through a public Uniswap-v2-based router — it does **not** request asset-draining approvals and is **not** a phishing scam.

It has been showing a security false-positive on connect, so we're requesting allowlist addition to prevent MetaMask's phishing list from blocking it. The project's contracts are verified on the Robinhood Chain block explorer (Blockscout).

### Confirmation

- [x] The domain is not a phishing scam.
- [x] I am associated with / authorized to request allowlisting for this domain.

Thank you!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain allowlist entry with no logic changes; incorrect allowlisting could reduce phishing protection for that host only.
> 
> **Overview**
> Adds **`viralonchain.com`** to the **`whitelist`** array in `src/config.json`, alongside other trusted dApp domains.
> 
> This is intended to stop MetaMask’s phishing protection from blocking the official VIRAL on Robinhood Chain site when users connect their wallet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e7d20018a9c9d9f3a6a2db763be0bb9897be09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->