### PR TITLE
Remove and allowlist scoreinvest.fr false positive

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -68,6 +68,7 @@
     "revoke.cash",
     "satoshilabs.com",
     "satoshilabs.design",
+    "scoreinvest.fr",
     "127.0.0.1",
     "localhost"
   ],
@@ -21350,7 +21351,6 @@
     "dev.kraken69.at",
     "coinbaserecoveryportal.com",
     "coinbase.giving",
-    "scoreinvest.fr",
     "richardcasinoca.ca",
     "krav30.at",
     "krav45.at",


### PR DESCRIPTION
## Summary

- remove `scoreinvest.fr` from the blocklist;
- add `scoreinvest.fr` to the allowlist to prevent automated re-ingestion of the same false positive.

## Why

This resolves #232082.

`scoreinvest.fr` is a legitimate French financial-education website with an identified publisher, legal notice, privacy policy and public contact details. It does not impersonate a third-party brand, connect to a cryptocurrency wallet, request signing keys or credentials, or execute cryptocurrency transactions.

The domain was originally added by `security-alliance-bot` in #228043. That automated PR was created and merged within 38 seconds and contains no domain-specific evidence establishing behavior covered by this repository's blocking policy. The current PhishDestroy report also records URLScan score `0`, zero wallet indicators and zero Telegram indicators.

Independent editorial references also identify ScoreInvest as a financial-analysis source, including two `aufeminin.com` articles published in May 2026:

- https://www.aufeminin.com/societe/debats-de-societes/plafond-du-livret-a-atteint-la-seule-alternative-de-2026-recommandee-par-les-experts-pour-ne-payer-aucun-impot-2727989.html
- https://www.aufeminin.com/societe/debats-de-societes/livret-a-a-15-en-2026-faut-il-le-fuir-ces-francais-ont-trouve-la-meilleure-alternative-qui-soit-2724210.html

Live references:

- https://scoreinvest.fr/
- https://scoreinvest.fr/mentions-legales
- https://scoreinvest.fr/confidentialite
- https://phishdestroy.io/domain/scoreinvest.fr/

## Validation

`yarn test:config`: **212 assertions passed, 0 failed**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only allowlist/blocklist update with no application logic or security-sensitive code changes.
> 
> **Overview**
> Fixes a false positive for **scoreinvest.fr** by **removing** it from the **blacklist** and **adding** it to the **whitelist** in `src/config.json`.
> 
> The allowlist entry is meant to stop the same domain from being blocked again if automated ingestion re-adds it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9050f4e66e1ad9c47ebaa3f3925e1834c9586bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->