### PR TITLE
Added phishing domain

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -103488,6 +103488,7 @@
     "kraken-slon-krab.ru",
     "browser-trrust-ext.wixstudio.com",
     "my-trust-extension.wixstudio.com",
-    "ethdrops-global.xyz"
+    "ethdrops-global.xyz",
+    "claim-aligned.xyz"
   ]
 }

--- a/src/config.json
+++ b/src/config.json
@@ -103487,6 +103487,7 @@
     "lobstrproject.org",
     "kraken-slon-krab.ru",
     "browser-trrust-ext.wixstudio.com",
-    "my-trust-extension.wixstudio.com"
+    "my-trust-extension.wixstudio.com",
+    "ethdrops-global.xyz"
   ]
 }


### PR DESCRIPTION
A crypto drainer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only blacklist updates with no runtime or security-logic changes.
> 
> **Overview**
> Adds **`ethdrops-global.xyz`** and **`claim-aligned.xyz`** to the **`blacklist`** in `src/config.json`, extending the phishing domain list alongside recent similar entries (e.g. fake wallet extensions on Wix).
> 
> No application logic changes—only two new blocked hostnames for consumers of this config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8ec0828d4ba18ca097a5738d40696443db6d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->