### PR TITLE
Add new phishing domains to blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -106338,6 +106338,7 @@
     "airdrop-alignedlayer.xyz",
     "campaignjup.top",
     "bullverse.dev",
-    "alignedlayer.cloud"
+    "alignedlayer.cloud",
+    "alignedlayers.wiki"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -106337,6 +106337,7 @@
     "lnktap.cc",
     "airdrop-alignedlayer.xyz",
     "campaignjup.top",
-    "bullverse.dev"
+    "bullverse.dev",
+    "alignedlayer.cloud"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -106334,6 +106334,9 @@
     "apps-trustapp.wixstudio.com",
     "enweb-trustappssio.wixstudio.com",
     "ledger-com-portfolio.cc",
-    "lnktap.cc"
+    "lnktap.cc",
+    "airdrop-alignedlayer.xyz",
+    "campaignjup.top",
+    "bullverse.dev"
   ]
 }


### PR DESCRIPTION
Added multiple phishing domains to the blocklist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only blocklist update with no logic, auth, or infrastructure changes. Risk is limited to possible false positives if a listed domain is legitimate.
> 
> **Overview**
> Adds five phishing domains to the existing blocklist in `src/config.json`: `airdrop-alignedlayer.xyz`, `campaignjup.top`, `bullverse.dev`, `alignedlayer.cloud`, and `alignedlayers.wiki`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c2f05a7ccc9d31e106889caecce6028c2898ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->