### PR TITLE
fix: Allowlist legitimate YesOrNo test domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12,6 +12,8 @@
     "satoshilabs.com"
   ],
   "whitelist": [
+    "test.yesorno.fun",
+    "dev-yesorno.com",
     "pcswap.org",
     "sophon.xyz",
     "opensea.pro",

--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -37,6 +37,8 @@ export const runTests = (config: Config) => {
                 "metamask.io",
                 "metamask.com",
                 "etherscan.io",
+                "test.yesorno.fun",
+                "dev-yesorno.com",
                 // allowlist subdomains
                 "www.metamask.io",
                 "portfolio.metamask.com",
@@ -99,6 +101,8 @@ export const runTests = (config: Config) => {
                 "ethereum1.cz",
                 "metalab.co",
                 "originprotocol.com",
+                "test.yesorno.fun",
+                "dev-yesorno.com",
             ],
             config,
         );
@@ -154,6 +158,8 @@ export const runTests = (config: Config) => {
                 "metamask.io",
                 "metamask.com",
                 "etherscan.io",
+                "test.yesorno.fun",
+                "dev-yesorno.com",
                 // allowlist subdomains
                 "www.metamask.io",
                 "portfolio.metamask.com",
@@ -216,6 +222,8 @@ export const runTests = (config: Config) => {
                 "ethereum1.cz",
                 "metalab.co",
                 "originprotocol.com",
+                "test.yesorno.fun",
+                "dev-yesorno.com",
             ],
             currentConfig,
         );


### PR DESCRIPTION
Add both exact hostnames to the `whitelist` array in `src/config.json`, preserving the file's established domain-only representation and avoiding a broader parent-domain exemption. Do not alter the blocklist or fuzzylist: neither contains the reported hosts, and the issue does not justify changing detection for unrelated domains. MetaMask currently warns on `test.yesorno.fun` and `dev-yesorno.com`, two restricted development environments used by the reporter's prediction-market project for testnet wallet, EIP-712, and trading-agent flows. The reporter states that neither host requests secrets, impersonates another service, nor intentionally drains wallets, and supplied the project's public website and social presence after a collaborator requested more context.

Check `test.yesorno.fun` with the legacy config shape and confirm the detector reports it as non-phishing; Check `dev-yesorno.com` with the legacy config shape and confirm the detector reports it as non-phishing.

Fixes #281309

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the phishing detector allowlist, which can weaken protection if the domains are misclassified. Scope is limited to two exact hostnames with matching tests.
> 
> **Overview**
> **Allowlists** `test.yesorno.fun` and `dev-yesorno.com` in `src/config.json` so MetaMask no longer flags these YesOrNo prediction-market test environments as phishing.
> 
> Updates `test/test-config.ts` so both legacy and current config shapes treat the hosts as allowlisted and non-phishing. Blocklist and fuzzylist are unchanged; only the exact hostnames are exempted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2dd1beb5c684239780a276d58a668a5e6a306db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->