### PR TITLE
Add oraclizer.io and sandbox.oraclizer.io to allowlist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -69,7 +69,9 @@
     "satoshilabs.com",
     "satoshilabs.design",
     "127.0.0.1",
-    "localhost"
+    "localhost",
+    "oraclizer.io",
+    "sandbox.oraclizer.io"
   ],
   "blacklist": [
     "poly-mark.xyz",


### PR DESCRIPTION
## Legitimate domains

- https://oraclizer.io — project site of Oraclizer, a regulated-asset tokenization platform (docs: https://docs.oraclizer.io, research: https://research.oraclizer.io)
- https://sandbox.oraclizer.io — its public testnet sandbox: investor/issuer portals and a block explorer for an app-chain testnet (chainId 73011, Polygon CDK)

## Why allowlist

The sandbox runs a public testnet bug-bounty, so wallet users visit it directly. Sign-in uses a standard EIP-4361 (SIWE) message and the dapp switches the wallet to its own chain before requesting a signature; the site never requests approvals or mainnet transactions — everything involved is a valueless testnet asset.

Neither domain is on this repository's lists today; this is a proactive allowlist request because at least one wallet's signature-time scanner has shown a false-positive warning for the sandbox domain, and to guard against future fuzzy-list matches. As of 2026-08-26 the domains are also clean on GoPlus, PhishFort, ScamSniffer, and ChainPatrol.

I am the domain owner and can verify via DNS or a page on either domain if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only allowlist additions with no code or security-logic changes.
> 
> **Overview**
> Adds **`oraclizer.io`** and **`sandbox.oraclizer.io`** to the domain **allowlist** in `src/config.json` (the `whitelist` array used as the trusted-domain list).
> 
> This is a proactive trust signal so wallet signature scanners and fuzzy matching are less likely to flag Oraclizer’s production site and public testnet sandbox. No application logic changes—only the published allowlist data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c63347f267da56a138263889857c895df565ca34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->